### PR TITLE
fix: enforce project mode in Python coordinator path

### DIFF
--- a/agent/coordinator/__main__.py
+++ b/agent/coordinator/__main__.py
@@ -87,6 +87,14 @@ async def coordinate(config: CoordinatorConfig) -> int:
         issue_number = assignment.get("issue_number")
         issue_body = assignment.get("issue_body", "")
 
+        # Extract and validate project mode from assignment
+        project_mode = assignment.get("mode", "full")
+        if project_mode not in ("full", "plan", "analyze"):
+            logger.warning("Unknown mode '%s' for %s, defaulting to 'full'", project_mode, repo)
+            project_mode = "full"
+        config.project_mode = project_mode
+        logger.info("Project %s mode: %s", repo, project_mode)
+
         # Fetch issue body if we have an issue number but no body
         if issue_number and not issue_body:
             issue_body = _fetch_issue_body(repo, issue_number, workspace)

--- a/agent/coordinator/config.py
+++ b/agent/coordinator/config.py
@@ -44,6 +44,9 @@ class CoordinatorConfig:
     planning_enabled: bool = True
     planning_max_revisions: int = 2
 
+    # Project mode (set per-assignment in __main__.py, not from config file)
+    project_mode: str = "full"  # "full", "plan", or "analyze"
+
     @classmethod
     def from_args(
         cls,

--- a/agent/coordinator/scheduler.py
+++ b/agent/coordinator/scheduler.py
@@ -438,7 +438,7 @@ async def _run_and_monitor(
     try:
         # --- Plan review gate ---
         approved_plan: dict | None = None
-        if not _should_skip_planning(task, config):
+        if config.project_mode != "analyze" and not _should_skip_planning(task, config):
             logger.info(
                 "Starting plan phase for employee %d, task '%s'",
                 employee_index,
@@ -453,6 +453,17 @@ async def _run_and_monitor(
                 await dag.mark_failed(task.id, "Plan phase failed or was rejected")
                 post_task_event(config, "task_failed", task)
                 return task.id
+
+        # --- Mode gate: analyze/plan modes must NOT proceed to implementation ---
+        if config.project_mode in ("analyze", "plan"):
+            logger.info(
+                "MODE GATE: Skipping implementation for employee %d, task '%s' "
+                "(mode=%s — implementation not permitted)",
+                employee_index, task.title, config.project_mode,
+            )
+            await dag.mark_completed(task.id, exit_code=0)
+            post_task_event(config, "task_completed", task)
+            return task.id
 
         # Start employee subprocess (with approved plan if available)
         employee_task = asyncio.create_task(


### PR DESCRIPTION
## Summary
- PR #135 gated analyze/plan modes in the **legacy bash path** only, but the system uses the **Python coordinator** by default
- The coordinator received `"mode": "analyze"` in assignments JSON but completely ignored it — spawning implementation employees on read-only projects
- Adds `project_mode` to `CoordinatorConfig`, extracts it from assignments in `__main__.py`, and gates `run_employee()` in `scheduler.py`

## Test plan
- [ ] Set a project to `"mode": "analyze"` in `manager-config.json`
- [ ] Start the agent and verify logs show `MODE GATE: Skipping implementation`
- [ ] Confirm no `.stream.jsonl` implementation files are created
- [ ] Confirm no code modifications, branches, or commits on the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)