### PR TITLE
fix #47: UX overhaul - simplify navigation, unify run lifecycle, improve clarity

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -11,8 +11,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.dependencies import get_db
-from app.models import Run, Project
-from app.schemas import RunOut, RunList, ActiveEmployeeOut
+from app.models import Run, Project, CoordinatorTask, CoordinatorMessage, QueueItem, Plan
+from app.schemas import (
+    RunOut, RunList, ActiveEmployeeOut, RunFullContext,
+    CoordinatorTaskOut, CoordinatorMessageOut, QueueItemOut, PlanOut,
+)
 from app.services.diff_parser import parse_unified_diff, DiffResult
 from app.services.log_importer import import_historical_runs
 from app.services.systemd import systemctl
@@ -96,6 +99,67 @@ async def get_run(run_id: str, db: AsyncSession = Depends(get_db)):
     if not run:
         raise HTTPException(status_code=404, detail="Run not found")
     return run
+
+
+@router.get("/{run_id}/full", response_model=RunFullContext)
+async def get_run_full_context(run_id: str, db: AsyncSession = Depends(get_db)):
+    """Return unified run context: run + coordinator tasks + queue item + plan.
+
+    This powers the unified Run Detail view (AC2) by fetching all related
+    data in a single request instead of requiring 4+ separate API calls.
+    """
+    # 1. Fetch the run
+    result = await db.execute(select(Run).where(Run.run_id == run_id))
+    run = result.scalar_one_or_none()
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    # 2. Fetch coordinator tasks for this run
+    tasks_result = await db.execute(
+        select(CoordinatorTask).where(CoordinatorTask.run_id == run_id)
+    )
+    tasks = tasks_result.scalars().all()
+
+    # 3. Fetch coordinator messages for this run
+    msgs_result = await db.execute(
+        select(CoordinatorMessage)
+        .where(CoordinatorMessage.run_id == run_id)
+        .order_by(CoordinatorMessage.created_at)
+    )
+    messages = msgs_result.scalars().all()
+
+    # 4. Fetch related queue item (by run_id)
+    queue_result = await db.execute(
+        select(QueueItem).where(QueueItem.run_id == run_id)
+    )
+    queue_item = queue_result.scalar_one_or_none()
+
+    # 5. Fetch related plan (by implementation_run_id or run_id)
+    plan_result = await db.execute(
+        select(Plan).where(
+            (Plan.implementation_run_id == run_id) | (Plan.run_id == run_id)
+        )
+    )
+    plan = plan_result.scalar_one_or_none()
+
+    # 6. Get project repo name
+    project_repo: Optional[str] = None
+    if run.project_id:
+        proj_result = await db.execute(
+            select(Project).where(Project.id == run.project_id)
+        )
+        project = proj_result.scalar_one_or_none()
+        if project:
+            project_repo = project.repo
+
+    return RunFullContext(
+        run=RunOut.model_validate(run),
+        coordinator_tasks=[CoordinatorTaskOut.model_validate(t) for t in tasks],
+        coordinator_messages=[CoordinatorMessageOut.model_validate(m) for m in messages],
+        queue_item=QueueItemOut.model_validate(queue_item) if queue_item else None,
+        plan=PlanOut.model_validate(plan) if plan else None,
+        project_repo=project_repo,
+    )
 
 
 @router.get("/{run_id}/diff", response_model=DiffResult)

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -393,3 +393,19 @@ class AnalyticsResponse(BaseModel):
     verdict_distribution: List[VerdictDistribution] = []
     project_token_usage: List[ProjectTokenUsage] = []
     daily_run_counts: List[DailyRunCount] = []
