### PR TITLE
feat #29: backend analytics endpoint (GET /api/analytics)

### DIFF
--- a/dashboard/backend/app/main.py
+++ b/dashboard/backend/app/main.py
@@ -19,6 +19,7 @@ from app.services.log_importer import import_historical_runs
 from app.services.stale_run_reaper import reap_stale_runs
 
 from app.routers import (
+    analytics,
     health,
     projects,
     runs,
@@ -137,6 +138,7 @@ app.add_middleware(
 
 # Mount routers
 app.include_router(health.router)
+app.include_router(analytics.router)
 app.include_router(projects.router)
 app.include_router(runs.router)
 app.include_router(logs.router)

--- a/dashboard/backend/app/routers/analytics.py
+++ b/dashboard/backend/app/routers/analytics.py
@@ -1,0 +1,171 @@
+"""Analytics endpoints for run statistics and token usage charts."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select, func, case, and_, cast, Date
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_db
+from app.models import Run, Project
+from app.schemas import (
+    AnalyticsResponse,
+    DailyTokenUsage,
+    VerdictDistribution,
+    ProjectTokenUsage,
+    DailyRunCount,
+)
+
+router = APIRouter(prefix="/api/analytics", tags=["analytics"])
+
+
+@router.get("", response_model=AnalyticsResponse)
+async def get_analytics(
+    days: int = Query(30, ge=1, le=365, description="Number of days to look back"),
+    project_id: Optional[int] = Query(None, description="Filter by project ID"),
+    db: AsyncSession = Depends(get_db),
+) -> AnalyticsResponse:
+    """Aggregate run statistics for charts.
+
+    Returns daily token usage, verdict distribution, per-project token totals,
+    and daily run frequency for the specified time window.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    # Base filter conditions
+    base_conditions = [Run.started_at >= cutoff]
+    if project_id is not None:
+        base_conditions.append(Run.project_id == project_id)
+
+    # 1. Daily token usage (GROUP BY date)
+    daily_tokens_query = (
+        select(
+            func.date(Run.started_at).label("date"),
+            func.coalesce(func.sum(Run.tokens_total), 0).label("tokens_total"),
+            func.coalesce(func.sum(Run.tokens_input), 0).label("tokens_input"),
+            func.coalesce(func.sum(Run.tokens_output), 0).label("tokens_output"),
+            func.count(Run.id).label("run_count"),
+        )
+        .where(and_(*base_conditions))
+        .group_by(func.date(Run.started_at))
+        .order_by(func.date(Run.started_at))
+    )
+    daily_tokens_result = await db.execute(daily_tokens_query)
+    daily_tokens_rows = daily_tokens_result.all()
+
+    daily_token_usage = [
+        DailyTokenUsage(
+            date=row.date,
+            tokens_total=row.tokens_total,
+            tokens_input=row.tokens_input,
+            tokens_output=row.tokens_output,
+            run_count=row.run_count,
+        )
+        for row in daily_tokens_rows
+    ]
+
+    # 2. Verdict distribution (GROUP BY verdict)
+    verdict_query = (
+        select(
+            func.coalesce(Run.verdict, "none").label("verdict"),
+            func.count(Run.id).label("count"),
+        )
+        .where(and_(*base_conditions))
+        .group_by(func.coalesce(Run.verdict, "none"))
+    )
+    verdict_result = await db.execute(verdict_query)
+    verdict_rows = verdict_result.all()
+
+    # Also count failed runs separately (status='failed' regardless of verdict)
+    failed_query = (
+        select(func.count(Run.id))
+        .where(and_(*base_conditions, Run.status == "failed"))
+    )
+    failed_result = await db.execute(failed_query)
+    failed_count = failed_result.scalar() or 0
+
+    verdict_distribution = [
+        VerdictDistribution(verdict=row.verdict, count=row.count)
+        for row in verdict_rows
+    ]
+
+    # 3. Tokens per project (GROUP BY project_id, joined with project name)
+    project_tokens_query = (
+        select(
+            Run.project_id,
+            Project.repo.label("project_repo"),
+            func.coalesce(func.sum(Run.tokens_total), 0).label("tokens_total"),
+            func.coalesce(func.sum(Run.tokens_input), 0).label("tokens_input"),
+            func.coalesce(func.sum(Run.tokens_output), 0).label("tokens_output"),
+            func.count(Run.id).label("run_count"),
+        )
+        .outerjoin(Project, Run.project_id == Project.id)
+        .where(and_(*base_conditions, Run.project_id.isnot(None)))
+        .group_by(Run.project_id, Project.repo)
+        .order_by(func.sum(Run.tokens_total).desc())
+        .limit(10)
+    )
+    project_tokens_result = await db.execute(project_tokens_query)
+    project_tokens_rows = project_tokens_result.all()
+
+    project_token_usage = [
+        ProjectTokenUsage(
+            project_id=row.project_id,
+            project_repo=row.project_repo or f"project-{row.project_id}",
+            tokens_total=row.tokens_total,
+            tokens_input=row.tokens_input,
+            tokens_output=row.tokens_output,
+            run_count=row.run_count,
+        )
+        for row in project_tokens_rows
+    ]
+
+    # 4. Daily run counts (GROUP BY date)
+    daily_runs_query = (
+        select(
+            func.date(Run.started_at).label("date"),
+            func.count(Run.id).label("total"),
+            func.sum(case((Run.status == "success", 1), else_=0)).label("success"),
+            func.sum(case((Run.status == "failed", 1), else_=0)).label("failed"),
+        )
+        .where(and_(*base_conditions))
+        .group_by(func.date(Run.started_at))
+        .order_by(func.date(Run.started_at))
+    )
+    daily_runs_result = await db.execute(daily_runs_query)
+    daily_runs_rows = daily_runs_result.all()
+
+    daily_run_counts = [
+        DailyRunCount(
+            date=row.date,
+            total=row.total,
+            success=row.success or 0,
+            failed=row.failed or 0,
+        )
+        for row in daily_runs_rows
+    ]
+
+    # Summary totals
+    total_tokens_result = await db.execute(
+        select(
+            func.coalesce(func.sum(Run.tokens_total), 0),
+            func.coalesce(func.sum(Run.tokens_input), 0),
+            func.coalesce(func.sum(Run.tokens_output), 0),
+            func.count(Run.id),
+        ).where(and_(*base_conditions))
+    )
+    summary_row = total_tokens_result.one()
+
+    return AnalyticsResponse(
+        days=days,
+        total_tokens=summary_row[0],
+        total_tokens_input=summary_row[1],
+        total_tokens_output=summary_row[2],
+        total_runs=summary_row[3],
+        failed_runs=failed_count,
+        daily_token_usage=daily_token_usage,
+        verdict_distribution=verdict_distribution,
+        project_token_usage=project_token_usage,
+        daily_run_counts=daily_run_counts,
+    )

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -275,3 +275,52 @@ class GuidanceSend(BaseModel):
     guidance_type: str = "info"  # warning/redirect/stop/info
     content: str
     workspace: Optional[str] = None
+
+
+# --- Analytics ---
+
+class DailyTokenUsage(BaseModel):
+    """Token usage aggregated by day."""
+    date: str
+    tokens_total: int = 0
+    tokens_input: int = 0
+    tokens_output: int = 0
+    run_count: int = 0
+
+
+class VerdictDistribution(BaseModel):
+    """Count of runs per verdict type."""
+    verdict: str
+    count: int
+
+
+class ProjectTokenUsage(BaseModel):
+    """Token usage aggregated by project."""
+    project_id: int
+    project_repo: str
+    tokens_total: int = 0
+    tokens_input: int = 0
+    tokens_output: int = 0
+    run_count: int = 0
+
+
+class DailyRunCount(BaseModel):
+    """Run frequency aggregated by day."""
+    date: str
+    total: int = 0
+    success: int = 0
+    failed: int = 0
+
+
+class AnalyticsResponse(BaseModel):
+    """Aggregated analytics data for charts."""
+    days: int
+    total_tokens: int = 0
+    total_tokens_input: int = 0
+    total_tokens_output: int = 0
+    total_runs: int = 0
+    failed_runs: int = 0
+    daily_token_usage: List[DailyTokenUsage] = []
+    verdict_distribution: List[VerdictDistribution] = []
+    project_token_usage: List[ProjectTokenUsage] = []
+    daily_run_counts: List[DailyRunCount] = []


### PR DESCRIPTION
## Summary
- New `GET /api/analytics` FastAPI endpoint with daily token usage, verdict distribution, per-project token totals, and daily run counts
- Configurable `days` param (1–365, default 30) and optional `project_id` filter
- Pydantic response schemas added to `schemas.py`, router registered in `main.py`

## Notes
This backend-only branch is the first half of issue #29. The complete full-stack implementation (including frontend charts and analytics page) is in `autonomous/issue-29-analytics-page` which has been merged to main. This PR is preserved for historical reference — the backend code is already in main via the integration branch.

## Test plan
- [x] Smoke tested with httpx against real DB: GET /api/analytics 200, days=7 200, days=90 200, days=0 422, days=999 422
- [x] Verified response includes daily_token_usage, verdict_distribution, project_token_usage, daily_run_counts arrays + summary totals

🤖 Manager verdict: PR (backend complete; full-stack implementation delivered via integration branch)