### PR TITLE
fix #60: enforce read-only mode for analyze/plan employees

### DIFF
--- a/agent/prompts/manager.md
+++ b/agent/prompts/manager.md
@@ -76,6 +76,8 @@ Evaluate ONLY:
 3. **Priority Accuracy** — are severity/priority labels reasonable?
 4. **Refinement Quality** — did the analyst add substantive analysis (root cause, file references, implementation guidance)?
 
+5. **Read-Only Compliance** — if the review package shows a `READ-ONLY VIOLATION` warning or any git diff, **REJECT immediately**. Analyze-mode employees must not modify source files under any circumstances. This overrides all other criteria.
+
 **NEVER reject analyze-mode work for "no code changes", "no branch", or "no diff." That is expected.**
 
 ### Plan Mode Review
@@ -86,6 +88,7 @@ Evaluate ONLY:
 2. **Scope Accuracy** — is the estimated scope reasonable given the files listed?
 3. **Acceptance Criteria** — are criteria specific and testable?
 4. **Verification Steps** — do plans include running the full pipeline (tests, lint, type check, build)?
+5. **Read-Only Compliance** — if the review package shows a `READ-ONLY VIOLATION` warning or any git diff, **REJECT immediately**. Plan-mode employees must not modify source files.
 
 ### Plan Review Mode (Pre-Implementation Plan Gate)
 

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -992,7 +992,11 @@ $custom_instructions"
     cmd+=(--fallback-model "$fallback_model")
     cmd+=(--max-turns "$max_turns")
     cmd+=(--system-prompt-file "$system_prompt")
-    # No --allowedTools/--disallowedTools: full VM access, prompt-enforced guardrails
+    # Analyze/plan modes: block file-mutation tools at CLI level (defense in depth)
+    if [ "$mode" = "analyze" ] || [ "$mode" = "plan" ]; then
+        cmd+=(--disallowedTools "Edit" "Write" "NotebookEdit")
+    fi
+    # Full mode: unrestricted tools (dedicated VM, prompt-enforced guardrails)
 
     log_info "Employee command: ${cmd[*]} '<prompt>'"
 
@@ -1366,6 +1370,21 @@ collect_employee_reports() {
             echo "" >> "$review_package"
             echo "This project is running in **analyze mode**. The employee was instructed to read code and create/refine GitHub issues ONLY — not to make any code changes. **Do NOT reject for absence of code changes.** Review the quality of created/refined issues instead." >> "$review_package"
             echo "" >> "$review_package"
+        fi
+
+        # Verify no source files were modified in analyze/plan modes (defense in depth)
+        if [ "$project_mode" = "analyze" ] || [ "$project_mode" = "plan" ]; then
+            local dirty_files
+            dirty_files=$(cd "$workspace" && { git diff --name-only 2>/dev/null; git ls-files --others --exclude-standard 2>/dev/null; } | grep -v '\.claude-' | grep -v 'node_modules')
+            if [ -n "$dirty_files" ]; then
+                echo "### ⚠️ READ-ONLY VIOLATION DETECTED" >> "$review_package"
+                echo "The following files were modified or created despite analyze/plan mode:" >> "$review_package"
+                echo '```' >> "$review_package"
+                echo "$dirty_files" >> "$review_package"
+                echo '```' >> "$review_package"
+                echo "**This employee violated read-only mode. REJECT immediately.**" >> "$review_package"
+                echo "" >> "$review_package"
+            fi
         fi
 
         # Find all employee reports (main workspace + worktree paths)


### PR DESCRIPTION
## Summary
- **Layer 1**: Added `--disallowedTools "Edit" "Write" "NotebookEdit"` to CLI invocation when mode is `analyze` or `plan`
- **Layer 2**: Post-run dirty workspace check detects modified/new source files and flags `READ-ONLY VIOLATION` in the manager's review package
- **Layer 3**: Manager prompt updated to immediately REJECT on read-only violations in both analyze and plan mode reviews

## Test plan
- [x] `bash -n` syntax check passes
- [x] `--disallowedTools` appears in built command for analyze/plan modes
- [x] Dirty check excludes `.claude-*` files and `node_modules`
- [x] Manager prompt includes violation enforcement for both analyze and plan modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)