### PR TITLE
fix: AgentPanel reversed feed, overflow fix, manager presence attribution

### DIFF
--- a/dashboard/frontend/src/App.svelte
+++ b/dashboard/frontend/src/App.svelte
@@ -100,7 +100,7 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="flex flex-col md:flex-row min-h-screen bg-bg">
+<div class="flex flex-col md:flex-row h-screen bg-bg">
   <!-- NavRail (bottom on mobile, left on desktop) -->
   <div class="hidden md:block">
     <NavRail />

--- a/dashboard/frontend/src/components/AgentPanel.svelte
+++ b/dashboard/frontend/src/components/AgentPanel.svelte
@@ -10,25 +10,8 @@
 
   let { onClose }: Props = $props();
 
-  let feedContainer: HTMLDivElement;
-  let autoScroll = $state(true);
-
-  // Auto-scroll to bottom on new entries
-  $effect(() => {
-    // Track length to trigger effect
-    const _len = agentPresence.conversationLog.length;
-    if (autoScroll && feedContainer) {
-      requestAnimationFrame(() => {
-        feedContainer.scrollTop = feedContainer.scrollHeight;
-      });
-    }
-  });
-
-  function handleScroll() {
-    if (!feedContainer) return;
-    const { scrollTop, scrollHeight, clientHeight } = feedContainer;
-    autoScroll = scrollHeight - scrollTop - clientHeight < 60;
-  }
+  // Reversed view — newest messages on top, no auto-scroll needed
+  let reversedLog = $derived(agentPresence.conversationLog.toReversed());
 
   let phaseLabel = $derived(
     agentPresence.phase === 'idle' ? 'Idle' :
@@ -60,7 +43,7 @@
 ></div>
 
 <!-- Panel -->
-<aside class="agent-panel-enter fixed md:relative right-0 top-0 md:top-auto h-full w-full md:w-[400px] md:max-w-[400px] bg-surface border-l border-border flex flex-col z-40 md:z-auto shrink-0">
+<aside class="agent-panel-enter fixed md:relative right-0 top-0 md:top-auto h-full w-full md:w-[400px] md:max-w-[400px] bg-surface border-l border-border flex flex-col z-40 md:z-auto shrink-0 overflow-hidden">
   <!-- Header -->
   <div class="flex items-center justify-between px-3 h-12 border-b border-border shrink-0">
     <div class="flex items-center gap-2">
@@ -87,16 +70,25 @@
 
   <!-- Conversation feed -->
   <div
-    bind:this={feedContainer}
-    onscroll={handleScroll}
-    class="flex-1 overflow-auto px-3 py-2 space-y-1"
+    class="flex-1 overflow-y-auto min-h-0 px-3 py-2 space-y-1"
   >
     {#if agentPresence.conversationLog.length === 0}
       <div class="flex items-center justify-center h-full text-text-muted text-sm">
         <p>No agent activity yet. Trigger a run to begin.</p>
       </div>
     {:else}
-      {#each agentPresence.conversationLog as entry (entry.id)}
+      <!-- Thinking indicator (newest activity, shown at top) -->
+      {#if agentPresence.agents.some(a => a.status === 'thinking')}
+        {@const thinkingAgent = agentPresence.agents.find(a => a.status === 'thinking')}
+        {#if thinkingAgent}
+          <div class="flex items-center gap-2 py-1">
+            <span class="text-[11px] font-semibold" style="color: {thinkingAgent.color}">{thinkingAgent.name}</span>
+            <AgentThinking color={thinkingAgent.color} />
+          </div>
+        {/if}
+      {/if}
+
+      {#each reversedLog as entry (entry.id)}
         <div class="flex gap-2 py-1 animate-slide-in-right {entry.type === 'guidance' ? 'flex-row-reverse' : ''}">
           <!-- Agent indicator -->
           <div class="shrink-0 w-5 text-center">
@@ -143,17 +135,6 @@
           </div>
         </div>
       {/each}
-
-      <!-- Thinking indicator -->
-      {#if agentPresence.agents.some(a => a.status === 'thinking')}
-        {@const thinkingAgent = agentPresence.agents.find(a => a.status === 'thinking')}
-        {#if thinkingAgent}
-          <div class="flex items-center gap-2 py-1">
-            <span class="text-[11px] font-semibold" style="color: {thinkingAgent.color}">{thinkingAgent.name}</span>
-            <AgentThinking color={thinkingAgent.color} />
-          </div>
-        {/if}
-      {/if}
     {/if}
   </div>
 

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -185,8 +185,13 @@ function handleWsMessage(data: string) {
   if (!parsed) return;
 
   const events = Array.isArray(parsed) ? parsed : [parsed];
-  // Determine current agent name from active agents
-  const activeAgent = agentPresence.agents.find(a => a.status === 'active' && a.role !== 'manager');
+  // Determine current agent name from active agents.
+  // During manager phases the WS log stream is the manager's CLI output.
+  const isManagerPhase = agentPresence.phase === 'manager_review' || agentPresence.phase === 'executing_verdict';
+  const activeAgent = isManagerPhase
+    ? agentPresence.agents.find(a => a.role === 'manager')
+    : (agentPresence.agents.find(a => a.status === 'active' && a.role !== 'manager')
+       ?? agentPresence.agents.find(a => a.status === 'active'));
   const agentName = activeAgent?.name ?? 'Dev-0';
   const agentColor = activeAgent?.color ?? ROLE_COLORS['dev-0'];
 


### PR DESCRIPTION
## Summary
- **AgentPanel**: Switch from auto-scroll to reversed log view (newest on top) — simpler, no scroll state management needed
- **AgentPanel**: Add `overflow-hidden` to aside to prevent content bleeding outside panel bounds
- **AgentPanel**: Move thinking indicator to top of feed (visible immediately in reversed view)
- **agent-presence**: Fix WS log attribution during manager phases (`manager_review`, `executing_verdict`) — messages were incorrectly attributed to employee agents
- **App.svelte**: Restore `h-screen` (was changed to `min-h-screen` by auth PR, breaks fixed layout)

## Test plan
- [ ] Open dashboard, trigger agent run, verify feed shows newest entries at top
- [ ] Verify thinking indicator appears at top of feed during active runs
- [ ] Verify manager review phase attributes log lines to manager agent
- [ ] Verify panel doesn't overflow on mobile widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)