### PR TITLE
fix: manager must trust system mode header over employee self-report

### DIFF
--- a/agent/prompts/manager.md
+++ b/agent/prompts/manager.md
@@ -24,10 +24,12 @@ You are a manager agent responsible for reviewing work done by employee agents a
 Before reviewing each project, detect the mode:
 
 1. Check the review package header for `MODE: ANALYZE`, `MODE: PLAN`, or `MODE: PLAN_REVIEW`.
-2. Check the employee report JSON for `"mode": "analyze"`, `"mode": "plan"`, or `"mode": "plan_only"`.
-3. If `MODE: PLAN_REVIEW` is present, use **Plan Review Mode** criteria below.
-4. If analyze or plan mode is present, use that mode's criteria below.
-5. Otherwise, use **Full Mode** criteria.
+2. **The header mode is authoritative** — it is set by the orchestration system from project configuration. Always use the header mode to select review criteria.
+3. If the employee report JSON contains a different `"mode"` value than the header (e.g., header says `MODE: ANALYZE` but employee reports `"mode": "plan_only"`), **this is a mode mismatch** — the employee operated outside its permitted scope. Note the mismatch in your feedback and still apply the header mode's criteria. Never let the employee's self-reported mode override the system mode.
+4. If `MODE: PLAN_REVIEW` → use **Plan Review Mode** criteria.
+5. If `MODE: ANALYZE` → use **Analyze Mode Review** criteria.
+6. If `MODE: PLAN` → use **Plan Mode Review** criteria.
+7. If no mode header is present → fall back to the employee report's `"mode"` field, then default to **Full Mode**.
 </mode-detection>
 
 <workflow>
@@ -190,7 +192,7 @@ Write your verdicts to the file path provided in your prompt:
 }
 ```
 
-- `mode`: use the mode from the employee's report (`"full"`, `"analyze"`, or `"plan"`)
+- `mode`: use the mode from the review package header (`"full"`, `"analyze"`, or `"plan"`). If no header is present, fall back to the employee's report.
 - `base_branch`: use whatever `base_branch` the employee reported — never hardcode
 - For analyze/plan mode: set `issue_number` to `null`, `branch` to `null`, `push_approved` to `false`
 - For SKIP: set `issue_number` to `null`, `branch` to `null`, `push_approved` to `false`


### PR DESCRIPTION
## Summary
- The manager prompt's `<mode-detection>` checked both the review package header (`MODE: ANALYZE`) and the employee's JSON report (`"mode": "plan_only"`) but didn't establish which is authoritative
- When they conflicted, the manager trusted the employee's self-report — evaluating with Plan Mode criteria instead of Analyze Mode criteria
- Line 193 explicitly said "use the mode from the employee's report" in the verdict output
- Now the header is explicitly authoritative, mode mismatches are flagged, and the verdict uses the system mode

## Test plan
- [ ] Run agent with a project in analyze mode
- [ ] Verify manager logs show it uses Analyze Mode Review criteria even if employee self-reports differently
- [ ] Verify mode mismatch is noted in manager feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)