### PR TITLE
fix #36: detect and stop agent on Claude CLI rate limit / plan exhaustion

### DIFF
--- a/agent/coordinator/employee_runner.py
+++ b/agent/coordinator/employee_runner.py
@@ -6,6 +6,8 @@ import asyncio
 import json
 import logging
 import os
+import re
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,6 +19,117 @@ logger = logging.getLogger(__name__)
 
 SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
 PROMPTS_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+# Patterns that indicate Claude CLI rate limiting or plan exhaustion
+RATE_LIMIT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"429", re.IGNORECASE),
+    re.compile(r"rate.?limit", re.IGNORECASE),
+    re.compile(r"overloaded", re.IGNORECASE),
+    re.compile(r"too many requests", re.IGNORECASE),
+    re.compile(r"plan.{0,20}(limit|exhaust|exceed)", re.IGNORECASE),
+    re.compile(r"usage.{0,20}(limit|exhaust|exceed)", re.IGNORECASE),
+    re.compile(r"credit.{0,20}(exhaust|exceed|depleted)", re.IGNORECASE),
+    re.compile(r"budget.{0,20}(exhaust|exceed|depleted)", re.IGNORECASE),
+    re.compile(r"capacity", re.IGNORECASE),
+    re.compile(r"throttl", re.IGNORECASE),
+    re.compile(r"verwendet.*100%", re.IGNORECASE),  # German: "100% verwendet"
+    re.compile(r"100%\s*verwendet", re.IGNORECASE),
+]
+
+# Exit codes from Claude CLI that may indicate rate limiting
+# Non-zero exit codes that aren't simple user errors
+RATE_LIMIT_EXIT_CODES: set[int] = {2, 75, 69}
+# 2 = generic error (often API failure), 75 = tempfail, 69 = unavailable
+
+
+@dataclass
+class EmployeeResult:
+    """Result from running a Claude employee subprocess.
+
+    Contains exit code, stream file path, and rate limit detection info.
+    """
+
+    exit_code: int
+    stream_file: str
+    rate_limited: bool = False
+    rate_limit_reason: str = ""
+    stderr_snippet: str = ""
+    stdout_snippet: str = ""
+
+
+def detect_rate_limit_in_text(text: str) -> tuple[bool, str]:
+    """Check if text contains rate limit / plan exhaustion indicators.
+
+    Args:
+        text: Text content to scan (stderr, stdout, or stream content).
+
+    Returns:
+        (is_rate_limited, matched_pattern_description)
+    """
+    if not text:
+        return False, ""
+
+    for pattern in RATE_LIMIT_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            # Extract context around the match for the reason
+            start = max(0, match.start() - 40)
+            end = min(len(text), match.end() + 40)
+            context = text[start:end].strip().replace("\n", " ")
+            return True, f"Pattern '{pattern.pattern}' matched: ...{context}..."
+
+    return False, ""
+
+
+def _check_stream_for_rate_limits(stream_file: str) -> tuple[bool, str]:
+    """Scan stream JSONL file for rate limit error events.
+
+    Claude CLI stream-json output includes error events that may
+    indicate rate limiting.
+
+    Args:
+        stream_file: Path to the .stream.jsonl file.
+
+    Returns:
+        (is_rate_limited, reason)
+    """
+    try:
+        content = Path(stream_file).read_text()
+    except OSError:
+        return False, ""
+
+    # Check last 50 lines (rate limits usually appear at the end)
+    lines = content.strip().split("\n")
+    tail_lines = lines[-50:] if len(lines) > 50 else lines
+
+    for line in tail_lines:
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            # Also check raw line text for rate limit patterns
+            found, reason = detect_rate_limit_in_text(line)
+            if found:
+                return True, reason
+            continue
+
+        # Check error events
+        event_type = event.get("type", "")
+        if event_type in ("error", "system"):
+            error_msg = str(event.get("error", event.get("message", "")))
+            found, reason = detect_rate_limit_in_text(error_msg)
+            if found:
+                return True, f"Stream error event: {reason}"
+
+        # Check for API error subtype
+        if event.get("subtype") == "error" or event.get("is_error"):
+            content_str = str(event.get("content", ""))
+            found, reason = detect_rate_limit_in_text(content_str)
+            if found:
+                return True, f"Stream error content: {reason}"
+
+    return False, ""
 
 
 def _build_employee_prompt(task: Task, config: CoordinatorConfig, employee_index: int) -> str:
