### PR TITLE
fix #18: Replace USD-based cost/budget system with token-based limits

### DIFF
--- a/agent/config/default-config.json
+++ b/agent/config/default-config.json
@@ -17,11 +17,11 @@
   },
   "limits": {
     "max_employee_turns": 200,
-    "max_employee_budget_usd": 25.00,
     "max_analyst_turns": 50,
-    "max_analyst_budget_usd": 5.00,
     "max_manager_turns": 30,
-    "max_manager_budget_usd": 3.00,
+    "token_limit_daily": 0,
+    "token_limit_monthly": 0,
+    "token_reserve_percent": 20,
     "session_limit_24h": 50,
     "max_session_percent": 80
   },

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -196,6 +196,44 @@ with open(tracking_file, 'w') as f:
 }
 
 # ============================================================================
+# TOKEN BUDGET CHECK
+# ============================================================================
+
+check_token_budget() {
+    # Check if token consumption is within configured limits.
+    # Queries the dashboard API for current token usage.
+    # Returns 0 if OK to proceed, 1 if budget exceeded.
+    local token_limit_daily token_reserve_pct
+    token_limit_daily=$(json_get "$CONFIG_FILE" "limits.token_limit_daily" 2>/dev/null || echo "0")
+    token_reserve_pct=$(json_get "$CONFIG_FILE" "limits.token_reserve_percent" 2>/dev/null || echo "20")
+
+    # If no daily token limit configured, skip check
+    [ "$token_limit_daily" = "0" ] && return 0
+
+    # Try to get token usage from dashboard API
+    local usage_json
+    usage_json=$(curl -s --max-time 3 "http://127.0.0.1:8420/api/config/token-usage" 2>/dev/null || echo "")
+    if [ -z "$usage_json" ]; then
+        log_warn "Could not reach dashboard API for token budget check, proceeding anyway"
+        return 0
+    fi
+
+    local can_spawn
+    can_spawn=$(echo "$usage_json" | python3 -c "import json,sys; print(json.load(sys.stdin).get('can_spawn_employee', True))" 2>/dev/null || echo "True")
+
+    if [ "$can_spawn" = "False" ]; then
+        local daily_total daily_limit
+        daily_total=$(echo "$usage_json" | python3 -c "import json,sys; print(json.load(sys.stdin).get('daily',{}).get('tokens_total',0))" 2>/dev/null || echo "?")
+        daily_limit=$(echo "$usage_json" | python3 -c "import json,sys; print(json.load(sys.stdin).get('daily',{}).get('effective_limit',0))" 2>/dev/null || echo "?")
+        log_warn "Token budget exceeded: ${daily_total} tokens used, effective limit ${daily_limit} (reserve ${token_reserve_pct}%)"
+        return 1
+    fi
+
+    log_info "Token budget: OK"
+    return 0
+}
+
+# ============================================================================
 # PREFLIGHT CHECKS
 # ============================================================================
 
@@ -373,16 +411,14 @@ run_employee() {
         fi
     fi
 
-    local model max_turns max_budget
+    local model max_turns
     model=$(json_get "$CONFIG_FILE" "models.employee" 2>/dev/null || echo "claude-opus-4-6")
     max_turns=$(json_get "$CONFIG_FILE" "limits.max_employee_turns" 2>/dev/null || echo "200")
-    max_budget=$(json_get "$CONFIG_FILE" "limits.max_employee_budget_usd" 2>/dev/null || echo "25.00")
 
     # Analyze/plan modes use Sonnet (cheaper — no code changes, just analysis/planning)
     if [ "$mode" = "analyze" ] || [ "$mode" = "plan" ]; then
         model="claude-sonnet-4-6"
         max_turns=50
-        max_budget="5.00"
     fi
 
     # Determine fallback model (must differ from primary)
@@ -496,7 +532,6 @@ $custom_instructions"
     cmd+=(--model "$model")
     cmd+=(--fallback-model "$fallback_model")
     cmd+=(--max-turns "$max_turns")
-    cmd+=(--max-budget-usd "$max_budget")
     cmd+=(--system-prompt-file "$system_prompt")
     # No --allowedTools/--disallowedTools: full VM access, prompt-enforced guardrails
 
@@ -545,10 +580,16 @@ for b in d.get('message',{}).get('content',[]):
                 [ -n "$text_snippet" ] && log_info "  Employee: $text_snippet"
                 ;;
             result)
