### PR TITLE
Add backlog label restriction to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,9 @@ See `ARCHITECTURE.md` for full system design.
 - SQLite database at `/var/lib/claude-agent-station/station.db`
 - Dashboard port: 8420
 
+## Issue Rules
+- **NEVER work on issues or features labeled `backlog`.** Under no circumstances should the agent pick up, implement, plan, or research any issue/feature that carries the `backlog` label. Skip them entirely — no exceptions.
+
 ## Git Workflow
 - **`main` is protected.** Direct pushes are blocked — even for admins.
 - All changes go through pull requests (no approval required — solo project).


### PR DESCRIPTION
## Summary
- Adds an "Issue Rules" section to CLAUDE.md prohibiting the agent from working on any issues or features labeled `backlog`

## Test plan
- [ ] Verify CLAUDE.md contains the new rule
- [ ] Confirm agent respects the restriction in future runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)