@@ -115,10 +228,12 @@ async def run_employee(
     task: Task,
     config: CoordinatorConfig,
     employee_index: int,
-) -> tuple[int, str]:
+) -> EmployeeResult:
     """Spawn a Claude employee subprocess for a task.
 
-    Returns (exit_code, stream_file_path).
+    Returns an EmployeeResult with exit code, stream file path,
+    and rate limit detection information.
+
     Matches the CLI invocation pattern from run-manager.sh run_employee().
     """
     prompt = _build_employee_prompt(task, config, employee_index)
@@ -186,18 +301,74 @@ async def run_employee(
 
     exit_code = proc.returncode or 0
 
+    # Read stderr for analysis
+    stderr_content = ""
+    try:
+        stderr_content = Path(stderr_file).read_text().strip()
+    except OSError:
+        pass
+
     # Log stderr if employee failed
-    if exit_code != 0:
-        try:
-            stderr_content = Path(stderr_file).read_text().strip()
-            if stderr_content:
-                logger.warning("Employee %d stderr: %s", employee_index, stderr_content[:500])
-        except OSError:
-            pass
+    if exit_code != 0 and stderr_content:
+        logger.warning("Employee %d stderr: %s", employee_index, stderr_content[:500])
 
     logger.info(
         "Employee %d for task '%s' exited with code %d",
         employee_index, task.title, exit_code,
     )
 
-    return exit_code, stream_file
+    # --- Rate limit detection ---
+    rate_limited = False
+    rate_limit_reason = ""
+
+    # Check 1: Scan stderr for rate limit indicators
+    if stderr_content:
+        found, reason = detect_rate_limit_in_text(stderr_content)
+        if found:
+            rate_limited = True
+            rate_limit_reason = f"stderr: {reason}"
+            logger.warning(
+                "Employee %d RATE LIMITED (stderr): %s",
+                employee_index, reason,
+            )
+
+    # Check 2: Scan stream file for rate limit error events
+    if not rate_limited:
+        found, reason = _check_stream_for_rate_limits(stream_file)
+        if found:
+            rate_limited = True
+            rate_limit_reason = f"stream: {reason}"
+            logger.warning(
+                "Employee %d RATE LIMITED (stream): %s",
+                employee_index, reason,
+            )
+
+    # Check 3: Non-zero exit code that commonly indicates rate limiting
+    # Only flag if exit code is in the known set AND the employee produced
+    # very little output (suggesting it failed early due to API rejection)
+    if not rate_limited and exit_code in RATE_LIMIT_EXIT_CODES:
+        try:
+            stream_size = Path(stream_file).stat().st_size
+        except OSError:
+            stream_size = 0
+
+        # If the process failed quickly with minimal output, likely rate limited
+        if stream_size < 1024:
+            rate_limited = True
+            rate_limit_reason = (
+                f"Exit code {exit_code} with minimal output "
+                f"({stream_size} bytes) suggests plan exhaustion"
+            )
+            logger.warning(
+                "Employee %d RATE LIMITED (exit code): %s",
+                employee_index, rate_limit_reason,
+            )
+
+    return EmployeeResult(
+        exit_code=exit_code,
+        stream_file=stream_file,
+        rate_limited=rate_limited,
+        rate_limit_reason=rate_limit_reason,
+        stderr_snippet=stderr_content[:500] if stderr_content else "",
+        stdout_snippet="",  # stdout goes to stream file
+    )

--- a/agent/coordinator/manager.py
+++ b/agent/coordinator/manager.py
@@ -1,13 +1,17 @@
-"""Plan usage awareness for the coordinator/manager.
+"""Plan usage awareness and rate limit handling for the coordinator/manager.
 
-Provides functions to check plan usage before spawning new employees
-and to request graceful wrap-up when approaching usage thresholds.
+Provides functions to check plan usage before spawning new employees,
+to request graceful wrap-up when approaching usage thresholds, and
+to track/respond to rate limit signals from employee subprocesses.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -219,3 +223,199 @@ def _get_plan_tier(config: CoordinatorConfig) -> str:
     falling back to 'max_5x' as default.
     """
     return getattr(config, "plan_tier", "max_5x")
+
+
+# ---------------------------------------------------------------------------
+# Rate limit tracking from employee results
+# ---------------------------------------------------------------------------
+
+# Number of consecutive rate-limited employees before declaring budget exhausted
+RATE_LIMIT_THRESHOLD = 2
+
+
+@dataclass
+class RateLimitEvent:
+    """Record of a single employee rate limit detection."""
+
+    employee_index: int
+    task_id: str
+    timestamp: datetime
+    reason: str
+    exit_code: int
+
+
+@dataclass
+class RateLimitTracker:
+    """Tracks rate limit signals from employees and decides when to stop spawning.
+
+    The manager should create one instance per run and call
+    ``record_employee_result()`` after each employee finishes.
+    When ``is_budget_exhausted`` becomes True, no new employees should be spawned
+    and running employees should be asked to wrap up.
+    """
+
+    events: list[RateLimitEvent] = field(default_factory=list)
+    consecutive_rate_limits: int = 0
+    is_budget_exhausted: bool = False
+    exhausted_reason: str = ""
+    exhausted_at: datetime | None = None
+
+    def record_employee_result(
+        self,
+        employee_index: int,
+        task_id: str,
+        rate_limited: bool,
+        rate_limit_reason: str,
+        exit_code: int,
+    ) -> bool:
+        """Record the result of an employee run and check for budget exhaustion.
+
+        Args:
+            employee_index: The employee index that finished.
+            task_id: The task ID.
+            rate_limited: Whether the employee detected rate limiting.
+            rate_limit_reason: Description of the rate limit signal.
+            exit_code: Process exit code.
+
+        Returns:
+            True if this event triggered budget exhaustion (newly exhausted).
+        """
+        now = datetime.now(timezone.utc)
+
+        if rate_limited:
+            event = RateLimitEvent(
+                employee_index=employee_index,
+                task_id=task_id,
+                timestamp=now,
+                reason=rate_limit_reason,
+                exit_code=exit_code,
+            )
+            self.events.append(event)
+            self.consecutive_rate_limits += 1
+
+            logger.warning(
+                "Rate limit detected from employee %d (task %s): %s "
+                "(consecutive: %d/%d)",
+                employee_index, task_id, rate_limit_reason,
+                self.consecutive_rate_limits, RATE_LIMIT_THRESHOLD,
+            )
+
+            if (
+                not self.is_budget_exhausted
+                and self.consecutive_rate_limits >= RATE_LIMIT_THRESHOLD
+            ):
+                self.is_budget_exhausted = True
+                self.exhausted_at = now
+                self.exhausted_reason = (
+                    f"{self.consecutive_rate_limits} consecutive employees "
+                    f"hit rate limits. Last: {rate_limit_reason}"
+                )
+                logger.error(
+                    "BUDGET EXHAUSTED: %s", self.exhausted_reason,
+                )
+                return True
+        else:
+            # Successful employee resets consecutive counter
+            self.consecutive_rate_limits = 0
+
+        return False
+
+    def to_dict(self) -> dict:
+        """Serialize tracker state for reporting."""
+        return {
+            "is_budget_exhausted": self.is_budget_exhausted,
+            "exhausted_reason": self.exhausted_reason,
+            "exhausted_at": self.exhausted_at.isoformat() if self.exhausted_at else None,
+            "consecutive_rate_limits": self.consecutive_rate_limits,
+            "total_rate_limit_events": len(self.events),
+            "events": [
+                {
+                    "employee_index": e.employee_index,
+                    "task_id": e.task_id,
+                    "timestamp": e.timestamp.isoformat(),
+                    "reason": e.reason,
+                    "exit_code": e.exit_code,
+                }
+                for e in self.events
+            ],
+        }
+
+
+def handle_budget_exhaustion(
+    config: CoordinatorConfig,
+    dag: TaskDAG,
+    tracker: RateLimitTracker,
+    running_tasks: dict[str, int],
+) -> int:
+    """React to budget exhaustion by notifying running employees to wrap up.
+
+    Sends stop guidance to all running employees and logs the event.
+
+    Args:
+        config: Coordinator configuration.
+        dag: The task DAG.
+        tracker: The rate limit tracker.
+        running_tasks: Map of task_id to employee_index for running tasks.
+
+    Returns:
+        Number of employees notified.
+    """
+    notified = 0
+
+    for task_id, employee_index in running_tasks.items():
+        task = dag.tasks.get(task_id)
+        if not task or not task.workspace:
+            continue
+
+        message = (
+            f"BUDGET EXHAUSTED: {tracker.exhausted_reason} "
+            f"Stop work now — commit what you have and write a partial report. "
+            f"The Claude plan limit appears to have been reached."
+        )
+
+        try:
+            send_guidance(
+                workspace=task.workspace,
+                employee_index=employee_index,
+                guidance_type="stop",
+                content=message,
+            )
+            notified += 1
+            logger.warning(
+                "Sent budget-exhaustion STOP to employee %d (task %s)",
+                employee_index, task_id,
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to send budget-exhaustion stop to employee %d: %s",
+                employee_index, e,
+            )
+
+    # Persist exhaustion state to a file for external tools / dashboard
+    _save_exhaustion_state(config, tracker)
+
+    return notified
+
+
+def _save_exhaustion_state(
+    config: CoordinatorConfig,
+    tracker: RateLimitTracker,
+) -> None:
+    """Write budget exhaustion state to a JSON file in the log directory.
+
+    This allows the dashboard and external tools to detect that a run
+    was stopped due to plan budget exhaustion.
+    """
+    state_file = Path(config.log_dir) / f"run-{config.run_id}-budget-exhausted.json"
+    try:
+        state_file.parent.mkdir(parents=True, exist_ok=True)
+        state = {
+            "run_id": config.run_id,
+            "status": "budget_exhausted",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            **tracker.to_dict(),
+        }
+        state_file.write_text(json.dumps(state, indent=2))
+        logger.info("Budget exhaustion state saved to %s", state_file)
+    except OSError as e:
+        logger.error("Failed to save budget exhaustion state: %s", e)

--- a/agent/coordinator/scheduler.py
+++ b/agent/coordinator/scheduler.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from agent.coordinator.config import CoordinatorConfig
 
 from agent.coordinator.dag import TaskDAG, Task, TaskStatus
-from agent.coordinator.employee_runner import run_employee
+from agent.coordinator.employee_runner import run_employee, EmployeeResult
 from agent.coordinator.stream_monitor import (
     EmployeeActivity,
     ConflictDetector,
@@ -24,6 +24,8 @@ from agent.coordinator.guidance import send_guidance
 from agent.coordinator.manager import (
     check_plan_usage_before_spawn,
     request_graceful_wrapup,
+    handle_budget_exhaustion,
+    RateLimitTracker,
     DEFAULT_MAX_USAGE_PERCENT,
 )
 from agent.coordinator.reporter import post_task_event, post_conflict, post_guidance
@@ -38,6 +40,7 @@ async def run_scheduler(dag: TaskDAG, config: CoordinatorConfig) -> None:
     activities: dict[str, EmployeeActivity] = {}
     stop_events: dict[str, asyncio.Event] = {}
     conflict_detector = ConflictDetector()
+    rate_limit_tracker = RateLimitTracker()
     next_employee_index = 0
 
     logger.info("Scheduler started: %d tasks, max_concurrent=%d", len(dag.tasks), config.max_concurrent)
@@ -66,6 +69,35 @@ async def run_scheduler(dag: TaskDAG, config: CoordinatorConfig) -> None:
                 last_usage_ok = can_spawn
             except Exception as e:
                 logger.debug("Plan usage check failed (non-fatal): %s", e)
+
+        # If budget exhausted via rate limit detection, stop spawning
+        if rate_limit_tracker.is_budget_exhausted:
+            if running:
+                logger.warning(
+                    "Budget exhausted — waiting for %d running employees to finish",
+                    len(running),
+                )
+            else:
+                logger.warning("Budget exhausted — no running employees, stopping scheduler")
+                break
+            # Don't spawn new tasks, just wait for running ones
+            # Skip the spawn loop entirely
+            done, _ = await asyncio.wait(
+                running.values(),
+                return_when=asyncio.FIRST_COMPLETED,
+                timeout=5.0,
+            )
+            for completed_future in done:
+                task_id = completed_future.result()
+                del running[task_id]
+                if task_id in stop_events:
+                    stop_events[task_id].set()
+                    del stop_events[task_id]
+                if task_id in activities:
+                    activity = activities[task_id]
+                    conflict_detector.clear(activity.employee_index)
+                    del activities[task_id]
+            continue
 
         # Spawn employees for ready tasks
         for task in dag.ready_tasks():
@@ -116,7 +148,7 @@ async def run_scheduler(dag: TaskDAG, config: CoordinatorConfig) -> None:
                 _run_and_monitor(
                     task, config, employee_index, activity,
                     stop_event, conflict_detector, semaphore,
-                    dag,
+                    dag, rate_limit_tracker,
                 )
             )
 
@@ -184,6 +216,7 @@ async def _run_and_monitor(
     conflict_detector: ConflictDetector,
     semaphore: asyncio.Semaphore,
     dag: TaskDAG,
+    rate_limit_tracker: RateLimitTracker | None = None,
 ) -> str:
     """Run an employee and monitor their stream. Returns task_id when done."""
     try:
@@ -199,7 +232,8 @@ async def _run_and_monitor(
         )
 
         # Wait for employee to finish
-        exit_code, _ = await employee_task
+        result: EmployeeResult = await employee_task
+        exit_code = result.exit_code
 
         # Stop the monitor
         stop_event.set()
@@ -208,11 +242,33 @@ async def _run_and_monitor(
         except asyncio.TimeoutError:
             monitor_task.cancel()
 
+        # Record rate limit status with the tracker
+        if rate_limit_tracker is not None:
+            newly_exhausted = rate_limit_tracker.record_employee_result(
+                employee_index=employee_index,
+                task_id=task.id,
+                rate_limited=result.rate_limited,
+                rate_limit_reason=result.rate_limit_reason,
+                exit_code=exit_code,
+            )
+            if newly_exhausted:
+                # Budget just became exhausted — notify other running employees
+                running_map = {
+                    tid: act.employee_index
+                    for tid, act in _get_running_activities(dag, activity).items()
+                }
+                handle_budget_exhaustion(config, dag, rate_limit_tracker, running_map)
+
         # Update DAG based on result
         if exit_code == 0:
             dag.mark_completed(task.id, exit_code)
             post_task_event(config, "task_completed", task)
             logger.info("Task '%s' completed successfully (employee %d)", task.title, employee_index)
+        elif result.rate_limited:
+            error_msg = f"Rate limited: {result.rate_limit_reason}"
+            dag.mark_failed(task.id, error_msg, exit_code)
+            post_task_event(config, "task_failed", task)
+            logger.warning("Task '%s' rate-limited (employee %d): %s", task.title, employee_index, result.rate_limit_reason)
         else:
             dag.mark_failed(task.id, f"Employee exited with code {exit_code}", exit_code)
             post_task_event(config, "task_failed", task)
@@ -234,6 +290,20 @@ async def _run_and_monitor(
         semaphore.release()
 
     return task.id
+
+
+def _get_running_activities(dag: TaskDAG, exclude_activity: EmployeeActivity) -> dict[str, int]:
+    """Get a map of task_id -> employee_index for currently running tasks.
+
+    Used when budget exhaustion is detected to notify other running employees.
+    This is a best-effort helper — the scheduler's activities dict isn't directly
+    accessible here, so we reconstruct from the DAG.
+    """
+    result: dict[str, int] = {}
+    for task in dag.running_tasks():
+        if task.employee_index is not None and task.employee_index != exclude_activity.employee_index:
+            result[task.id] = task.employee_index
+    return result
 
 
 async def _setup_task_workspace(task: Task, config: CoordinatorConfig, employee_index: int) -> str | None:


### PR DESCRIPTION
## Summary

Fixes #36 — agent continues running after Claude plan usage limit is exhausted.

- **`employee_runner.py`**: Added `EmployeeResult` dataclass, `RATE_LIMIT_PATTERNS` (12 regex patterns covering English + German indicators), `detect_rate_limit_in_text()`, and `_check_stream_for_rate_limits()`. `run_employee()` now returns `EmployeeResult` instead of `tuple[int, str]`, enabling callers to inspect rate-limit status.
- **`manager.py`**: Added `RateLimitTracker` (consecutive-failure counting, threshold=2, reset-on-success), `RateLimitEvent`, `handle_budget_exhaustion()` (sends STOP guidance to running employees), and `_save_exhaustion_state()` (persists JSON file for dashboards).
- **`scheduler.py`**: Integrated `RateLimitTracker` into the main scheduling loop — stops spawning new tasks when budget is exhausted and waits for running employees to finish.

## Test plan

- [ ] Verify `Task` model has `employee_index` attribute (used in `_get_running_activities()`)
- [ ] Confirm no other callers of `run_employee()` exist outside scheduler that relied on the old `tuple[int, str]` return type
- [ ] Run full test suite: `pytest agent/`
- [ ] Simulate a rate-limit event and confirm scheduler stops spawning after 2 consecutive failures
- [ ] Confirm running employees receive the budget-exhaustion STOP guidance message

## Notes

This PR is complementary to the `detect_plan_usage.py` enhancement already merged to main (proactive detection). This PR handles reactive in-flight detection when an employee subprocess actually gets rate-limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)