-                local result_cost result_turns
-                result_cost=$(echo "$line" | python3 -c "import json,sys; print(f'{json.load(sys.stdin).get(\"total_cost_usd\",0):.2f}')" 2>/dev/null || echo "?")
+                local result_tokens result_turns
+                result_tokens=$(echo "$line" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+mu=d.get('modelUsage',{})
+t=sum(u.get('inputTokens',0)+u.get('outputTokens',0) for u in mu.values())
+print(f'{t:,}')
+" 2>/dev/null || echo "?")
                 result_turns=$(echo "$line" | python3 -c "import json,sys; print(json.load(sys.stdin).get('num_turns',0))" 2>/dev/null || echo "?")
-                log_info "  Employee result: Turns=$result_turns Cost=\$$result_cost"
+                log_info "  Employee result: Turns=$result_turns Tokens=$result_tokens"
                 ;;
         esac
     done
@@ -665,10 +706,9 @@ run_manager_review() {
 
     webhook_event "manager_review" "\"review_package\":\"$review_package\""
 
-    local model max_turns max_budget
+    local model max_turns
     model=$(json_get "$CONFIG_FILE" "models.manager" 2>/dev/null || echo "claude-sonnet-4-6")
     max_turns=$(json_get "$CONFIG_FILE" "limits.max_manager_turns" 2>/dev/null || echo "30")
-    max_budget=$(json_get "$CONFIG_FILE" "limits.max_manager_budget_usd" 2>/dev/null || echo "3.00")
 
     # Determine fallback model for manager
     local manager_fallback="claude-haiku-4-5-20251001"
@@ -680,7 +720,6 @@ run_manager_review() {
     cmd+=(--model "$model")
     cmd+=(--fallback-model "$manager_fallback")
     cmd+=(--max-turns "$max_turns")
-    cmd+=(--max-budget-usd "$max_budget")
     cmd+=(--system-prompt-file "$SCRIPT_DIR/../prompts/manager.md")
     # No --allowedTools: full VM access, prompt-enforced guardrails
 
@@ -722,9 +761,15 @@ for b in d.get('message',{}).get('content',[]):
                 [ -n "$text_snippet" ] && log_info "  Manager: $text_snippet" >&2
                 ;;
             result)
-                local result_cost
-                result_cost=$(echo "$line" | python3 -c "import json,sys; print(f'{json.load(sys.stdin).get(\"total_cost_usd\",0):.2f}')" 2>/dev/null || echo "?")
-                log_info "  Manager review cost: \$$result_cost" >&2
+                local result_tokens_mgr
+                result_tokens_mgr=$(echo "$line" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+mu=d.get('modelUsage',{})
+t=sum(u.get('inputTokens',0)+u.get('outputTokens',0) for u in mu.values())
+print(f'{t:,}')
+" 2>/dev/null || echo "?")
+                log_info "  Manager review tokens: $result_tokens_mgr" >&2
                 ;;
         esac
     done
@@ -939,18 +984,24 @@ write_digest() {
         echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
         echo ""
 
-        # Extract cost data from stream files
-        echo "## Cost Summary"
-        local total_cost=0
+        # Extract token usage from stream files
+        echo "## Token Usage Summary"
+        local total_tokens=0
         for stream in "$LOG_DIR"/run-${RUN_ID}-*.stream.jsonl; do
             [ -f "$stream" ] || continue
-            local stream_name cost
+            local stream_name tokens
             stream_name=$(basename "$stream" .stream.jsonl | sed "s/run-${RUN_ID}-//")
-            cost=$(tail -1 "$stream" | python3 -c "import json,sys; print(f'{json.load(sys.stdin).get(\"total_cost_usd\",0):.4f}')" 2>/dev/null || echo "0.0000")
-            echo "- **$stream_name**: \$$cost"
-            total_cost=$(python3 -c "print(f'{$total_cost + $cost:.4f}')" 2>/dev/null || echo "?")
+            tokens=$(tail -1 "$stream" | python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+mu=d.get('modelUsage',{})
+t=sum(u.get('inputTokens',0)+u.get('outputTokens',0) for u in mu.values())
+print(t)
+" 2>/dev/null || echo "0")
+            echo "- **$stream_name**: ${tokens} tokens"
+            total_tokens=$(python3 -c "print($total_tokens + $tokens)" 2>/dev/null || echo "?")
         done
-        echo "- **Total**: \$$total_cost"
+        echo "- **Total**: ${total_tokens} tokens"
         echo ""
 
         if [ -f "$verdicts_file" ]; then
@@ -1033,6 +1084,13 @@ main() {
         if ! check_rate_limit; then
             log_warn "Rate limit reached. Stopping before $repo"
             notify "rate_limit" "Rate limit reached before $repo in run $RUN_ID"
+            break
+        fi
+
+        # Check token budget before each employee
+        if ! check_token_budget; then
+            log_warn "Token budget exceeded. Stopping before $repo"
+            notify "token_budget" "Token budget exceeded before $repo in run $RUN_ID"
             break
         fi
 

--- a/dashboard/backend/app/database.py
+++ b/dashboard/backend/app/database.py
@@ -36,6 +36,9 @@ async def _migrate_add_columns(conn) -> None:
     migrations = [
         ("projects", "custom_instructions", "ALTER TABLE projects ADD COLUMN custom_instructions TEXT"),
         ("projects", "setup_script", "ALTER TABLE projects ADD COLUMN setup_script TEXT"),
+        ("runs", "tokens_input", "ALTER TABLE runs ADD COLUMN tokens_input INTEGER"),
+        ("runs", "tokens_output", "ALTER TABLE runs ADD COLUMN tokens_output INTEGER"),
+        ("runs", "tokens_total", "ALTER TABLE runs ADD COLUMN tokens_total INTEGER"),
     ]
     for table, column, sql in migrations:
         try:

--- a/dashboard/backend/app/models.py
+++ b/dashboard/backend/app/models.py
@@ -42,7 +42,10 @@ class Run(Base):
     verdict = Column(Text, nullable=True)  # APPROVE/PR/REJECT/null
     issue_number = Column(Integer, nullable=True)
     branch = Column(Text, nullable=True)
-    cost_usd = Column(Float, nullable=True)
+    cost_usd = Column(Float, nullable=True)  # Deprecated: kept for historical data
+    tokens_input = Column(Integer, nullable=True)
+    tokens_output = Column(Integer, nullable=True)
+    tokens_total = Column(Integer, nullable=True)
     turns = Column(Integer, nullable=True)
     duration_ms = Column(Integer, nullable=True)
     started_at = Column(DateTime, nullable=True)

--- a/dashboard/backend/app/routers/config_router.py
+++ b/dashboard/backend/app/routers/config_router.py
@@ -3,16 +3,17 @@
 import json
 import time
 import logging
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.dependencies import get_db
-from app.models import ConfigEntry
+from app.models import ConfigEntry, Run
 from app.services.config_sync import _read_config_json, _write_config_json, sync_config_to_db
 
 logger = logging.getLogger(__name__)
@@ -125,4 +126,75 @@ async def get_usage():
         "window_remaining_hours": round(remaining_hours, 1),
         "usage_percent": round((sessions_used / session_limit * 100) if session_limit > 0 else 0, 1),
         "last_run_ts": last_run,
+    }
+
+
+@router.get("/token-usage")
+async def get_token_usage(db: AsyncSession = Depends(get_db)):
+    """Get token consumption data against configured limits."""
+    config = _read_config_json()
+    limits = config.get("limits", {})
+    token_limit_daily = limits.get("token_limit_daily", 0)
+    token_limit_monthly = limits.get("token_limit_monthly", 0)
+    token_reserve_percent = limits.get("token_reserve_percent", 20)
+
+    now = datetime.now(timezone.utc)
+
+    # Daily tokens consumed (last 24h)
+    day_ago = now - timedelta(hours=24)
+    daily_result = await db.execute(
+        select(
+            func.coalesce(func.sum(Run.tokens_input), 0),
+            func.coalesce(func.sum(Run.tokens_output), 0),
+            func.coalesce(func.sum(Run.tokens_total), 0),
+        ).where(Run.started_at >= day_ago)
+    )
+    daily_row = daily_result.one()
+    daily_input = daily_row[0]
+    daily_output = daily_row[1]
+    daily_total = daily_row[2]
+
+    # Monthly tokens consumed (last 30 days)
+    month_ago = now - timedelta(days=30)
+    monthly_result = await db.execute(
+        select(
+            func.coalesce(func.sum(Run.tokens_total), 0),
+        ).where(Run.started_at >= month_ago)
+    )
+    monthly_total = monthly_result.scalar()
+
+    # Calculate effective limits (after reserve)
+    reserve_factor = 1 - (token_reserve_percent / 100)
+    effective_daily = int(token_limit_daily * reserve_factor) if token_limit_daily > 0 else 0
+    effective_monthly = int(token_limit_monthly * reserve_factor) if token_limit_monthly > 0 else 0
+
+    # Usage percentages
+    daily_percent = round((daily_total / effective_daily * 100) if effective_daily > 0 else 0, 1)
+    monthly_percent = round((monthly_total / effective_monthly * 100) if effective_monthly > 0 else 0, 1)
+
+    # Can spawn check: is there enough budget for an employee (~50K tokens avg)?
+    avg_employee_tokens = 50000
+    can_spawn = True
+    if effective_daily > 0 and (daily_total + avg_employee_tokens) > effective_daily:
+        can_spawn = False
+    if effective_monthly > 0 and (monthly_total + avg_employee_tokens) > effective_monthly:
+        can_spawn = False
+
+    return {
+        "daily": {
+            "tokens_input": daily_input,
+            "tokens_output": daily_output,
+            "tokens_total": daily_total,
+            "limit": token_limit_daily,
+            "effective_limit": effective_daily,
+            "usage_percent": daily_percent,
+        },
+        "monthly": {
+            "tokens_total": monthly_total,
+            "limit": token_limit_monthly,
+            "effective_limit": effective_monthly,
+            "usage_percent": monthly_percent,
+        },
+        "token_reserve_percent": token_reserve_percent,
+        "can_spawn_employee": can_spawn,
     }

--- a/dashboard/backend/app/routers/webhook.py
+++ b/dashboard/backend/app/routers/webhook.py
@@ -90,6 +90,9 @@ async def receive_run_event(
 
         run.status = final_status
         run.cost_usd = event.cost_usd
+        run.tokens_input = event.tokens_input
+        run.tokens_output = event.tokens_output
+        run.tokens_total = event.tokens_total
         run.turns = event.turns
         run.duration_ms = event.duration_ms
         run.finished_at = datetime.now(timezone.utc)

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -54,7 +54,10 @@ class RunOut(BaseModel):
     verdict: Optional[str] = None
     issue_number: Optional[int] = None
     branch: Optional[str] = None
-    cost_usd: Optional[float] = None
+    cost_usd: Optional[float] = None  # Deprecated: kept for historical data
+    tokens_input: Optional[int] = None
+    tokens_output: Optional[int] = None
+    tokens_total: Optional[int] = None
     turns: Optional[int] = None
     duration_ms: Optional[int] = None
     started_at: Optional[datetime] = None
@@ -182,7 +185,10 @@ class WebhookRunEvent(BaseModel):
     verdict: Optional[str] = None
     issue_number: Optional[int] = None
     branch: Optional[str] = None
-    cost_usd: Optional[float] = None
+    cost_usd: Optional[float] = None  # Deprecated: kept for backward compat
+    tokens_input: Optional[int] = None
+    tokens_output: Optional[int] = None
+    tokens_total: Optional[int] = None
     turns: Optional[int] = None
     duration_ms: Optional[int] = None
     reasoning: Optional[str] = None

--- a/dashboard/backend/app/services/log_importer.py
+++ b/dashboard/backend/app/services/log_importer.py
@@ -75,6 +75,12 @@ def _update_run_from_logs(run: "Run", data: dict) -> None:
         run.model = data["model"]
     if not run.cost_usd and data.get("cost_usd"):
         run.cost_usd = data["cost_usd"]
+    if not run.tokens_input and data.get("tokens_input"):
+        run.tokens_input = data["tokens_input"]
+    if not run.tokens_output and data.get("tokens_output"):
+        run.tokens_output = data["tokens_output"]
+    if not run.tokens_total and data.get("tokens_total"):
+        run.tokens_total = data["tokens_total"]
     if not run.turns and data.get("turns"):
         run.turns = data["turns"]
     if not run.duration_ms and data.get("duration_ms"):
@@ -184,6 +190,9 @@ def _build_run_data(
         "issue_number": issue_number,
         "branch": branch,
         "cost_usd": result_data.get("cost_usd") if result_data else None,
+        "tokens_input": result_data.get("tokens_input") if result_data else None,
+        "tokens_output": result_data.get("tokens_output") if result_data else None,
+        "tokens_total": result_data.get("tokens_total") if result_data else None,
         "turns": result_data.get("turns") if result_data else None,
         "duration_ms": result_data.get("duration_ms") if result_data else None,
         "started_at": started_at,

--- a/dashboard/backend/app/services/log_parser.py
+++ b/dashboard/backend/app/services/log_parser.py
@@ -55,15 +55,20 @@ def parse_run_timestamp(run_id: str) -> Optional[datetime]:
 def parse_result_json(filepath: str) -> Optional[Dict[str, Any]]:
     """Parse a run result .json file (the old format summary).
 
-    Returns dict with: cost_usd, turns, duration_ms, status, model.
+    Returns dict with: cost_usd, tokens_input, tokens_output, tokens_total,
+    turns, duration_ms, status, model.
     """
     try:
         with open(filepath, "r") as f:
             data = json.load(f)
         if data.get("type") != "result":
             return None
+        tokens = _extract_tokens(data)
         return {
             "cost_usd": data.get("total_cost_usd"),
+            "tokens_input": tokens[0],
+            "tokens_output": tokens[1],
+            "tokens_total": tokens[2],
             "turns": data.get("num_turns"),
             "duration_ms": data.get("duration_ms"),
             "status": "success" if data.get("subtype") == "success" else "failed",
@@ -96,8 +101,12 @@ def parse_stream_result(filepath: str) -> Optional[Dict[str, Any]]:
         if not result_line:
             return None
 
+        tokens = _extract_tokens(result_line)
         return {
             "cost_usd": result_line.get("total_cost_usd"),
+            "tokens_input": tokens[0],
+            "tokens_output": tokens[1],
+            "tokens_total": tokens[2],
             "turns": result_line.get("num_turns"),
             "duration_ms": result_line.get("duration_ms"),
             "status": "success" if result_line.get("subtype") == "success" else "failed",
@@ -176,3 +185,25 @@ def _extract_model(data: Dict[str, Any]) -> Optional[str]:
     if model_usage:
         return list(model_usage.keys())[0]
     return None
+
+
+def _extract_tokens(data: Dict[str, Any]) -> Tuple[Optional[int], Optional[int], Optional[int]]:
+    """Extract token usage from result data.
+
+    Claude CLI result events contain a modelUsage dict with per-model token counts.
+    We sum across all models to get totals.
+
+    Returns: (input_tokens, output_tokens, total_tokens)
+    """
+    model_usage = data.get("modelUsage", {})
+    if not model_usage:
+        return (None, None, None)
+
+    total_input = 0
+    total_output = 0
+    for _model, usage in model_usage.items():
+        total_input += usage.get("inputTokens", 0) or 0
+        total_output += usage.get("outputTokens", 0) or 0
+
+    total = total_input + total_output
+    return (total_input or None, total_output or None, total or None)

--- a/dashboard/frontend/src/components/ActivityFeed.svelte
+++ b/dashboard/frontend/src/components/ActivityFeed.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Run } from '../lib/types';
-  import { formatDuration, formatCost } from '../lib/format';
+  import { formatDuration, formatTokens } from '../lib/format';
   import { timeAgo } from '../lib/format';
   import StatusBadge from './StatusBadge.svelte';
   import StatusOrb from './StatusOrb.svelte';
@@ -42,7 +42,7 @@
           </span>
           <StatusBadge value={run.verdict} />
           <span class="text-xs text-text-dim ml-auto hidden sm:block">{formatDuration(run.duration_ms)}</span>
-          <span class="text-xs text-text-dim w-14 text-right font-data">{formatCost(run.cost_usd)}</span>
+          <span class="text-xs text-text-dim w-14 text-right font-data">{formatTokens(run.tokens_total)}</span>
           <span class="text-[10px] text-text-dim/60 hidden md:block w-16 text-right">{timeAgo(run.started_at)}</span>
         </a>
       {/each}

--- a/dashboard/frontend/src/components/LogEvent.svelte
+++ b/dashboard/frontend/src/components/LogEvent.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { ParsedLogEvent } from '../lib/log-parser';
   import { formatToolInput, truncate } from '../lib/log-parser';
-  import { formatDuration, formatCost } from '../lib/format';
+  import { formatDuration, formatTokens } from '../lib/format';
 
   interface Props {
     event: ParsedLogEvent;
@@ -139,8 +139,8 @@
       {#if event.durationMs}
         <span class="text-text-dim">{formatDuration(event.durationMs)}</span>
       {/if}
-      {#if event.costUsd != null}
-        <span class="text-text-dim">{formatCost(event.costUsd)}</span>
+      {#if event.tokensTotal}
+        <span class="text-text-dim">{formatTokens(event.tokensTotal)} tokens</span>
       {/if}
       {#if event.model}
         <span class="text-text-dim font-data">{event.model}</span>

--- a/dashboard/frontend/src/components/TokenBar.svelte
+++ b/dashboard/frontend/src/components/TokenBar.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import { formatTokens } from '../lib/format';
+
+  interface Props {
+    tokens: number | null;
+    maxTokens?: number;
+    label?: string;
+  }
+
+  let { tokens, maxTokens = 1, label = '' }: Props = $props();
+
+  let pct = $derived(tokens != null ? Math.min((tokens / maxTokens) * 100, 100) : 0);
+  let barColor = $derived(
+    tokens != null && tokens > maxTokens * 0.8 ? 'bg-reject' :
+    tokens != null && tokens > maxTokens * 0.5 ? 'bg-warning' : 'bg-pr'
+  );
+  let glowColor = $derived(
+    tokens != null && tokens > maxTokens * 0.8 ? 'shadow-[0_0_6px_rgba(239,68,68,0.2)]' :
+    tokens != null && tokens > maxTokens * 0.5 ? 'shadow-[0_0_6px_rgba(245,158,11,0.2)]' : 'shadow-[0_0_6px_rgba(168,85,247,0.2)]'
+  );
+</script>
+
+<div class="flex items-center gap-3">
+  {#if label}
+    <span class="text-xs text-text-dim w-24 truncate font-data">{label}</span>
+  {/if}
+  <div class="flex-1 h-2.5 bg-white/[0.04] rounded-full overflow-hidden">
+    <div class="h-full rounded-full transition-all duration-700 ease-out {barColor} {glowColor}" style:width="{pct}%"></div>
+  </div>
+  <span class="text-xs text-text-dim w-16 text-right font-data">{formatTokens(tokens)}</span>
+</div>

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Project, ProjectCreate, ProjectUpdate, Run, RunList, Plan, PlanList, SystemStatus, AuthStatus, LogSearchResult, RunLogs, UsageData, OAuthStartResponse, OAuthCallbackResponse } from './types';
+import type { Project, ProjectCreate, ProjectUpdate, Run, RunList, Plan, PlanList, SystemStatus, AuthStatus, LogSearchResult, RunLogs, UsageData, TokenUsageData, OAuthStartResponse, OAuthCallbackResponse } from './types';
 
 const BASE = import.meta.env.VITE_API_URL || '';
 
@@ -46,6 +46,7 @@ export const rescanRuns = () => request<{ status: string; imported: number }>('/
 // Config
 export const getConfig = () => request<Record<string, unknown>>('/api/config');
 export const getUsage = () => request<UsageData>('/api/config/usage');
+export const getTokenUsage = () => request<TokenUsageData>('/api/config/token-usage');
 export const updateConfig = (data: Record<string, unknown>) =>
   request<Record<string, unknown>>('/api/config', { method: 'PUT', body: JSON.stringify(data) });
 

--- a/dashboard/frontend/src/lib/format.ts
+++ b/dashboard/frontend/src/lib/format.ts
@@ -27,10 +27,18 @@ export function formatDuration(ms: number | null): string {
   return `${hours}h ${remainMin}m`;
 }
 
+/** @deprecated Use formatTokens instead. Kept for historical data display. */
 export function formatCost(usd: number | null): string {
   if (usd == null) return '-';
   if (usd < 0.01) return `$${usd.toFixed(4)}`;
   return `$${usd.toFixed(2)}`;
+}
+
+export function formatTokens(tokens: number | null): string {
+  if (tokens == null || tokens === 0) return '-';
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(1)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
+  return `${tokens}`;
 }
 
 export function formatDate(dateStr: string | null): string {

--- a/dashboard/frontend/src/lib/log-parser.ts
+++ b/dashboard/frontend/src/lib/log-parser.ts
@@ -30,7 +30,8 @@ export interface ParsedLogEvent {
 
   // result
   resultStatus?: string;
-  costUsd?: number;
+  costUsd?: number;  // Deprecated: kept for historical log display
+  tokensTotal?: number;
   numTurns?: number;
   durationMs?: number;
   model?: string;
@@ -129,11 +130,19 @@ export function parseLogLine(line: string): ParsedLogEvent | ParsedLogEvent[] | 
     }
 
     case 'result': {
+      // Extract total tokens from modelUsage
+      let tokensTotal = 0;
+      if (json.modelUsage) {
+        for (const usage of Object.values(json.modelUsage) as any[]) {
+          tokensTotal += (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+        }
+      }
       return {
         ...base,
         type: 'result',
         resultStatus: json.subtype || 'completed',
         costUsd: json.total_cost_usd,
+        tokensTotal: tokensTotal || undefined,
         numTurns: json.num_turns,
         durationMs: json.duration_ms,
         model: json.modelUsage ? Object.keys(json.modelUsage)[0] : undefined,

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -40,7 +40,10 @@ export interface Run {
   verdict: string | null;
   issue_number: number | null;
   branch: string | null;
-  cost_usd: number | null;
+  cost_usd: number | null;  // Deprecated: kept for historical data
+  tokens_input: number | null;
+  tokens_output: number | null;
+  tokens_total: number | null;
   turns: number | null;
   duration_ms: number | null;
   started_at: string | null;
@@ -122,6 +125,25 @@ export interface UsageData {
   last_run_ts: number;
 }
 
+export interface TokenUsageData {
+  daily: {
+    tokens_input: number;
+    tokens_output: number;
+    tokens_total: number;
+    limit: number;
+    effective_limit: number;
+    usage_percent: number;
+  };
+  monthly: {
+    tokens_total: number;
+    limit: number;
+    effective_limit: number;
+    usage_percent: number;
+  };
+  token_reserve_percent: number;
+  can_spawn_employee: boolean;
+}
+
 export interface StationConfig {
   projects?: any[];
   _mode_options?: Record<string, string>;
@@ -132,9 +154,11 @@ export interface StationConfig {
   };
   limits?: {
     max_employee_turns?: number;
-    max_employee_budget_usd?: number;
+    max_analyst_turns?: number;
     max_manager_turns?: number;
-    max_manager_budget_usd?: number;
+    token_limit_daily?: number;
+    token_limit_monthly?: number;
+    token_reserve_percent?: number;
     session_limit_24h?: number;
     max_session_percent?: number;
   };

--- a/dashboard/frontend/src/pages/ConfigPage.svelte
+++ b/dashboard/frontend/src/pages/ConfigPage.svelte
@@ -13,9 +13,11 @@
   let managerModel = $state('');
 
   let maxEmployeeTurns = $state<number | undefined>(undefined);
-  let maxEmployeeBudget = $state<number | undefined>(undefined);
+  let maxAnalystTurns = $state<number | undefined>(undefined);
   let maxManagerTurns = $state<number | undefined>(undefined);
-  let maxManagerBudget = $state<number | undefined>(undefined);
+  let tokenLimitDaily = $state<number | undefined>(undefined);
+  let tokenLimitMonthly = $state<number | undefined>(undefined);
+  let tokenReservePercent = $state<number | undefined>(undefined);
   let sessionLimit24h = $state<number | undefined>(undefined);
   let maxSessionPercent = $state<number | undefined>(undefined);
 
@@ -36,9 +38,11 @@
     managerModel = cfg.models?.manager ?? '';
 
     maxEmployeeTurns = cfg.limits?.max_employee_turns;
-    maxEmployeeBudget = cfg.limits?.max_employee_budget_usd;
+    maxAnalystTurns = cfg.limits?.max_analyst_turns;
     maxManagerTurns = cfg.limits?.max_manager_turns;
-    maxManagerBudget = cfg.limits?.max_manager_budget_usd;
+    tokenLimitDaily = cfg.limits?.token_limit_daily;
+    tokenLimitMonthly = cfg.limits?.token_limit_monthly;
+    tokenReservePercent = cfg.limits?.token_reserve_percent;
     sessionLimit24h = cfg.limits?.session_limit_24h;
     maxSessionPercent = cfg.limits?.max_session_percent;
 
@@ -78,9 +82,11 @@
       },
       limits: {
         max_employee_turns: maxEmployeeTurns,
-        max_employee_budget_usd: maxEmployeeBudget,
+        max_analyst_turns: maxAnalystTurns,
         max_manager_turns: maxManagerTurns,
-        max_manager_budget_usd: maxManagerBudget,
+        token_limit_daily: tokenLimitDaily,
+        token_limit_monthly: tokenLimitMonthly,
+        token_reserve_percent: tokenReservePercent,
         session_limit_24h: sessionLimit24h,
         max_session_percent: maxSessionPercent,
       },
@@ -154,26 +160,49 @@
       </div>
     </GlassCard>
 
-    <!-- Limits -->
+    <!-- Turn Limits -->
     <GlassCard class="p-5">
-      <h3 class="font-semibold mb-4">Limits</h3>
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <h3 class="font-semibold mb-4">Turn Limits</h3>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
           <label for="max-employee-turns" class="block text-sm text-text-dim mb-1">Max Employee Turns</label>
           <input id="max-employee-turns" type="number" bind:value={maxEmployeeTurns} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
         </div>
         <div>
-          <label for="max-employee-budget" class="block text-sm text-text-dim mb-1">Max Employee Budget (USD)</label>
-          <input id="max-employee-budget" type="number" step="0.01" bind:value={maxEmployeeBudget} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+          <label for="max-analyst-turns" class="block text-sm text-text-dim mb-1">Max Analyst Turns</label>
+          <input id="max-analyst-turns" type="number" bind:value={maxAnalystTurns} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
         </div>
         <div>
           <label for="max-manager-turns" class="block text-sm text-text-dim mb-1">Max Manager Turns</label>
           <input id="max-manager-turns" type="number" bind:value={maxManagerTurns} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
         </div>
+      </div>
+    </GlassCard>
+
+    <!-- Token Limits -->
+    <GlassCard class="p-5">
+      <h3 class="font-semibold mb-4">Token Budget</h3>
+      <p class="text-xs text-text-dim mb-4">Configure your claude.ai plan's token allowance. Set to 0 to disable token-based limiting.</p>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
-          <label for="max-manager-budget" class="block text-sm text-text-dim mb-1">Max Manager Budget (USD)</label>
-          <input id="max-manager-budget" type="number" step="0.01" bind:value={maxManagerBudget} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+          <label for="token-limit-daily" class="block text-sm text-text-dim mb-1">Daily Token Limit</label>
+          <input id="token-limit-daily" type="number" bind:value={tokenLimitDaily} placeholder="0 = unlimited" class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
         </div>
+        <div>
+          <label for="token-limit-monthly" class="block text-sm text-text-dim mb-1">Monthly Token Limit</label>
+          <input id="token-limit-monthly" type="number" bind:value={tokenLimitMonthly} placeholder="0 = unlimited" class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+        </div>
+        <div>
+          <label for="token-reserve-pct" class="block text-sm text-text-dim mb-1">Reserve for Manual Use (%)</label>
+          <input id="token-reserve-pct" type="number" min="0" max="100" bind:value={tokenReservePercent} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+        </div>
+      </div>
+    </GlassCard>
+
+    <!-- Session Limits -->
+    <GlassCard class="p-5">
+      <h3 class="font-semibold mb-4">Session Limits</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
           <label for="session-limit" class="block text-sm text-text-dim mb-1">Session Limit (24h)</label>
           <input id="session-limit" type="number" bind:value={sessionLimit24h} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />

--- a/dashboard/frontend/src/pages/DashboardPage.svelte
+++ b/dashboard/frontend/src/pages/DashboardPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Run, SystemStatus, UsageData, Project } from '../lib/types';
   import { getLatestRun, getSystemStatus, listRuns, getUsage, listProjects } from '../lib/api';
-  import { formatDuration, formatCost } from '../lib/format';
+  import { formatDuration, formatTokens } from '../lib/format';
   import { toastSuccess, toastError } from '../lib/toast.svelte';
   import LoadingSpinner from '../components/LoadingSpinner.svelte';
   import AgentWorkspace from '../components/AgentWorkspace.svelte';
@@ -47,8 +47,8 @@
     return () => clearInterval(interval);
   });
 
-  let totalCost = $derived(recentRuns.reduce((sum, r) => sum + (r.cost_usd ?? 0), 0));
-  let avgCost = $derived(recentRuns.length > 0 ? totalCost / recentRuns.length : 0);
+  let totalTokens = $derived(recentRuns.reduce((sum, r) => sum + (r.tokens_total ?? 0), 0));
+  let avgTokens = $derived(recentRuns.length > 0 ? totalTokens / recentRuns.length : 0);
 </script>
 
 <div class="space-y-5">
@@ -86,11 +86,11 @@
         class="stagger-2"
       />
       <MetricPanel
-        label="Total Cost"
-        value={totalCost}
-        format={(n) => formatCost(n)}
+        label="Total Tokens"
+        value={totalTokens}
+        format={(n) => formatTokens(n)}
         glow="purple"
-        subtitle="{recentRuns.length} runs, avg {formatCost(avgCost)}"
+        subtitle="{recentRuns.length} runs, avg {formatTokens(avgTokens)}"
         class="stagger-3"
       />
       <MetricPanel

--- a/dashboard/frontend/src/pages/RunDetailPage.svelte
+++ b/dashboard/frontend/src/pages/RunDetailPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Run } from '../lib/types';
   import { getRun } from '../lib/api';
-  import { formatDuration, formatCost, formatDate } from '../lib/format';
+  import { formatDuration, formatTokens, formatDate } from '../lib/format';
   import { toastError } from '../lib/toast.svelte';
   import StatusBadge from '../components/StatusBadge.svelte';
   import LoadingSpinner from '../components/LoadingSpinner.svelte';
@@ -53,8 +53,8 @@
         <p class="mt-1 font-medium">{formatDuration(run.duration_ms)}</p>
       </GlassCard>
       <GlassCard class="p-4">
-        <span class="text-xs text-text-dim">Cost</span>
-        <p class="mt-1 font-medium font-data">{formatCost(run.cost_usd)}</p>
+        <span class="text-xs text-text-dim">Tokens</span>
+        <p class="mt-1 font-medium font-data">{formatTokens(run.tokens_total)}</p>
       </GlassCard>
     </div>
 
@@ -81,6 +81,18 @@
           <tr>
             <td class="px-5 py-3 text-text-dim">Turns</td>
             <td class="px-5 py-3">{run.turns ?? '-'}</td>
+          </tr>
+          <tr>
+            <td class="px-5 py-3 text-text-dim">Tokens (Input)</td>
+            <td class="px-5 py-3 font-data">{formatTokens(run.tokens_input)}</td>
+          </tr>
+          <tr>
+            <td class="px-5 py-3 text-text-dim">Tokens (Output)</td>
+            <td class="px-5 py-3 font-data">{formatTokens(run.tokens_output)}</td>
+          </tr>
+          <tr>
+            <td class="px-5 py-3 text-text-dim">Tokens (Total)</td>
+            <td class="px-5 py-3 font-data">{formatTokens(run.tokens_total)}</td>
           </tr>
           <tr>
             <td class="px-5 py-3 text-text-dim">Started</td>

--- a/dashboard/frontend/src/pages/RunsPage.svelte
+++ b/dashboard/frontend/src/pages/RunsPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Run, Project } from '../lib/types';
   import { listRuns, listProjects, rescanRuns } from '../lib/api';
-  import { formatDuration, formatCost } from '../lib/format';
+  import { formatDuration, formatTokens } from '../lib/format';
   import { toastError, toastSuccess } from '../lib/toast.svelte';
   import StatusBadge from '../components/StatusBadge.svelte';
   import LoadingSpinner from '../components/LoadingSpinner.svelte';
@@ -114,7 +114,7 @@
             <th class="px-3 md:px-5 py-3 font-medium">Verdict</th>
             <th class="px-3 md:px-5 py-3 font-medium hidden md:table-cell">Mode</th>
             <th class="px-3 md:px-5 py-3 font-medium">Duration</th>
-            <th class="px-3 md:px-5 py-3 font-medium">Cost</th>
+            <th class="px-3 md:px-5 py-3 font-medium">Tokens</th>
             <th class="px-3 md:px-5 py-3 font-medium hidden sm:table-cell">Started</th>
           </tr>
         </thead>
@@ -127,7 +127,7 @@
               <td class="px-3 md:px-5 py-3"><StatusBadge value={run.verdict} /></td>
               <td class="px-3 md:px-5 py-3 hidden md:table-cell"><StatusBadge value={run.mode} variant="mode" /></td>
               <td class="px-3 md:px-5 py-3 text-text-dim">{formatDuration(run.duration_ms)}</td>
-              <td class="px-3 md:px-5 py-3 text-text-dim font-data">{formatCost(run.cost_usd)}</td>
+              <td class="px-3 md:px-5 py-3 text-text-dim font-data">{formatTokens(run.tokens_total)}</td>
               <td class="px-3 md:px-5 py-3 hidden sm:table-cell"><TimeAgo date={run.started_at} /></td>
             </tr>
           {/each}


### PR DESCRIPTION
## Summary

- Removes all USD-based budget limits (`max_employee_budget_usd`, `max_manager_budget_usd`, `--max-budget-usd` CLI flag) in favor of token-based limits
- Adds `token_limit_daily`, `token_limit_monthly`, and `token_reserve_percent` config fields with a pre-spawn budget check against the dashboard API
- Tracks `tokens_input`, `tokens_output`, `tokens_total` per run in the database (with migration), webhook, and frontend — replacing cost displays site-wide

## Changes (20 files)

- **Config**: New token limit fields; removed USD budget fields
- **Agent scripts**: Removed `--max-budget-usd`, added `check_token_budget()` with graceful fallback, updated digest to show token counts
- **Backend**: DB migration for token columns, `_extract_tokens()` helper, new `/api/config/token-usage` endpoint, webhook updated
- **Frontend**: All cost displays replaced with token displays; new `formatTokens()`, `TokenBar.svelte`, `TokenUsageData` type; Config page split into Turn/Token/Session sections

## Backward Compatibility

`cost_usd` is kept as a deprecated nullable field in both the DB and API schemas so historical run data is not broken.

## Test Plan

- [ ] Verify frontend builds with no errors
- [ ] Confirm token columns appear in DB after migration
- [ ] Trigger a run and check token data appears in dashboard
- [ ] Set a daily token limit and verify pre-spawn check blocks when exceeded
- [ ] Confirm historical runs still display without errors

🤖 Generated by [Claude Agent Station](https://github.com/kenhaesler/claude-agent-station) — manager verdict: PR (large cross-cutting change, 20 files)