### PR TITLE
hotfix: WebSocket log stream crash from HTTPBearer auth

### DIFF
--- a/dashboard/backend/app/main.py
+++ b/dashboard/backend/app/main.py
@@ -141,9 +141,10 @@ app.add_middleware(
 )
 
 # Mount routers
-# Exempt: health (monitoring must always be reachable) and webhook (has own auth)
+# Exempt: health (monitoring), webhook (has own auth), logs.ws_router (WebSocket — has inline auth)
 app.include_router(health.router)
 app.include_router(webhook.router)
+app.include_router(logs.ws_router)
 
 # Protected routers: require API key when STATION_API_KEY is configured
 _auth = [Depends(verify_api_key)]

--- a/dashboard/backend/app/routers/logs.py
+++ b/dashboard/backend/app/routers/logs.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import re
+import secrets
 from typing import Optional, List
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
@@ -12,14 +13,29 @@ from app.services.log_streamer import tail_log_file
 
 router = APIRouter(prefix="/api/logs", tags=["logs"])
 
+# Separate router for the WebSocket endpoint — HTTPBearer auth dependencies
+# cannot resolve on WebSocket connections (no Request object), so this router
+# is registered WITHOUT the global _auth dependency in main.py.
+ws_router = APIRouter(prefix="/api/logs", tags=["logs"])
 
-@router.websocket("/stream")
+
+@ws_router.websocket("/stream")
 async def stream_logs(
     websocket: WebSocket,
     file: Optional[str] = None,
     from_beginning: bool = False,
+    token: Optional[str] = Query(default=None),
 ):
-    """WebSocket endpoint for live log streaming."""
+    """WebSocket endpoint for live log streaming.
+
+    Auth: when STATION_API_KEY is set, the client must pass ?token=<key>.
+    """
+    # Inline auth — WebSocket can't use HTTPBearer
+    if settings.api_key:
+        if not token or not secrets.compare_digest(token, settings.api_key):
+            await websocket.close(code=1008, reason="Unauthorized")
+            return
+
     await websocket.accept()
 
     # Validate file path if provided (must be within log_dir)

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -445,9 +445,13 @@ function sampleIntensity() {
 export function connect() {
   if (ws) return;
 
-  // WebSocket for log stream
+  // WebSocket for log stream — pass API key as query param when configured
+  const apiKey = getStoredApiKey();
+  const wsUrl = apiKey
+    ? `/api/logs/stream?token=${encodeURIComponent(apiKey)}`
+    : '/api/logs/stream';
   ws = new LogWebSocket(
-    '/api/logs/stream',
+    wsUrl,
     handleWsMessage,
     (status) => { agentPresence.wsConnected = status; }
   );


### PR DESCRIPTION
## Summary
- Fix #65 regression: `HTTPBearer` auth dependency crashes on WebSocket connections (`TypeError: __call__() missing 1 required positional argument: 'request'`), breaking the live agent message feed entirely
- Split WebSocket endpoint into separate `ws_router` with inline token validation
- Frontend passes API key as `?token=` query param on WebSocket URL (matching existing SSE pattern)

## Test plan
- [x] Service restarted, no `TypeError` in logs
- [x] WebSocket connects successfully (`connection open`, no immediate close)
- [x] SSE still connects (`New SSE subscriber`)
- [x] Health check returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)