+
+
+# --- Unified Run Context ---
+
+class RunFullContext(BaseModel):
+    """Unified run context: run + coordinator tasks + queue item + plan.
+
+    Powers the unified Run Detail view (AC2) by returning all related
+    data in a single response instead of requiring 4+ separate API calls.
+    """
+    run: RunOut
+    coordinator_tasks: List[CoordinatorTaskOut] = []
+    coordinator_messages: List[CoordinatorMessageOut] = []
+    queue_item: Optional[QueueItemOut] = None
+    plan: Optional[PlanOut] = None
+    project_repo: Optional[str] = None

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -241,3 +241,28 @@ async def test_get_active_employees_empty(client):
     resp = await client.get("/api/runs/active-employees")
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+# --- Full context (unified run detail) ---
+
+@pytest.mark.asyncio
+async def test_get_run_full_context(client, sample_runs):
+    """GET /api/runs/{run_id}/full returns run with related context."""
+    resp = await client.get("/api/runs/run-001/full")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["run"]["run_id"] == "run-001"
+    assert data["run"]["status"] == "success"
+    assert data["project_repo"] == "owner/test-repo"
+    assert isinstance(data["coordinator_tasks"], list)
+    assert isinstance(data["coordinator_messages"], list)
+    # No queue item or plan linked to this run
+    assert data["queue_item"] is None
+    assert data["plan"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_run_full_context_not_found(client):
+    """GET /api/runs/{run_id}/full returns 404 for unknown run."""
+    resp = await client.get("/api/runs/nonexistent-run/full")
+    assert resp.status_code == 404

--- a/dashboard/frontend/src/App.svelte
+++ b/dashboard/frontend/src/App.svelte
@@ -18,6 +18,7 @@
   import QueuePage from './pages/QueuePage.svelte';
   import AnalyticsPage from './pages/AnalyticsPage.svelte';
   import PromptsPage from './pages/PromptsPage.svelte';
+  import SettingsPage from './pages/SettingsPage.svelte';
 
   let serviceActive = $state(false);
   let authOk = $state(false);
@@ -104,12 +105,14 @@
         <RunDetailPage runId={route.param ?? ''} />
       {:else if route.page === 'logs'}
         <LogsPage />
+      {:else if route.page === 'settings'}
+        <SettingsPage />
       {:else if route.page === 'config'}
-        <ConfigPage />
+        <SettingsPage />
       {:else if route.page === 'prompts'}
         <PromptsPage />
       {:else if route.page === 'system'}
-        <SystemPage />
+        <SettingsPage />
       {/if}
     </main>
   </div>

--- a/dashboard/frontend/src/components/ActiveRunBanner.svelte
+++ b/dashboard/frontend/src/components/ActiveRunBanner.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import type { Run } from '../lib/types';
+  import { getLatestRun, listProjects } from '../lib/api';
+  import type { RunPhase } from '../lib/workspace-renderer';
+
+  let activeRun = $state<Run | null>(null);
+  let projectName = $state<string | null>(null);
+  let elapsed = $state(0);
+
+  let phase = $derived((): RunPhase => {
+    if (!activeRun) return 'idle';
+    if (activeRun.status === 'reviewing') return 'manager_review';
+    if (activeRun.status === 'running') return 'employee';
+    return 'idle';
+  });
+
+  let isActive = $derived(phase() !== 'idle');
+
+  let phaseLabel = $derived(() => {
+    switch (phase()) {
+      case 'coordinating': return 'Coordinating';
+      case 'employee': return 'Employees Working';
+      case 'manager_review': return 'Manager Review';
+      case 'executing_verdict': return 'Executing Verdict';
+      default: return '';
+    }
+  });
+
+  let phaseColor = $derived(() => {
+    switch (phase()) {
+      case 'coordinating': return 'rgb(168, 85, 247)';
+      case 'employee': return 'rgb(59, 130, 246)';
+      case 'manager_review': return 'rgb(245, 158, 11)';
+      case 'executing_verdict': return 'rgb(16, 185, 129)';
+      default: return 'rgb(6, 182, 212)';
+    }
+  });
+
+  function formatElapsed(s: number): string {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    if (m > 0) return `${m}m ${sec}s`;
+    return `${sec}s`;
+  }
+
+  async function poll() {
+    try {
+      const run = await getLatestRun();
+      if (run && (run.status === 'running' || run.status === 'reviewing')) {
+        activeRun = run;
+        // Resolve project name
+        if (run.project_id && !projectName) {
+          try {
+            const projects = await listProjects();
+            const proj = projects.find(p => p.id === run.project_id);
+            if (proj) projectName = proj.repo;
+          } catch { /* ignore */ }
+        }
+      } else {
+        activeRun = null;
+        projectName = null;
+      }
+    } catch { /* ignore */ }
+  }
+
+  // Elapsed timer
+  $effect(() => {
+    if (!activeRun?.started_at) { elapsed = 0; return; }
+    const start = new Date(activeRun.started_at).getTime();
+    elapsed = Math.max(0, Math.floor((Date.now() - start) / 1000));
+    const interval = setInterval(() => {
+      elapsed = Math.max(0, Math.floor((Date.now() - start) / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  });
+
+  // Poll for active run
+  $effect(() => {
+    poll();
+    const interval = setInterval(poll, 8000);
+    return () => clearInterval(interval);
+  });
+</script>
+
+{#if isActive && activeRun}
+  <a
+    href="#/runs/{activeRun.run_id}"
+    class="active-run-banner flex items-center gap-2 px-3 py-1 rounded-md text-xs transition-all
+      hover:bg-white/[0.06] no-underline cursor-pointer group"
+    style="border: 1px solid {phaseColor()}30; background: {phaseColor()}08;"
+  >
+    <!-- Pulsing dot -->
+    <span class="relative flex h-2 w-2 shrink-0">
+      <span class="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75" style="background: {phaseColor()};"></span>
+      <span class="relative inline-flex rounded-full h-2 w-2" style="background: {phaseColor()};"></span>
+    </span>
+
+    <!-- Phase label -->
+    <span class="font-medium hidden md:inline" style="color: {phaseColor()};">{phaseLabel()}</span>
+
+    <!-- Project name -->
+    {#if projectName}
+      <span class="text-text-dim hidden lg:inline">{projectName.split('/').pop()}</span>
+    {/if}
+
+    <!-- Elapsed time -->
+    <span class="font-data tabular-nums text-text-dim">{formatElapsed(elapsed)}</span>
+
+    <!-- Arrow indicator -->
+    <span class="text-text-dim group-hover:text-text transition-colors">&rarr;</span>
+  </a>
+{/if}

--- a/dashboard/frontend/src/components/HeaderBar.svelte
+++ b/dashboard/frontend/src/components/HeaderBar.svelte
@@ -2,6 +2,7 @@
   import StatusOrb from './StatusOrb.svelte';
   import ArcGauge from './ArcGauge.svelte';
   import AiStatusLine from './AiStatusLine.svelte';
+  import ActiveRunBanner from './ActiveRunBanner.svelte';
 
   interface Props {
     serviceActive: boolean;
@@ -56,6 +57,9 @@
     <div class="hidden md:block">
       <AiStatusLine messages={statusMessages} speed={45} />
     </div>
+
+    <!-- AC3: Always-visible active run progress indicator -->
+    <ActiveRunBanner />
   </div>
 
   <!-- Status indicators + trigger button -->

--- a/dashboard/frontend/src/components/Sidebar.svelte
+++ b/dashboard/frontend/src/components/Sidebar.svelte
@@ -10,18 +10,18 @@
 
   let collapsed = $state(false);
 
+  // AC1: Reduced to 5 primary navigation items (down from 11)
+  // Coordinator + Queue -> integrated into Run Detail (AC4)
+  // Analytics -> accessible from Dashboard (AC4)
+  // Config + System -> merged into Settings (AC4)
+  // Logs -> accessible from Settings and Run Detail
+  // Prompts -> accessible from Settings
   const links = [
     { page: 'dashboard', label: 'Dashboard' },
     { page: 'projects', label: 'Projects' },
     { page: 'plans', label: 'Plans' },
     { page: 'runs', label: 'Runs' },
-    { page: 'coordinator', label: 'Coordinator' },
-    { page: 'queue', label: 'Queue' },
-    { page: 'analytics', label: 'Analytics' },
-    { page: 'logs', label: 'Logs' },
-    { page: 'config', label: 'Config' },
-    { page: 'prompts', label: 'Prompts' },
-    { page: 'system', label: 'System' },
+    { page: 'settings', label: 'Settings' },
   ] as const;
 
   function closeMobile() {
@@ -70,7 +70,7 @@
 
   <nav class="flex flex-col gap-1 px-2 py-3 flex-1">
     {#each links as link}
-      {@const active = route.page === link.page || (link.page === 'runs' && route.page === 'run-detail') || (link.page === 'plans' && route.page === 'plan-detail') || (link.page === 'coordinator' && route.page === 'coordinator')}
+      {@const active = route.page === link.page || (link.page === 'runs' && route.page === 'run-detail') || (link.page === 'plans' && route.page === 'plan-detail') || (link.page === 'settings' && (route.page === 'config' || route.page === 'system' || route.page === 'prompts'))}
       <a
         href="#{link.page === 'dashboard' ? '/' : `/${link.page}`}"
         onclick={closeMobile}
@@ -91,20 +91,8 @@
             <path d="M4 4h12M4 8h12M4 12h8" /><path d="M13 12l2 2 4-4" stroke-width="2" />
           {:else if link.page === 'runs'}
             <circle cx="10" cy="10" r="8" /><polygon points="8,6 15,10 8,14" fill="currentColor" stroke="none" />
-          {:else if link.page === 'coordinator'}
-            <circle cx="10" cy="6" r="2.5" /><circle cx="5" cy="15" r="2.5" /><circle cx="15" cy="15" r="2.5" /><line x1="10" y1="8.5" x2="6.5" y2="12.5" /><line x1="10" y1="8.5" x2="13.5" y2="12.5" /><line x1="7.5" y1="15" x2="12.5" y2="15" />
-          {:else if link.page === 'queue'}
-            <path d="M3 4h14M3 8h14M3 12h14M3 16h14" /><rect x="14" y="3" width="4" height="3" rx="0.5" /><rect x="14" y="7" width="4" height="3" rx="0.5" /><rect x="14" y="11" width="4" height="3" rx="0.5" />
-          {:else if link.page === 'analytics'}
-            <path d="M3 17V10" /><path d="M7 17V7" /><path d="M11 17V12" /><path d="M15 17V4" /><path d="M19 17V9" />
-          {:else if link.page === 'logs'}
-            <rect x="3" y="2" width="14" height="16" rx="1" /><line x1="6" y1="6" x2="14" y2="6" /><line x1="6" y1="9.5" x2="14" y2="9.5" /><line x1="6" y1="13" x2="11" y2="13" />
-          {:else if link.page === 'config'}
+          {:else if link.page === 'settings'}
             <circle cx="10" cy="10" r="3" /><path d="M10 1.5v2M10 16.5v2M1.5 10h2M16.5 10h2M3.4 3.4l1.4 1.4M15.2 15.2l1.4 1.4M3.4 16.6l1.4-1.4M15.2 4.8l1.4-1.4" />
-          {:else if link.page === 'prompts'}
-            <path d="M4 4h12a1 1 0 011 1v10a1 1 0 01-1 1H4a1 1 0 01-1-1V5a1 1 0 011-1z" /><path d="M6 7h8M6 10h6M6 13h4" />
-          {:else if link.page === 'system'}
-            <rect x="3" y="2" width="14" height="5" rx="1" /><rect x="3" y="9" width="14" height="5" rx="1" /><circle cx="6" cy="4.5" r="0.75" fill="currentColor" /><circle cx="6" cy="11.5" r="0.75" fill="currentColor" /><line x1="8" y1="17" x2="12" y2="17" /><line x1="10" y1="14" x2="10" y2="17" />
           {/if}
         </svg>
         {#if !collapsed}

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Project, ProjectCreate, ProjectUpdate, Run, RunList, ActiveEmployeeData, Plan, PlanList, SystemStatus, AuthStatus, LogSearchResult, RunLogs, UsageData, TokenUsageData, OAuthStartResponse, OAuthCallbackResponse, CoordinatorTask, CoordinatorTaskDetail, CoordinatorDAG, CoordinatorMessage, AnalyticsData, DiffResult, QueueItem, QueueItemList, QueueStats } from './types';
+import type { Project, ProjectCreate, ProjectUpdate, Run, RunList, RunFullContext, ActiveEmployeeData, Plan, PlanList, SystemStatus, AuthStatus, LogSearchResult, RunLogs, UsageData, TokenUsageData, OAuthStartResponse, OAuthCallbackResponse, CoordinatorTask, CoordinatorTaskDetail, CoordinatorDAG, CoordinatorMessage, AnalyticsData, DiffResult, QueueItem, QueueItemList, QueueStats } from './types';
 
 const BASE = import.meta.env.VITE_API_URL || '';
 
@@ -44,6 +44,7 @@ export const getLatestRun = () => request<Run>('/api/runs/latest');
 export const getRun = (runId: string) => request<Run>(`/api/runs/${runId}`);
 export const triggerRun = () => request<{ status: string; detail: string }>('/api/runs/trigger', { method: 'POST' });
 export const getRunDiff = (runId: string) => request<DiffResult>(`/api/runs/${runId}/diff`);
+export const getRunFullContext = (runId: string) => request<RunFullContext>(`/api/runs/${runId}/full`);
 export const rescanRuns = () => request<{ status: string; imported: number }>('/api/runs/rescan', { method: 'POST' });
 
 // Config

--- a/dashboard/frontend/src/lib/router.svelte.ts
+++ b/dashboard/frontend/src/lib/router.svelte.ts
@@ -1,4 +1,4 @@
-type Page = 'dashboard' | 'projects' | 'plans' | 'plan-detail' | 'runs' | 'run-detail' | 'coordinator' | 'queue' | 'analytics' | 'logs' | 'config' | 'prompts' | 'system';
+type Page = 'dashboard' | 'projects' | 'plans' | 'plan-detail' | 'runs' | 'run-detail' | 'coordinator' | 'queue' | 'analytics' | 'logs' | 'config' | 'prompts' | 'system' | 'settings';
 
 interface Route {
   page: Page;
@@ -12,7 +12,7 @@ function parseHash(): Route {
   if (parts.length === 0) return { page: 'dashboard', param: null };
 
   const page = parts[0] as Page;
-  const validPages: Page[] = ['dashboard', 'projects', 'plans', 'runs', 'coordinator', 'queue', 'analytics', 'logs', 'config', 'prompts', 'system'];
+  const validPages: Page[] = ['dashboard', 'projects', 'plans', 'runs', 'coordinator', 'queue', 'analytics', 'logs', 'config', 'prompts', 'system', 'settings'];
 
   if (page === 'plans' && parts.length > 1) {
     return { page: 'plan-detail', param: parts[1] };

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -348,6 +348,16 @@ export interface DailyRunCount {
   failed: number;
 }
 
+/** Unified run context returned by GET /api/runs/{id}/full */
+export interface RunFullContext {
+  run: Run;
+  coordinator_tasks: CoordinatorTask[];
+  coordinator_messages: CoordinatorMessage[];
+  queue_item: QueueItem | null;
+  plan: Plan | null;
+  project_repo: string | null;
+}
+
 export interface AnalyticsData {
   days: number;
   total_tokens: number;

--- a/dashboard/frontend/src/pages/DashboardPage.svelte
+++ b/dashboard/frontend/src/pages/DashboardPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { Run, SystemStatus, UsageData, Project, CoordinatorTask } from '../lib/types';
-  import { getLatestRun, getSystemStatus, listRuns, getUsage, listProjects, getCoordinatorTasks } from '../lib/api';
+  import type { Run, SystemStatus, UsageData, Project, CoordinatorTask, AnalyticsData } from '../lib/types';
+  import { getLatestRun, getSystemStatus, listRuns, getUsage, listProjects, getCoordinatorTasks, getAnalytics } from '../lib/api';
   import { formatDuration, formatTokens } from '../lib/format';
   import { toastSuccess, toastError } from '../lib/toast.svelte';
   import {
@@ -20,6 +20,8 @@
   import LiveAgentFeed from '../components/LiveAgentFeed.svelte';
   import AgentStatusCards from '../components/AgentStatusCards.svelte';
   import ArcGauge from '../components/ArcGauge.svelte';
+  import BarChart from '../components/BarChart.svelte';
+  import DonutChart from '../components/DonutChart.svelte';
   import type { RunPhase } from '../lib/workspace-renderer';
 
   let latest = $state<Run | null>(null);
@@ -30,6 +32,9 @@
   let projectMap = $state<Record<number, string>>({});
   let coordinatorTasks = $state<CoordinatorTask[]>([]);
   let loading = $state(true);
+  let analyticsExpanded = $state(false);
+  let analytics = $state<AnalyticsData | null>(null);
+  let analyticsLoading = $state(false);
 
   async function load() {
     try {
@@ -119,6 +124,50 @@
   let toolSummary = $derived(
     liveActivity.currentTool ? `${liveActivity.currentTool.name}: ${liveActivity.currentTool.summary}` : null
   );
+
+  // Analytics helpers (AC4: analytics accessible from Dashboard)
+  async function toggleAnalytics() {
+    analyticsExpanded = !analyticsExpanded;
+    if (analyticsExpanded && !analytics && !analyticsLoading) {
+      analyticsLoading = true;
+      try {
+        analytics = await getAnalytics({ days: 30 });
+      } catch { /* ignore */ }
+      finally { analyticsLoading = false; }
+    }
+  }
+
+  function fmtTokens(v: number): string {
+    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+    if (v >= 1_000) return `${(v / 1_000).toFixed(1)}K`;
+    return v.toLocaleString();
+  }
+
+  let tokenBarData = $derived(
+    (analytics?.daily_token_usage ?? []).map(d => ({
+      label: d.date.split('-').slice(1).join('/'),
+      value: d.tokens_total,
+    }))
+  );
+
+  const verdictColors: Record<string, string> = {
+    approved: '#10b981', rejected: '#ef4444', partial: '#f59e0b',
+    none: '#64748b', skipped: '#8b5cf6', error: '#dc2626',
+  };
+
+  let verdictSegments = $derived(
+    (analytics?.verdict_distribution ?? []).map(d => ({
+      label: d.verdict === 'none' ? 'No Verdict' : d.verdict.charAt(0).toUpperCase() + d.verdict.slice(1),
+      value: d.count,
+      color: verdictColors[d.verdict] ?? '#94a3b8',
+    }))
+  );
+
+  let successRate = $derived(() => {
+    if (!analytics || analytics.total_runs === 0) return '0';
+    const approved = analytics.verdict_distribution.find(v => v.verdict === 'approved')?.count ?? 0;
+    return Math.round((approved / analytics.total_runs) * 100).toString();
+  });
 </script>
 
 <div class="space-y-5">
@@ -251,6 +300,68 @@
     <!-- Activity Feed -->
     <div class="animate-fade-in-up stagger-5">
       <ActivityFeed runs={recentRuns} {projectMap} />
+    </div>
+
+    <!-- Analytics Section (AC4: accessible from Dashboard) -->
+    <div class="animate-fade-in-up">
+      <GlassCard glow="cyan" class="p-5">
+        <button class="w-full flex items-center justify-between cursor-pointer" onclick={toggleAnalytics}>
+          <h2 class="font-semibold flex items-center gap-2">
+            <svg class="w-4 h-4 text-accent-cyan" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M3 17V10" /><path d="M7 17V7" /><path d="M11 17V12" /><path d="M15 17V4" /><path d="M19 17V9" />
+            </svg>
+            Analytics
+            <span class="text-xs font-normal text-text-dim">30-day overview</span>
+          </h2>
+          <span class="text-text-dim text-sm transition-transform {analyticsExpanded ? 'rotate-90' : ''}">&#9654;</span>
+        </button>
+
+        {#if analyticsExpanded}
+          <div class="mt-4">
+            {#if analyticsLoading}
+              <div class="flex justify-center py-8"><LoadingSpinner /></div>
+            {:else if analytics}
+              <!-- Summary stats -->
+              <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+                <div class="p-3 rounded-lg bg-white/[0.03]">
+                  <div class="text-[10px] text-text-dim uppercase tracking-wider mb-1">Total Runs</div>
+                  <div class="text-xl font-bold font-data text-text">{analytics.total_runs.toLocaleString()}</div>
+                </div>
+                <div class="p-3 rounded-lg bg-white/[0.03]">
+                  <div class="text-[10px] text-text-dim uppercase tracking-wider mb-1">Total Tokens</div>
+                  <div class="text-xl font-bold font-data text-accent-cyan">{fmtTokens(analytics.total_tokens)}</div>
+                </div>
+                <div class="p-3 rounded-lg bg-white/[0.03]">
+                  <div class="text-[10px] text-text-dim uppercase tracking-wider mb-1">Input Tokens</div>
+                  <div class="text-xl font-bold font-data text-emerald-400">{fmtTokens(analytics.total_tokens_input)}</div>
+                </div>
+                <div class="p-3 rounded-lg bg-white/[0.03]">
+                  <div class="text-[10px] text-text-dim uppercase tracking-wider mb-1">Failed Runs</div>
+                  <div class="text-xl font-bold font-data {analytics.failed_runs > 0 ? 'text-red-400' : 'text-text'}">{analytics.failed_runs}</div>
+                </div>
+              </div>
+
+              <!-- Charts -->
+              <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                {#if tokenBarData.length > 0}
+                  <div>
+                    <h3 class="text-xs font-semibold text-text-dim mb-2">Daily Token Usage</h3>
+                    <BarChart data={tokenBarData} valueFormatter={fmtTokens} barColor="#06b6d4" height={180} />
+                  </div>
+                {/if}
+                {#if verdictSegments.length > 0}
+                  <div class="flex flex-col items-center">
+                    <h3 class="text-xs font-semibold text-text-dim mb-2 self-start">Run Verdicts</h3>
+                    <DonutChart segments={verdictSegments} size={180} thickness={24} centerValue="{successRate()}%" centerLabel="approved" />
+                  </div>
+                {/if}
+              </div>
+            {:else}
+              <p class="text-text-dim text-sm">No analytics data available.</p>
+            {/if}
+          </div>
+        {/if}
+      </GlassCard>
     </div>
   {/if}
 </div>

--- a/dashboard/frontend/src/pages/RunDetailPage.svelte
+++ b/dashboard/frontend/src/pages/RunDetailPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { Run, DiffResult } from '../lib/types';
-  import { getRun, getRunDiff } from '../lib/api';
+  import type { Run, RunFullContext, DiffResult, CoordinatorTask, CoordinatorMessage } from '../lib/types';
+  import { getRunFullContext, getRunDiff } from '../lib/api';
   import { formatDuration, formatTokens, formatDate } from '../lib/format';
   import { toastError } from '../lib/toast.svelte';
   import StatusBadge from '../components/StatusBadge.svelte';
@@ -9,22 +9,50 @@
   import EmployeeReport from '../components/EmployeeReport.svelte';
   import DiffViewer from '../components/DiffViewer.svelte';
   import GlassCard from '../components/GlassCard.svelte';
+  import PhaseTimeline from '../components/PhaseTimeline.svelte';
+  import type { RunPhase } from '../lib/workspace-renderer';
 
   interface Props { runId: string; }
   let { runId }: Props = $props();
 
-  let run = $state<Run | null>(null);
+  let context = $state<RunFullContext | null>(null);
   let loading = $state(true);
   let diff = $state<DiffResult | null>(null);
   let diffLoading = $state(false);
   let diffExpanded = $state(false);
+  let coordinatorExpanded = $state(true);
+  let messagesExpanded = $state(false);
+  let selectedTaskId = $state<string | null>(null);
+
+  // Derived run for convenience
+  let run = $derived(context?.run ?? null);
+
+  // Derive run phase for the phase timeline
+  let runPhase = $derived((): RunPhase => {
+    if (!run) return 'idle';
+    if (run.status === 'running') {
+      if (context?.coordinator_tasks && context.coordinator_tasks.length > 0) {
+        const hasRunning = context.coordinator_tasks.some(t => t.status === 'running');
+        if (hasRunning) return 'employee';
+        const allPending = context.coordinator_tasks.every(t => t.status === 'pending' || t.status === 'ready');
+        if (allPending) return 'coordinating';
+      }
+      return 'employee';
+    }
+    if (run.status === 'reviewing') return 'manager_review';
+    if (run.verdict) return 'executing_verdict';
+    return 'idle';
+  });
+
+  let isRunActive = $derived(run?.status === 'running' || run?.status === 'reviewing');
 
   async function load(id: string) {
     loading = true;
     diff = null;
     diffExpanded = false;
+    selectedTaskId = null;
     try {
-      run = await getRun(id);
+      context = await getRunFullContext(id);
     } catch (e: any) {
       toastError(e.message);
     } finally {
@@ -51,18 +79,89 @@
     }
   }
 
-  $effect(() => { load(runId); });
+  // Coordinator task helpers
+  function statusColor(status: string): string {
+    switch (status) {
+      case 'completed': return 'text-green-400 bg-green-500/10 border-green-500/30';
+      case 'running': return 'text-yellow-400 bg-yellow-500/10 border-yellow-500/30';
+      case 'ready': return 'text-cyan-400 bg-cyan-500/10 border-cyan-500/30';
+      case 'failed': return 'text-red-400 bg-red-500/10 border-red-500/30';
+      case 'blocked': return 'text-orange-400 bg-orange-500/10 border-orange-500/30';
+      default: return 'text-text-dim bg-white/5 border-white/10';
+    }
+  }
+
+  function statusIcon(status: string): string {
+    switch (status) {
+      case 'completed': return '\u2713';
+      case 'running': return '\u25C9';
+      case 'ready': return '\u25CB';
+      case 'failed': return '\u2715';
+      case 'blocked': return '\u2298';
+      default: return '\u00B7';
+    }
+  }
+
+  function parseDeps(depsJson: string | null): string[] {
+    if (!depsJson) return [];
+    try { return JSON.parse(depsJson); } catch { return []; }
+  }
+
+  function parseJsonArray(json: string | null): string[] {
+    if (!json) return [];
+    try { return JSON.parse(json); } catch { return []; }
+  }
+
+  function taskDuration(start: string | null, end: string | null): string {
+    if (!start) return '--';
+    const s = new Date(start).getTime();
+    const e = end ? new Date(end).getTime() : Date.now();
+    const ms = e - s;
+    if (ms < 1000) return `${ms}ms`;
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+    return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`;
+  }
+
+  function msgTypeColor(type: string): string {
+    switch (type) {
+      case 'conflict': return 'text-red-400';
+      case 'guidance': return 'text-cyan-400';
+      case 'error': return 'text-red-400';
+      default: return 'text-text-dim';
+    }
+  }
+
+  // Auto-refresh for active runs
+  $effect(() => {
+    load(runId);
+    let interval: ReturnType<typeof setInterval> | null = null;
+    if (isRunActive) {
+      interval = setInterval(() => load(runId), 5000);
+    }
+    return () => { if (interval) clearInterval(interval); };
+  });
 </script>
 
-<div class="space-y-6 animate-fade-in-up">
+<div class="space-y-5 animate-fade-in-up">
   <div class="flex items-center gap-3 min-w-0">
     <a href="#/runs" class="text-text-dim hover:text-text shrink-0">&larr; Runs</a>
     <h1 class="text-lg md:text-2xl font-bold font-data truncate">{runId}</h1>
+    {#if context?.project_repo}
+      <span class="text-xs text-text-dim hidden sm:inline">{context.project_repo}</span>
+    {/if}
   </div>
 
-  {#if loading}
+  {#if loading && !context}
     <div class="flex justify-center py-12"><LoadingSpinner /></div>
   {:else if run}
+    <!-- Phase Timeline (always visible for active runs, shows completed state for finished runs) -->
+    {#if isRunActive || run.status === 'success' || run.status === 'failed'}
+      <PhaseTimeline
+        phase={isRunActive ? runPhase() : 'idle'}
+        startedAt={run.started_at}
+      />
+    {/if}
+
     <!-- Metadata Grid -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4">
       <GlassCard glow={run.verdict === 'APPROVE' ? 'emerald' : run.verdict === 'REJECT' ? 'red' : 'purple'} class="p-4">
@@ -101,23 +200,23 @@
           </tr>
           <tr>
             <td class="px-5 py-3 text-text-dim">Issue</td>
-            <td class="px-5 py-3">{run.issue_number ?? '-'}</td>
+            <td class="px-5 py-3">
+              {#if run.issue_number && context?.project_repo}
+                <a href="https://github.com/{context.project_repo}/issues/{run.issue_number}" target="_blank" rel="noopener" class="text-accent-cyan hover:underline">
+                  #{run.issue_number}
+                </a>
+              {:else}
+                {run.issue_number ?? '-'}
+              {/if}
+            </td>
           </tr>
           <tr>
             <td class="px-5 py-3 text-text-dim">Turns</td>
             <td class="px-5 py-3">{run.turns ?? '-'}</td>
           </tr>
           <tr>
-            <td class="px-5 py-3 text-text-dim">Tokens (Input)</td>
-            <td class="px-5 py-3 font-data">{formatTokens(run.tokens_input)}</td>
-          </tr>
-          <tr>
-            <td class="px-5 py-3 text-text-dim">Tokens (Output)</td>
-            <td class="px-5 py-3 font-data">{formatTokens(run.tokens_output)}</td>
-          </tr>
-          <tr>
-            <td class="px-5 py-3 text-text-dim">Tokens (Total)</td>
-            <td class="px-5 py-3 font-data">{formatTokens(run.tokens_total)}</td>
+            <td class="px-5 py-3 text-text-dim">Tokens (Input / Output)</td>
+            <td class="px-5 py-3 font-data">{formatTokens(run.tokens_input)} / {formatTokens(run.tokens_output)}</td>
           </tr>
           <tr>
             <td class="px-5 py-3 text-text-dim">Started</td>
@@ -141,15 +240,210 @@
               </td>
             </tr>
           {/if}
-          {#if run.log_file}
-            <tr>
-              <td class="px-5 py-3 text-text-dim">Log File</td>
-              <td class="px-5 py-3 font-data text-xs">{run.log_file}</td>
-            </tr>
-          {/if}
         </tbody>
       </table>
     </GlassCard>
+
+    <!-- Related Queue Item (AC2: queue items link to run) -->
+    {#if context?.queue_item}
+      {@const qi = context.queue_item}
+      <GlassCard glow="amber" class="p-5">
+        <h2 class="font-semibold mb-3 flex items-center gap-2">
+          <svg class="w-4 h-4 text-accent-amber" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M3 4h14M3 8h14M3 12h14M3 16h14" /><rect x="14" y="3" width="4" height="3" rx="0.5" />
+          </svg>
+          Queue Item
+          <span class="text-xs font-normal px-2 py-0.5 rounded {qi.state === 'completed' ? 'bg-green-500/20 text-green-400' : qi.state === 'failed' ? 'bg-red-500/20 text-red-400' : qi.state === 'in_progress' ? 'bg-yellow-500/20 text-yellow-400' : 'bg-white/10 text-text-dim'}">{qi.state}</span>
+        </h2>
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
+          <div>
+            <span class="text-text-dim text-xs block mb-0.5">Project</span>
+            <span class="text-text">{qi.project_repo}</span>
+          </div>
+          {#if qi.issue_number}
+            <div>
+              <span class="text-text-dim text-xs block mb-0.5">Issue</span>
+              <span class="text-text">#{qi.issue_number} {qi.issue_title ?? ''}</span>
+            </div>
+          {/if}
+          <div>
+            <span class="text-text-dim text-xs block mb-0.5">Priority</span>
+            <span class="text-text">{qi.priority}</span>
+          </div>
+          <div>
+            <span class="text-text-dim text-xs block mb-0.5">Retries</span>
+            <span class="text-text">{qi.retry_count}/{qi.max_retries}</span>
+          </div>
+        </div>
+        {#if qi.error_message}
+          <div class="mt-3 p-2 rounded bg-red-500/10 border border-red-500/20 text-red-400 text-xs">{qi.error_message}</div>
+        {/if}
+      </GlassCard>
+    {/if}
+
+    <!-- Related Plan (AC2: plans link to run) -->
+    {#if context?.plan}
+      {@const plan = context.plan}
+      <GlassCard glow="blue" class="p-5">
+        <h2 class="font-semibold mb-3 flex items-center gap-2">
+          <svg class="w-4 h-4 text-accent-blue" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4 4h12M4 8h12M4 12h8" /><path d="M13 12l2 2 4-4" stroke-width="2" />
+          </svg>
+          Implementation Plan
+          <span class="text-xs font-normal px-2 py-0.5 rounded bg-white/10 text-text-dim">{plan.status}</span>
+        </h2>
+        <div class="space-y-2 text-sm">
+          <div>
+            <a href="#/plans/{plan.id}" class="text-accent-cyan hover:underline font-medium">{plan.title}</a>
+          </div>
+          {#if plan.description}
+            <p class="text-text-dim text-xs line-clamp-3">{plan.description}</p>
+          {/if}
+          <div class="flex gap-4 text-xs text-text-dim">
+            {#if plan.estimated_scope}
+              <span>Scope: {plan.estimated_scope}</span>
+            {/if}
+            {#if plan.issue_number}
+              <span>Issue #{plan.issue_number}</span>
+            {/if}
+          </div>
+        </div>
+      </GlassCard>
+    {/if}
+
+    <!-- Coordinator Tasks (AC2 + AC4: integrated into run detail) -->
+    {#if context?.coordinator_tasks && context.coordinator_tasks.length > 0}
+      {@const tasks = context.coordinator_tasks}
+      {@const completedCount = tasks.filter(t => t.status === 'completed').length}
+      {@const failedCount = tasks.filter(t => t.status === 'failed').length}
+      <GlassCard glow="purple" class="p-5">
+        <button
+          class="w-full flex items-center justify-between"
+          onclick={() => coordinatorExpanded = !coordinatorExpanded}
+        >
+          <h2 class="font-semibold flex items-center gap-2">
+            <svg class="w-4 h-4 text-purple-400" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="10" cy="6" r="2.5" /><circle cx="5" cy="15" r="2.5" /><circle cx="15" cy="15" r="2.5" /><line x1="10" y1="8.5" x2="6.5" y2="12.5" /><line x1="10" y1="8.5" x2="13.5" y2="12.5" />
+            </svg>
+            Coordinator Tasks
+            <span class="text-xs font-data text-text-dim">
+              {completedCount}/{tasks.length} done
+              {#if failedCount > 0}
+                <span class="text-red-400">&middot; {failedCount} failed</span>
+              {/if}
+            </span>
+          </h2>
+          <span class="text-text-dim text-sm transition-transform {coordinatorExpanded ? 'rotate-90' : ''}">&#9654;</span>
+        </button>
+
+        {#if coordinatorExpanded}
+          <div class="mt-4 space-y-2">
+            {#each tasks as task}
+              {@const deps = parseDeps(task.depends_on)}
+              {@const isSelected = selectedTaskId === task.id}
+              <button
+                class="w-full text-left p-3 rounded-lg border transition-all duration-200 cursor-pointer
+                  {isSelected ? 'ring-1 ring-accent-cyan border-accent-cyan/50 bg-accent-cyan/5' : statusColor(task.status)}"
+                onclick={() => selectedTaskId = isSelected ? null : task.id}
+              >
+                <div class="flex items-center gap-2 mb-1">
+                  <span class="text-xs font-bold w-5 h-5 rounded-full flex items-center justify-center border {statusColor(task.status)}">
+                    {statusIcon(task.status)}
+                  </span>
+                  <span class="text-sm font-medium truncate flex-1 text-text">{task.title}</span>
+                  <span class="text-text-dim text-xs shrink-0 transition-transform duration-200" class:rotate-180={isSelected}>
+                    &#9660;
+                  </span>
+                </div>
+                <div class="flex items-center gap-3 text-xs opacity-70 ml-7">
+                  <span class="capitalize">{task.status}</span>
+                  {#if task.employee_index != null}
+                    <span class="px-1.5 py-0.5 rounded bg-white/10 text-text-dim">E{task.employee_index}</span>
+                  {/if}
+                  {#if deps.length > 0}
+                    <span class="text-text-dim">{deps.length} dep{deps.length > 1 ? 's' : ''}</span>
+                  {/if}
+                  {#if task.started_at}
+                    <span class="text-text-dim ml-auto">{taskDuration(task.started_at, task.finished_at)}</span>
+                  {/if}
+                </div>
+
+                <!-- Expanded task detail -->
+                {#if isSelected}
+                  <div class="mt-3 pt-3 border-t border-hud-line space-y-2 text-xs" onclick={(e: MouseEvent) => e.stopPropagation()}>
+                    {#if task.description}
+                      <p class="text-text-dim">{task.description}</p>
+                    {/if}
+                    {#if task.result_summary}
+                      <div class="p-2 rounded bg-green-500/5 border border-green-500/20 text-green-400">{task.result_summary}</div>
+                    {/if}
+                    {#if task.error_message}
+                      <div class="p-2 rounded bg-red-500/10 border border-red-500/20 text-red-400 font-mono whitespace-pre-wrap">{task.error_message}</div>
+                    {/if}
+                    {#if task.branch}
+                      <div><span class="text-text-dim">Branch:</span> <span class="font-mono text-text">{task.branch}</span></div>
+                    {/if}
+                    {#if task.touched_files}
+                      {@const files = parseJsonArray(task.touched_files)}
+                      {#if files.length > 0}
+                        <div>
+                          <span class="text-text-dim">Files ({files.length}):</span>
+                          <div class="flex flex-wrap gap-1 mt-1">
+                            {#each files as f}
+                              <span class="font-mono px-1.5 py-0.5 rounded bg-white/5 text-text-dim">{f}</span>
+                            {/each}
+                          </div>
+                        </div>
+                      {/if}
+                    {/if}
+                    <div class="flex gap-4">
+                      {#if task.started_at}
+                        <span><span class="text-text-dim">Started:</span> {new Date(task.started_at).toLocaleString()}</span>
+                      {/if}
+                      {#if task.finished_at}
+                        <span><span class="text-text-dim">Finished:</span> {new Date(task.finished_at).toLocaleString()}</span>
+                      {/if}
+                    </div>
+                  </div>
+                {/if}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </GlassCard>
+    {/if}
+
+    <!-- Coordinator Messages -->
+    {#if context?.coordinator_messages && context.coordinator_messages.length > 0}
+      <GlassCard class="p-5">
+        <button
+          class="w-full flex items-center justify-between"
+          onclick={() => messagesExpanded = !messagesExpanded}
+        >
+          <h2 class="font-semibold flex items-center gap-2">
+            Coordinator Messages
+            <span class="text-xs font-data text-text-dim">{context.coordinator_messages.length}</span>
+          </h2>
+          <span class="text-text-dim text-sm transition-transform {messagesExpanded ? 'rotate-90' : ''}">&#9654;</span>
+        </button>
+        {#if messagesExpanded}
+          <div class="mt-3 divide-y divide-border/20 max-h-60 overflow-auto">
+            {#each context.coordinator_messages as msg}
+              <div class="py-2 flex items-start gap-3 text-xs">
+                <span class="{msgTypeColor(msg.message_type)} shrink-0">{msg.message_type}</span>
+                <span class="text-text-dim shrink-0">
+                  {msg.direction === 'to_employee' ? '\u2192' : '\u2190'} E{msg.employee_index ?? '?'}
+                </span>
+                <span class="text-text flex-1">{msg.content}</span>
+                {#if msg.created_at}
+                  <span class="text-text-dim shrink-0">{new Date(msg.created_at).toLocaleTimeString()}</span>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </GlassCard>
+    {/if}
 
     <!-- Employee Report -->
     <GlassCard class="p-5">
@@ -184,7 +478,7 @@
               </span>
             {/if}
           </h2>
-          <span class="text-text-dim text-sm transition-transform {diffExpanded ? 'rotate-90' : ''}">▶</span>
+          <span class="text-text-dim text-sm transition-transform {diffExpanded ? 'rotate-90' : ''}">&#9654;</span>
         </button>
         {#if diffExpanded}
           <div class="mt-4">
@@ -198,11 +492,21 @@
       </GlassCard>
     {/if}
 
-    <!-- Log Link -->
-    <div class="flex gap-3">
+    <!-- Action Links -->
+    <div class="flex gap-3 flex-wrap">
       <a href="#/logs?run={run.run_id}" class="px-4 py-2 glass rounded-lg text-sm hover:bg-white/[0.03] transition-colors">
         View Logs
       </a>
+      {#if context?.plan}
+        <a href="#/plans/{context.plan.id}" class="px-4 py-2 glass rounded-lg text-sm hover:bg-white/[0.03] transition-colors">
+          View Plan
+        </a>
+      {/if}
+      {#if run.concurrent_group_id}
+        <a href="#/runs?group={run.concurrent_group_id}" class="px-4 py-2 glass rounded-lg text-sm hover:bg-white/[0.03] transition-colors">
+          View Parallel Runs
+        </a>
+      {/if}
     </div>
   {:else}
     <p class="text-text-dim">Run not found</p>

--- a/dashboard/frontend/src/pages/SettingsPage.svelte
+++ b/dashboard/frontend/src/pages/SettingsPage.svelte
@@ -1,0 +1,628 @@
+<script lang="ts">
+  /**
+   * SettingsPage — merges ConfigPage + SystemPage into one (AC4).
+   * Tabs: Configuration | System & Auth | Logs
+   */
+  import type { SystemStatus, AuthStatus, StationConfig } from '../lib/types';
+  import {
+    getConfig, updateConfig, testNotification, getSystemStatus, getAuthStatus,
+    serviceAction, triggerRun, startOAuthLogin, submitOAuthCode,
+  } from '../lib/api';
+  import { toastSuccess, toastError } from '../lib/toast.svelte';
+  import LoadingSpinner from '../components/LoadingSpinner.svelte';
+  import GlassCard from '../components/GlassCard.svelte';
+  import UsageSliders from '../components/UsageSliders.svelte';
+  import PlanUsageDisplay from '../components/PlanUsageDisplay.svelte';
+  import ResourceMeter from '../components/ResourceMeter.svelte';
+  import StatusOrb from '../components/StatusOrb.svelte';
+
+  type Tab = 'config' | 'system' | 'logs';
+  let activeTab = $state<Tab>('config');
+
+  // --- Config state ---
+  let configLoading = $state(true);
+  let saving = $state(false);
+  let showAdvanced = $state(false);
+  let testingSending = $state(false);
+
+  let employeeModel = $state('');
+  let managerModel = $state('');
+  let maxUsagePercent = $state(60);
+  let reservePercent = $state(40);
+  let maxEmployeeTurns = $state<number | undefined>(undefined);
+  let maxAnalystTurns = $state<number | undefined>(undefined);
+  let maxManagerTurns = $state<number | undefined>(undefined);
+  let maxConcurrentEmployees = $state<number | undefined>(undefined);
+  let maxEmployeesPerProject = $state<number | undefined>(undefined);
+  let tokenBudgetStrategy = $state('');
+  let schedule = $state('');
+  let notificationsEnabled = $state(false);
+  let notificationsMethod = $state('');
+  let notificationFile = $state('');
+  let webhookUrl = $state('');
+  let webhookType = $state('slack');
+  let notifyOnApprove = $state(true);
+  let notifyOnReject = $state(true);
+  let notifyOnPr = $state(true);
+  let notifyOnError = $state(true);
+  let dashboardUrl = $state('');
+  let telegramChatId = $state('');
+  let logDir = $state('');
+  let digestDir = $state('');
+  let snapshot = $state<StationConfig>({});
+
+  // --- System state ---
+  let system = $state<SystemStatus | null>(null);
+  let auth = $state<AuthStatus | null>(null);
+  let systemLoading = $state(true);
+
+  // OAuth flow state
+  type OAuthFlowState = 'idle' | 'waiting_for_code' | 'submitting' | 'done';
+  let oauthFlow = $state<OAuthFlowState>('idle');
+  let oauthState = $state('');
+  let oauthCode = $state('');
+  let oauthError = $state('');
+
+  function applyConfig(cfg: StationConfig) {
+    employeeModel = cfg.models?.employee ?? '';
+    managerModel = cfg.models?.manager ?? '';
+    maxUsagePercent = cfg.limits?.max_usage_percent ?? 60;
+    reservePercent = cfg.limits?.reserve_percent ?? 40;
+    maxEmployeeTurns = cfg.limits?.max_employee_turns;
+    maxAnalystTurns = cfg.limits?.max_analyst_turns;
+    maxManagerTurns = cfg.limits?.max_manager_turns;
+    maxConcurrentEmployees = cfg.limits?.max_concurrent_employees;
+    maxEmployeesPerProject = cfg.limits?.max_employees_per_project;
+    tokenBudgetStrategy = cfg.limits?.token_budget_strategy ?? '';
+    schedule = cfg.schedule ?? '';
+    notificationsEnabled = cfg.notifications?.enabled ?? false;
+    notificationsMethod = cfg.notifications?.method ?? '';
+    notificationFile = cfg.notifications?.notification_file ?? '';
+    webhookUrl = cfg.notifications?.webhook_url ?? '';
+    webhookType = cfg.notifications?.webhook_type ?? 'slack';
+    dashboardUrl = cfg.notifications?.dashboard_url ?? '';
+    telegramChatId = cfg.notifications?.telegram_chat_id ?? '';
+    const notifyOn = cfg.notifications?.notify_on ?? ['approve', 'reject', 'pr', 'error'];
+    notifyOnApprove = notifyOn.includes('approve');
+    notifyOnReject = notifyOn.includes('reject');
+    notifyOnPr = notifyOn.includes('pr');
+    notifyOnError = notifyOn.includes('error');
+    logDir = cfg.logging?.log_dir ?? '';
+    digestDir = cfg.logging?.digest_dir ?? '';
+  }
+
+  async function loadConfig() {
+    configLoading = true;
+    try {
+      const raw = await getConfig();
+      const cfg = raw as unknown as StationConfig;
+      snapshot = structuredClone(cfg);
+      applyConfig(cfg);
+    } catch (e: any) {
+      toastError(e.message);
+    } finally {
+      configLoading = false;
+    }
+  }
+
+  async function loadSystem() {
+    try {
+      const [sysRes, authRes] = await Promise.all([getSystemStatus(), getAuthStatus()]);
+      system = sysRes;
+      auth = authRes;
+    } catch (e: any) {
+      toastError(e.message);
+    } finally {
+      systemLoading = false;
+    }
+  }
+
+  function reset() { applyConfig(snapshot); }
+
+  function buildNotifyOn(): string[] {
+    const list: string[] = [];
+    if (notifyOnApprove) list.push('approve');
+    if (notifyOnReject) list.push('reject');
+    if (notifyOnPr) list.push('pr');
+    if (notifyOnError) list.push('error');
+    return list;
+  }
+
+  function buildPayload(): Record<string, unknown> {
+    return {
+      models: { employee: employeeModel || undefined, manager: managerModel || undefined },
+      limits: {
+        max_usage_percent: maxUsagePercent, reserve_percent: reservePercent,
+        max_employee_turns: maxEmployeeTurns, max_analyst_turns: maxAnalystTurns,
+        max_manager_turns: maxManagerTurns, max_concurrent_employees: maxConcurrentEmployees,
+        max_employees_per_project: maxEmployeesPerProject,
+        token_budget_strategy: tokenBudgetStrategy || undefined,
+      },
+      schedule: schedule || undefined,
+      notifications: {
+        enabled: notificationsEnabled, method: notificationsMethod || undefined,
+        notification_file: notificationFile || undefined, webhook_url: webhookUrl || undefined,
+        webhook_type: webhookType || undefined, notify_on: buildNotifyOn(),
+        dashboard_url: dashboardUrl || undefined, telegram_chat_id: telegramChatId || undefined,
+      },
+      logging: { log_dir: logDir || undefined, digest_dir: digestDir || undefined },
+    };
+  }
+
+  async function save() {
+    saving = true;
+    try {
+      const result = await updateConfig(buildPayload());
+      const cfg = result as unknown as StationConfig;
+      snapshot = structuredClone(cfg);
+      applyConfig(cfg);
+      toastSuccess('Configuration saved successfully');
+    } catch (e: any) {
+      toastError(`Failed to save: ${e.message}`);
+    } finally {
+      saving = false;
+    }
+  }
+
+  async function sendTestNotification() {
+    testingSending = true;
+    try {
+      await save();
+      const result = await testNotification();
+      if (result.success) toastSuccess(result.message || 'Test notification sent!');
+    } catch (e: any) {
+      toastError(`Test failed: ${e.message}`);
+    } finally {
+      testingSending = false;
+    }
+  }
+
+  async function handleOAuthStart() {
+    oauthError = '';
+    try {
+      const res = await startOAuthLogin();
+      oauthState = res.state;
+      oauthFlow = 'waiting_for_code';
+      oauthCode = '';
+      window.open(res.auth_url, '_blank');
+    } catch (e: any) { oauthError = e.message; }
+  }
+
+  async function handleOAuthSubmit() {
+    if (!oauthCode.trim()) return;
+    oauthError = '';
+    oauthFlow = 'submitting';
+    try {
+      const res = await submitOAuthCode(oauthCode.trim(), oauthState);
+      if (res.success) {
+        oauthFlow = 'done';
+        toastSuccess('Authentication successful');
+        await loadSystem();
+        setTimeout(() => { oauthFlow = 'idle'; }, 2000);
+      } else {
+        oauthError = res.error || 'Token exchange failed';
+        oauthFlow = 'waiting_for_code';
+      }
+    } catch (e: any) {
+      oauthError = e.message;
+      oauthFlow = 'waiting_for_code';
+    }
+  }
+
+  function handleOAuthCancel() {
+    oauthFlow = 'idle'; oauthState = ''; oauthCode = ''; oauthError = '';
+  }
+
+  async function doServiceAction(action: string, unit: string) {
+    try {
+      await serviceAction(action, unit);
+      toastSuccess(`${action} ${unit}`);
+      await loadSystem();
+    } catch (e: any) { toastError(e.message); }
+  }
+
+  async function handleTrigger() {
+    try {
+      await triggerRun();
+      toastSuccess('Run triggered');
+      await loadSystem();
+    } catch (e: any) { toastError(e.message); }
+  }
+
+  function formatUptime(s: number | null | undefined): string {
+    if (s == null) return '-';
+    const d = Math.floor(s / 86400);
+    const h = Math.floor((s % 86400) / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    return `${d}d ${h}h ${m}m`;
+  }
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: 'config', label: 'Configuration' },
+    { key: 'system', label: 'System & Auth' },
+    { key: 'logs', label: 'Logging' },
+  ];
+
+  $effect(() => {
+    loadConfig();
+    loadSystem();
+    const sysInterval = setInterval(loadSystem, 10000);
+    return () => clearInterval(sysInterval);
+  });
+</script>
+
+<div class="space-y-6 animate-fade-in-up">
+  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+    <h1 class="text-2xl font-bold">Settings</h1>
+    <!-- Tab selector -->
+    <div class="flex items-center gap-1 glass rounded-lg p-1">
+      {#each tabs as tab}
+        <button
+          onclick={() => activeTab = tab.key}
+          class="px-3 py-1.5 text-xs font-medium rounded-md transition-all duration-200 cursor-pointer
+            {activeTab === tab.key
+              ? 'bg-accent-cyan/20 text-accent-cyan shadow-[0_0_8px_rgba(6,182,212,0.2)]'
+              : 'text-text-dim hover:text-text hover:bg-white/[0.04]'}"
+        >
+          {tab.label}
+        </button>
+      {/each}
+    </div>
+  </div>
+
+  <!-- ========== CONFIG TAB ========== -->
+  {#if activeTab === 'config'}
+    {#if configLoading}
+      <div class="flex justify-center py-12"><LoadingSpinner /></div>
+    {:else}
+      <!-- Plan Usage Display -->
+      <GlassCard glow="cyan" class="p-5">
+        <h3 class="font-semibold mb-4 flex items-center gap-2">
+          <svg class="w-4 h-4 text-accent-cyan" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          Plan Usage
+        </h3>
+        <PlanUsageDisplay />
+      </GlassCard>
+
+      <!-- Usage Budget -->
+      <GlassCard glow="blue" class="p-5">
+        <h3 class="font-semibold mb-1 flex items-center gap-2">
+          <svg class="w-4 h-4 text-accent-blue" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/>
+          </svg>
+          Usage Budget
+        </h3>
+        <p class="text-xs text-text-dim mb-5">Control how much of your Claude plan the agent can consume.</p>
+        <UsageSliders {maxUsagePercent} {reservePercent}
+          onMaxUsageChange={(v) => maxUsagePercent = v}
+          onReserveChange={(v) => reservePercent = v}
+        />
+      </GlassCard>
+
+      <!-- Models -->
+      <GlassCard class="p-5">
+        <h3 class="font-semibold mb-4">Models</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label for="employee-model" class="block text-sm text-text-dim mb-1">Employee Model</label>
+            <input id="employee-model" type="text" bind:value={employeeModel} placeholder="claude-sonnet-4-20250514"
+              class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+          </div>
+          <div>
+            <label for="manager-model" class="block text-sm text-text-dim mb-1">Manager Model</label>
+            <input id="manager-model" type="text" bind:value={managerModel} placeholder="claude-sonnet-4-20250514"
+              class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+          </div>
+        </div>
+      </GlassCard>
+
+      <!-- Parallel Execution -->
+      <GlassCard class="p-5">
+        <h3 class="font-semibold mb-4">Parallel Execution</h3>
+        <p class="text-xs text-text-dim mb-4">Control how many employees run concurrently.</p>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div>
+            <label for="max-concurrent" class="block text-sm text-text-dim mb-1">Max Concurrent Employees</label>
+            <input id="max-concurrent" type="number" min="1" max="10" bind:value={maxConcurrentEmployees} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+          </div>
+          <div>
+            <label for="max-per-project" class="block text-sm text-text-dim mb-1">Max Employees per Project</label>
+            <input id="max-per-project" type="number" min="1" max="5" bind:value={maxEmployeesPerProject} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+          </div>
+          <div>
+            <label for="budget-strategy" class="block text-sm text-text-dim mb-1">Budget Strategy</label>
+            <select id="budget-strategy" bind:value={tokenBudgetStrategy} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors">
+              <option value="equal_split">Equal Split</option>
+              <option value="priority_weighted">Priority Weighted</option>
+            </select>
+          </div>
+        </div>
+      </GlassCard>
+
+      <!-- Schedule -->
+      <GlassCard class="p-5">
+        <h3 class="font-semibold mb-4">Schedule</h3>
+        <div>
+          <label for="schedule-expr" class="block text-sm text-text-dim mb-1">Schedule Expression</label>
+          <input id="schedule-expr" type="text" bind:value={schedule} placeholder="*-*-* 08,12,18:00:00" class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+        </div>
+      </GlassCard>
+
+      <!-- Webhook Notifications -->
+      <GlassCard glow="amber" class="p-5">
+        <h3 class="font-semibold mb-1 flex items-center gap-2">
+          <svg class="w-4 h-4 text-accent-amber" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M13.73 21a2 2 0 0 1-3.46 0" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          Webhook Notifications
+        </h3>
+        <p class="text-xs text-text-dim mb-5">Get real-time alerts via Slack, Discord, Telegram, or any webhook.</p>
+        <div class="space-y-4">
+          <div class="flex items-center gap-3">
+            <input id="notif-enabled" type="checkbox" bind:checked={notificationsEnabled} class="w-4 h-4 accent-accent-amber cursor-pointer" />
+            <label for="notif-enabled" class="text-sm text-text cursor-pointer">Enable Notifications</label>
+          </div>
+
+          {#if notificationsEnabled}
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label for="notif-method" class="block text-sm text-text-dim mb-1">Method</label>
+                <select id="notif-method" bind:value={notificationsMethod} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-amber/50 transition-colors">
+                  <option value="file">File</option>
+                  <option value="webhook">Webhook</option>
+                </select>
+              </div>
+              {#if notificationsMethod === 'file'}
+                <div>
+                  <label for="notif-file" class="block text-sm text-text-dim mb-1">Notification File</label>
+                  <input id="notif-file" type="text" bind:value={notificationFile} placeholder="/var/lib/claude-agent-station/notifications.json" class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-amber/50 transition-colors" />
+                </div>
+              {/if}
+            </div>
+
+            {#if notificationsMethod === 'webhook'}
+              <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label for="webhook-type" class="block text-sm text-text-dim mb-1">Webhook Type</label>
+                  <select id="webhook-type" bind:value={webhookType} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-amber/50 transition-colors">
+                    <option value="slack">Slack</option>
+                    <option value="discord">Discord</option>
+                    <option value="telegram">Telegram</option>
+                    <option value="generic">Generic (JSON)</option>
+                  </select>
+                </div>
+                <div>
+                  <label for="webhook-url" class="block text-sm text-text-dim mb-1">
+                    {webhookType === 'telegram' ? 'Bot API URL' : 'Webhook URL'}
+                  </label>
+                  <input id="webhook-url" type="url" bind:value={webhookUrl}
+                    placeholder={webhookType === 'slack' ? 'https://hooks.slack.com/services/...' : webhookType === 'discord' ? 'https://discord.com/api/webhooks/...' : webhookType === 'telegram' ? 'https://api.telegram.org/bot<TOKEN>/sendMessage' : 'https://example.com/webhook'}
+                    class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-amber/50 transition-colors" />
+                </div>
+              </div>
+
+              {#if webhookType === 'telegram'}
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label for="telegram-chat-id" class="block text-sm text-text-dim mb-1">Telegram Chat ID</label>
+                    <input id="telegram-chat-id" type="text" bind:value={telegramChatId} placeholder="-1001234567890" class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-amber/50 transition-colors" />
+                  </div>
+                </div>
+              {/if}
+
+              <div>
+                <label for="dashboard-url-s" class="block text-sm text-text-dim mb-1">Dashboard URL (for links in notifications)</label>
+                <input id="dashboard-url-s" type="url" bind:value={dashboardUrl} placeholder="https://your-server:8420" class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-amber/50 transition-colors" />
+              </div>
+
+              <div>
+                <p class="text-sm text-text-dim mb-2">Notify on:</p>
+                <div class="flex flex-wrap gap-4">
+                  <label class="flex items-center gap-2 text-sm text-text cursor-pointer">
+                    <input type="checkbox" bind:checked={notifyOnApprove} class="w-4 h-4 accent-accent-emerald cursor-pointer" /> Approve
+                  </label>
+                  <label class="flex items-center gap-2 text-sm text-text cursor-pointer">
+                    <input type="checkbox" bind:checked={notifyOnReject} class="w-4 h-4 accent-accent-red cursor-pointer" /> Reject
+                  </label>
+                  <label class="flex items-center gap-2 text-sm text-text cursor-pointer">
+                    <input type="checkbox" bind:checked={notifyOnPr} class="w-4 h-4 accent-accent-blue cursor-pointer" /> PR Created
+                  </label>
+                  <label class="flex items-center gap-2 text-sm text-text cursor-pointer">
+                    <input type="checkbox" bind:checked={notifyOnError} class="w-4 h-4 accent-accent-amber cursor-pointer" /> Error / Stale Run
+                  </label>
+                </div>
+              </div>
+
+              <div>
+                <button onclick={sendTestNotification} disabled={testingSending || !webhookUrl}
+                  class="px-4 py-2 bg-gradient-to-r from-accent-amber/80 to-accent-amber text-white rounded-lg text-sm font-medium hover:shadow-[0_0_16px_rgba(245,158,11,0.3)] disabled:opacity-40 cursor-pointer transition-all">
+                  {testingSending ? 'Sending...' : 'Send Test Notification'}
+                </button>
+              </div>
+            {/if}
+          {/if}
+        </div>
+      </GlassCard>
+
+      <!-- Advanced Settings -->
+      <GlassCard class="p-5">
+        <button onclick={() => showAdvanced = !showAdvanced} class="flex items-center gap-2 w-full text-left cursor-pointer">
+          <svg class="w-4 h-4 text-text-dim transition-transform duration-200" class:rotate-90={showAdvanced} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg>
+          <h3 class="font-semibold">Advanced Settings</h3>
+          <span class="text-xs text-text-dim ml-auto">Turn limits</span>
+        </button>
+        {#if showAdvanced}
+          <div class="mt-5 space-y-6 animate-fade-in-up">
+            <div>
+              <h4 class="text-sm font-medium text-text-dim mb-3">Turn Limits</h4>
+              <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div>
+                  <label for="max-employee-turns" class="block text-sm text-text-dim mb-1">Max Employee Turns</label>
+                  <input id="max-employee-turns" type="number" bind:value={maxEmployeeTurns} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+                </div>
+                <div>
+                  <label for="max-analyst-turns" class="block text-sm text-text-dim mb-1">Max Analyst Turns</label>
+                  <input id="max-analyst-turns" type="number" bind:value={maxAnalystTurns} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+                </div>
+                <div>
+                  <label for="max-manager-turns" class="block text-sm text-text-dim mb-1">Max Manager Turns</label>
+                  <input id="max-manager-turns" type="number" bind:value={maxManagerTurns} class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+                </div>
+              </div>
+            </div>
+          </div>
+        {/if}
+      </GlassCard>
+
+      <!-- Save / Reset -->
+      <div class="flex items-center gap-3">
+        <button onclick={save} disabled={saving}
+          class="px-5 py-2 bg-gradient-to-r from-accent-blue to-accent-emerald text-white rounded-lg text-sm font-medium hover:shadow-[0_0_16px_rgba(59,130,246,0.3)] disabled:opacity-50 cursor-pointer transition-all">
+          {saving ? 'Saving...' : 'Save Changes'}
+        </button>
+        <button onclick={reset} disabled={saving}
+          class="px-5 py-2 glass text-text rounded-lg text-sm font-medium hover:bg-white/[0.03] disabled:opacity-50 cursor-pointer transition-colors">
+          Reset
+        </button>
+      </div>
+    {/if}
+
+  <!-- ========== SYSTEM TAB ========== -->
+  {:else if activeTab === 'system'}
+    {#if systemLoading}
+      <div class="flex justify-center py-12"><LoadingSpinner /></div>
+    {:else}
+      <!-- Service Controls -->
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <GlassCard glow={system?.service.active ? 'blue' : 'none'} class="p-5 space-y-4">
+          <div class="flex items-center justify-between">
+            <h3 class="font-semibold">Agent Service</h3>
+            <div class="flex items-center gap-2">
+              <StatusOrb active={system?.service.active ?? false} />
+              <span class="text-sm">{system?.service.active ? 'Active' : 'Inactive'}</span>
+            </div>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <button onclick={handleTrigger} class="px-3 py-1.5 text-sm bg-gradient-to-r from-accent-blue to-accent-emerald text-white rounded-lg hover:shadow-[0_0_12px_rgba(59,130,246,0.2)] cursor-pointer transition-all">Trigger Run</button>
+            <button onclick={() => doServiceAction('stop', 'claude-agent.service')} class="px-3 py-1.5 text-sm glass rounded-lg text-text-dim hover:text-text cursor-pointer transition-colors">Stop</button>
+          </div>
+        </GlassCard>
+
+        <GlassCard glow={system?.timer.active ? 'emerald' : 'none'} class="p-5 space-y-4">
+          <div class="flex items-center justify-between">
+            <h3 class="font-semibold">Timer</h3>
+            <div class="flex items-center gap-2">
+              <StatusOrb active={system?.timer.active ?? false} color="#10b981" />
+              <span class="text-sm">{system?.timer.active ? 'Active' : 'Inactive'}</span>
+            </div>
+          </div>
+          {#if system?.timer.next_trigger}
+            <p class="text-sm text-text-dim">Next: {system.timer.next_trigger}</p>
+          {/if}
+          <div class="flex flex-wrap gap-2">
+            <button onclick={() => doServiceAction('start', 'claude-agent.timer')} class="px-3 py-1.5 text-sm glass rounded-lg text-text-dim hover:text-text cursor-pointer transition-colors">Enable</button>
+            <button onclick={() => doServiceAction('stop', 'claude-agent.timer')} class="px-3 py-1.5 text-sm glass rounded-lg text-text-dim hover:text-text cursor-pointer transition-colors">Disable</button>
+          </div>
+        </GlassCard>
+      </div>
+
+      <!-- Resources -->
+      <GlassCard class="p-5 space-y-4">
+        <h3 class="font-semibold">Resources</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <ResourceMeter label="Memory" value={system?.resources.memory_used_mb ?? null} max={system?.resources.memory_total_mb ?? 4096} unit="MB" />
+          <ResourceMeter label="Disk Used" value={system?.resources.disk_used_gb ?? null} max={system?.resources.disk_total_gb ?? 100} unit="GB" />
+        </div>
+        <div class="flex gap-6 text-sm text-text-dim font-data">
+          <span>Load: {system?.resources.load_avg?.map(v => v.toFixed(2)).join(', ') ?? '-'}</span>
+          <span>Uptime: {formatUptime(system?.resources.uptime_seconds)}</span>
+        </div>
+      </GlassCard>
+
+      <!-- Auth Status -->
+      <GlassCard glow={auth?.logged_in && !auth.expired ? 'emerald' : 'red'} class="p-5 space-y-3">
+        <h3 class="font-semibold">Auth Status</h3>
+        <div class="flex items-center gap-3">
+          <StatusOrb active={auth?.logged_in === true && !auth.expired} />
+          <span class="text-sm">
+            {#if auth?.logged_in && !auth.expired}
+              Authenticated
+            {:else if auth?.logged_in && auth.expired}
+              Token Expired
+            {:else}
+              Not Logged In
+            {/if}
+          </span>
+        </div>
+        {#if auth?.expires_at}
+          <p class="text-xs text-text-dim">Expires: {new Date(auth.expires_at).toLocaleString()}</p>
+        {/if}
+        {#if auth?.error}
+          <p class="text-xs text-reject">{auth.error}</p>
+        {/if}
+
+        {#if oauthFlow === 'idle'}
+          <button onclick={handleOAuthStart}
+            class="px-3 py-1.5 text-sm bg-gradient-to-r from-accent-blue to-accent-emerald text-white rounded-lg hover:shadow-[0_0_12px_rgba(59,130,246,0.2)] cursor-pointer transition-all">
+            {auth?.logged_in && !auth.expired ? 'Re-authenticate' : 'Login with Claude'}
+          </button>
+        {:else if oauthFlow === 'waiting_for_code'}
+          <div class="space-y-2">
+            <p class="text-sm text-text-dim">A new tab has opened. Authenticate on claude.ai, then paste the code below.</p>
+            <div class="flex gap-2">
+              <input type="text" bind:value={oauthCode} placeholder="Paste authorization code"
+                class="flex-1 px-3 py-1.5 text-sm bg-white/[0.04] border border-border/50 rounded-lg focus:outline-none focus:border-accent-blue/50 transition-colors"
+                onkeydown={(e: KeyboardEvent) => { if (e.key === 'Enter') handleOAuthSubmit(); }} />
+              <button onclick={handleOAuthSubmit} disabled={!oauthCode.trim()}
+                class="px-3 py-1.5 text-sm bg-gradient-to-r from-accent-blue to-accent-emerald text-white rounded-lg cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed">Submit</button>
+              <button onclick={handleOAuthCancel}
+                class="px-3 py-1.5 text-sm glass rounded-lg text-text-dim hover:text-text cursor-pointer transition-colors">Cancel</button>
+            </div>
+          </div>
+        {:else if oauthFlow === 'submitting'}
+          <div class="flex items-center gap-2 text-sm text-text-dim"><LoadingSpinner /><span>Exchanging code for tokens...</span></div>
+        {:else if oauthFlow === 'done'}
+          <p class="text-sm text-approve text-glow-emerald">Authentication successful!</p>
+        {/if}
+
+        {#if oauthError}
+          <p class="text-xs text-reject">{oauthError}</p>
+        {/if}
+      </GlassCard>
+    {/if}
+
+  <!-- ========== LOGS TAB ========== -->
+  {:else if activeTab === 'logs'}
+    <GlassCard class="p-5">
+      <h3 class="font-semibold mb-4">Logging Directories</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <label for="log-dir" class="block text-sm text-text-dim mb-1">Log Directory</label>
+          <input id="log-dir" type="text" bind:value={logDir} placeholder="/var/log/claude-agent/" class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+        </div>
+        <div>
+          <label for="digest-dir" class="block text-sm text-text-dim mb-1">Digest Directory</label>
+          <input id="digest-dir" type="text" bind:value={digestDir} placeholder="/var/log/claude-agent/digests/" class="w-full bg-white/[0.04] border border-border/50 rounded-lg px-3 py-2 text-sm text-text focus:outline-none focus:border-accent-blue/50 transition-colors" />
+        </div>
+      </div>
+    </GlassCard>
+
+    <GlassCard class="p-5">
+      <h3 class="font-semibold mb-3">Log Viewer</h3>
+      <p class="text-sm text-text-dim mb-4">For real-time log streaming, use the dedicated log viewer.</p>
+      <a href="#/logs" class="px-4 py-2 glass rounded-lg text-sm hover:bg-white/[0.03] transition-colors inline-block">
+        Open Log Viewer
+      </a>
+    </GlassCard>
+
+    <div class="flex items-center gap-3">
+      <button onclick={save} disabled={saving}
+        class="px-5 py-2 bg-gradient-to-r from-accent-blue to-accent-emerald text-white rounded-lg text-sm font-medium hover:shadow-[0_0_16px_rgba(59,130,246,0.3)] disabled:opacity-50 cursor-pointer transition-all">
+        {saving ? 'Saving...' : 'Save Changes'}
+      </button>
+    </div>
+  {/if}
+</div>


### PR DESCRIPTION
## Summary

Implements all 6 acceptance criteria from issue #47:

- **AC1** — Sidebar reduced from 11 → 5 items (Dashboard, Projects, Plans, Runs, Settings). All pages remain reachable within 2 clicks.
- **AC2** — Unified `RunDetailPage` now shows phase timeline, coordinator tasks, queue item, plan link, employee report, and code diff in a single view. New `GET /api/runs/{id}/full` backend endpoint powers this.
- **AC3** — New `ActiveRunBanner` component in the header bar shows current phase, elapsed time, and project name from any page. Clicking navigates to the active run.
- **AC4** — `Config` + `System` pages merged into a single `SettingsPage` with tabs (Configuration | System & Auth | Logs). Analytics moved to an expandable panel on the Dashboard.
- **AC5** — Run detail shows related queue item, coordinator tasks, and implementation plan.
- **AC6** — Dashboard prioritizes active run status and recent activity.

## Changes

- `backend/app/routers/runs.py` — new `GET /api/runs/{id}/full` endpoint
- `backend/app/schemas.py` — new `RunFullContext` schema
- `backend/tests/test_runs.py` — 2 new tests for the full context endpoint
- `frontend/src/pages/RunDetailPage.svelte` — full context integration, phase timeline, coordinator tasks, queue item, plan
- `frontend/src/pages/SettingsPage.svelte` — new merged settings page (was Config + System)
- `frontend/src/pages/DashboardPage.svelte` — analytics expandable panel
- `frontend/src/components/ActiveRunBanner.svelte` — new always-visible run progress indicator
- `frontend/src/components/HeaderBar.svelte` — ActiveRunBanner integration
- `frontend/src/components/Sidebar.svelte` — reduced to 5 items
- `frontend/src/App.svelte`, `router.svelte.ts`, `api.ts`, `types.ts` — supporting changes

## Test Plan

- [x] 148 backend tests pass (148 passed, 0 failed), including 2 new endpoint tests
- [ ] Verify sidebar shows exactly 5 items on desktop and mobile
- [ ] Verify ActiveRunBanner appears during an active run and clicking navigates to run detail
- [ ] Verify Settings tabs (Config / System / Logs) all load and save correctly
- [ ] Verify Run Detail shows coordinator tasks, queue item, and plan when present
- [ ] Verify Analytics panel expands/collapses on Dashboard
- [ ] Verify old URLs (#/config, #/system) still work (backward compat)

🤖 Reviewed and approved for PR by Manager Agent