### PR TITLE
fix: Python 3.9 compatibility for PR #125 changes

### DIFF
--- a/dashboard/backend/app/config.py
+++ b/dashboard/backend/app/config.py
@@ -1,6 +1,8 @@
 """Application configuration via pydantic-settings."""
 
 
+from __future__ import annotations
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 

--- a/dashboard/backend/app/database.py
+++ b/dashboard/backend/app/database.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Async SQLAlchemy engine, session factory, and DB initialization."""
 
 import logging

--- a/dashboard/backend/app/dependencies.py
+++ b/dashboard/backend/app/dependencies.py
@@ -1,5 +1,7 @@
 """FastAPI dependencies."""
 
+from __future__ import annotations
+
 import secrets
 from collections.abc import AsyncGenerator
 

--- a/dashboard/backend/app/main.py
+++ b/dashboard/backend/app/main.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """FastAPI application with lifespan: init DB, sync config, import logs."""
 
 import asyncio

--- a/dashboard/backend/app/models.py
+++ b/dashboard/backend/app/models.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 """SQLAlchemy ORM models."""
 
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, Text
 
@@ -9,7 +11,7 @@ from app.database import Base
 
 def _utcnow() -> datetime:
     """Return current UTC time as a timezone-aware datetime."""
-    return datetime.now(UTC)
+    return datetime.now(timezone.utc)
 
 
 class Project(Base):

--- a/dashboard/backend/app/routers/analytics.py
+++ b/dashboard/backend/app/routers/analytics.py
@@ -1,6 +1,8 @@
 """Analytics endpoints for run statistics and token usage charts."""
 
-from datetime import UTC, datetime, timedelta
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import and_, case, func, select
@@ -30,7 +32,7 @@ async def get_analytics(
     Returns daily token usage, verdict distribution, per-project token totals,
     and daily run frequency for the specified time window.
     """
-    cutoff = datetime.now(UTC) - timedelta(days=days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
 
     # Base filter conditions
     base_conditions = [Run.started_at >= cutoff]

--- a/dashboard/backend/app/routers/config_router.py
+++ b/dashboard/backend/app/routers/config_router.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 """Config management endpoints."""
 
 import asyncio
 import json
 import logging
 import time
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -243,7 +245,7 @@ async def get_token_usage(db: AsyncSession = Depends(get_db)):
         limits.get("token_reserve_percent", _NEW_LIMIT_DEFAULTS["reserve_percent"]),
     )
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
 
     # Daily tokens consumed (last 24h)
     day_ago = now - timedelta(hours=24)

--- a/dashboard/backend/app/routers/coordinator.py
+++ b/dashboard/backend/app/routers/coordinator.py
@@ -1,5 +1,7 @@
 """Coordinator API: task DAG status, messages, and guidance."""
 
+from __future__ import annotations
+
 import json
 import logging
 from pathlib import Path

--- a/dashboard/backend/app/routers/events.py
+++ b/dashboard/backend/app/routers/events.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """SSE endpoint for streaming real-time agent events to the dashboard."""
 
 import json

--- a/dashboard/backend/app/routers/health.py
+++ b/dashboard/backend/app/routers/health.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Health check endpoint."""
 
 from fastapi import APIRouter

--- a/dashboard/backend/app/routers/logs.py
+++ b/dashboard/backend/app/routers/logs.py
@@ -1,5 +1,7 @@
 """Log streaming (WebSocket) and search endpoints."""
 
+from __future__ import annotations
+
 import asyncio
 import contextlib
 import json

--- a/dashboard/backend/app/routers/oauth.py
+++ b/dashboard/backend/app/routers/oauth.py
@@ -1,5 +1,7 @@
 """OAuth PKCE login flow for claude-agent user."""
 
+from __future__ import annotations
+
 import base64
 import contextlib
 import hashlib

--- a/dashboard/backend/app/routers/plan_usage.py
+++ b/dashboard/backend/app/routers/plan_usage.py
@@ -1,8 +1,10 @@
 """Plan usage detection and history API endpoints."""
 
+from __future__ import annotations
+
 import json
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, ConfigDict
@@ -89,7 +91,7 @@ DEFAULT_WEEKLY_LIMIT = 180_000_000
 
 def _get_week_boundaries() -> tuple[datetime, datetime]:
     """Get current week start (Monday 00:00 UTC) and next reset time."""
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     days_since_monday = now.weekday()
     week_start = (now - timedelta(days=days_since_monday)).replace(
         hour=0, minute=0, second=0, microsecond=0
@@ -109,7 +111,7 @@ async def get_plan_usage(
     Returns session-level, weekly, and per-model usage percentages,
     plus throttle recommendation.
     """
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     week_start, next_reset = _get_week_boundaries()
 
     tier_limits = PLAN_LIMITS.get(plan_tier, PLAN_LIMITS.get("pro", {}))
@@ -222,7 +224,7 @@ async def record_usage_snapshot(
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Record a usage snapshot to history (called periodically or on-demand)."""
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     week_start, next_reset = _get_week_boundaries()
 
     tier_limits = PLAN_LIMITS.get(plan_tier, PLAN_LIMITS.get("pro", {}))

--- a/dashboard/backend/app/routers/plans.py
+++ b/dashboard/backend/app/routers/plans.py
@@ -1,5 +1,7 @@
 """CRUD endpoints for implementation plans."""
 
+from __future__ import annotations
+
 import json
 import logging
 from pathlib import Path

--- a/dashboard/backend/app/routers/projects.py
+++ b/dashboard/backend/app/routers/projects.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """CRUD endpoints for projects. Mutations sync back to config JSON."""
 
 

--- a/dashboard/backend/app/routers/prompts.py
+++ b/dashboard/backend/app/routers/prompts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """System prompt management endpoints.
 
 Allows reading default prompts and storing custom overrides.

--- a/dashboard/backend/app/routers/queue.py
+++ b/dashboard/backend/app/routers/queue.py
@@ -1,7 +1,9 @@
 """Task queue CRUD with state machine validation."""
 
+from __future__ import annotations
+
 import logging
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -39,7 +41,7 @@ ALL_STATES = set(TRANSITIONS.keys()) | {"completed"}
 
 
 def _utcnow() -> datetime:
-    return datetime.now(UTC)
+    return datetime.now(timezone.utc)
 
 
 @router.get("", response_model=QueueItemList)

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -1,6 +1,9 @@
 """Run history endpoints."""
 
+from __future__ import annotations
+
 import asyncio
+from typing import Optional
 import logging
 from pathlib import Path
 
@@ -90,7 +93,7 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
     ]
 
 
-@router.get("/latest", response_model=RunOut | None)
+@router.get("/latest", response_model=Optional[RunOut])
 async def get_latest_run(db: AsyncSession = Depends(get_db)):
     result = await db.execute(
         select(Run).order_by(desc(Run.started_at)).limit(1)

--- a/dashboard/backend/app/routers/system.py
+++ b/dashboard/backend/app/routers/system.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 """System status, service control, and auth endpoints."""
 
 import json
 import os
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, HTTPException
 
@@ -67,8 +69,8 @@ async def auth_status():
             return {"logged_in": True, "expired": False, "expires_at": None}
 
         # expiresAt is epoch milliseconds
-        expires_dt = datetime.fromtimestamp(expires_at / 1000, tz=UTC)
-        expired = datetime.now(UTC) > expires_dt
+        expires_dt = datetime.fromtimestamp(expires_at / 1000, tz=timezone.utc)
+        expired = datetime.now(timezone.utc) > expires_dt
 
         return {
             "logged_in": True,

--- a/dashboard/backend/app/routers/webhook.py
+++ b/dashboard/backend/app/routers/webhook.py
@@ -1,10 +1,12 @@
 """Webhook endpoint for receiving live run events from run-manager.sh."""
 
+from __future__ import annotations
+
 import json
 import logging
 import secrets
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 from sqlalchemy import select
@@ -90,7 +92,7 @@ async def receive_run_event(
                 mode=event.mode,
                 model=event.model,
                 status="running",
-                started_at=datetime.now(UTC),
+                started_at=datetime.now(timezone.utc),
                 employee_index=event.employee_index,
                 concurrent_group_id=event.concurrent_group_id,
                 trace_id=event.trace_id,
@@ -131,7 +133,7 @@ async def receive_run_event(
         run.tokens_total = event.tokens_total
         run.turns = event.turns
         run.duration_ms = event.duration_ms
-        run.finished_at = datetime.now(UTC)
+        run.finished_at = datetime.now(timezone.utc)
         run.model = event.model or run.model
 
         # Read employee report from disk if not already populated
@@ -150,7 +152,7 @@ async def receive_run_event(
                 run_id=event.run_id,
                 project_id=project_id,
                 status="running",
-                started_at=datetime.now(UTC),
+                started_at=datetime.now(timezone.utc),
                 trace_id=event.trace_id,
             )
             db.add(run)
@@ -170,7 +172,7 @@ async def receive_run_event(
                 run_id=event.run_id,
                 project_id=project_id,
                 status="reviewing",
-                started_at=datetime.now(UTC),
+                started_at=datetime.now(timezone.utc),
                 trace_id=event.trace_id,
             )
             db.add(run)
@@ -243,10 +245,10 @@ async def receive_run_event(
             }
             ctask.status = status_map.get(event_name, ctask.status)
             if event_name == "task_started":
-                ctask.started_at = datetime.now(UTC)
+                ctask.started_at = datetime.now(timezone.utc)
                 ctask.employee_index = event.employee_index
             elif event_name in ("task_completed", "task_failed"):
-                ctask.finished_at = datetime.now(UTC)
+                ctask.finished_at = datetime.now(timezone.utc)
 
     elif event_name in ("conflict_detected", "guidance_sent"):
         # Coordinator messages — log them
@@ -279,7 +281,7 @@ async def receive_run_event(
                 run_id=event.run_id,
                 project_id=project_id,
                 status=event.status or "running",
-                started_at=datetime.now(UTC),
+                started_at=datetime.now(timezone.utc),
                 trace_id=event.trace_id,
             )
             db.add(run)

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -1,5 +1,7 @@
 """Pydantic request/response schemas."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any
 

--- a/dashboard/backend/app/services/config_sync.py
+++ b/dashboard/backend/app/services/config_sync.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Bidirectional sync between station-config.json and DB projects table.
 
 JSON is the source of truth for the agent. The DB mirrors it for the API.

--- a/dashboard/backend/app/services/diff_parser.py
+++ b/dashboard/backend/app/services/diff_parser.py
@@ -1,6 +1,8 @@
 """Parse unified git diff output into structured JSON data."""
 
 
+from __future__ import annotations
+
 from pydantic import BaseModel
 
 

--- a/dashboard/backend/app/services/event_bus.py
+++ b/dashboard/backend/app/services/event_bus.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 """In-memory pub/sub event bus for broadcasting SSE events to connected clients."""
 
 import asyncio
 import logging
 from collections.abc import AsyncGenerator
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -22,7 +24,7 @@ async def publish(event: dict[str, Any]) -> None:
 
     A server-side timestamp is injected automatically.
     """
-    event.setdefault("timestamp", datetime.now(UTC).isoformat())
+    event.setdefault("timestamp", datetime.now(timezone.utc).isoformat())
 
     dead: list[asyncio.Queue[dict[str, Any]]] = []
     async with _lock:

--- a/dashboard/backend/app/services/idempotency.py
+++ b/dashboard/backend/app/services/idempotency.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Simple in-memory idempotency check for webhook events."""
 
 import logging

--- a/dashboard/backend/app/services/log_importer.py
+++ b/dashboard/backend/app/services/log_importer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Import existing log files into the database on startup."""
 
 import json

--- a/dashboard/backend/app/services/log_parser.py
+++ b/dashboard/backend/app/services/log_parser.py
@@ -1,5 +1,7 @@
 """Parse agent log files: stream JSONL, verdict JSON, employee reports."""
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/dashboard/backend/app/services/log_streamer.py
+++ b/dashboard/backend/app/services/log_streamer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Async file tail for WebSocket live log streaming.
 
 Uses asyncio.to_thread with standard open(), polling at configurable interval.

--- a/dashboard/backend/app/services/notifier.py
+++ b/dashboard/backend/app/services/notifier.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Webhook notification service for Slack, Discord, Telegram, and generic webhooks.
 
 Sends notifications when runs complete, verdicts are issued, or errors occur.

--- a/dashboard/backend/app/services/stale_run_reaper.py
+++ b/dashboard/backend/app/services/stale_run_reaper.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Detect and reap runs stuck in 'running' after the agent process dies.
 
 When the agent is killed (hard stop, OOM, etc.) the run_complete webhook
@@ -7,7 +9,7 @@ runs as 'interrupted' so the UI reflects reality.
 """
 
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -39,7 +41,7 @@ async def reap_stale_runs(db: AsyncSession) -> int:
     if not stale_runs:
         return 0
 
-    now = datetime.now(UTC)
+    now = datetime.now(timezone.utc)
     for run in stale_runs:
         old_status = run.status
         run.status = "interrupted"

--- a/dashboard/backend/app/services/systemd.py
+++ b/dashboard/backend/app/services/systemd.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Systemd service control via subprocess with action whitelist."""
 
 import asyncio

--- a/dashboard/backend/migrations/0003_simplify_config_schema.py
+++ b/dashboard/backend/migrations/0003_simplify_config_schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 """Migration 0003: Simplify config schema.
 
 Removes old overlapping limit fields from station-config.json and replaces

--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -5,5 +5,6 @@ aiosqlite>=0.20.0
 python-multipart>=0.0.12
 websockets>=13.0
 pydantic>=2.0
+eval-type-backport>=0.2.0;python_version<"3.10"
 pydantic-settings>=2.0
 httpx>=0.27.0

--- a/dashboard/backend/tests/test_analytics.py
+++ b/dashboard/backend/tests/test_analytics.py
@@ -8,7 +8,7 @@ Covers:
 - Daily token usage, verdict distribution, project token usage, daily run counts
 """
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -46,7 +46,7 @@ async def sample_analytics_data(setup_db):
         session.add_all([project_a, project_b])
         await session.flush()
 
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
 
         runs = [
             # Project A: 2 successful runs today

--- a/dashboard/backend/tests/test_config.py
+++ b/dashboard/backend/tests/test_config.py
@@ -11,7 +11,7 @@ Covers:
 
 import json
 import time
-from datetime import UTC
+from datetime import timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -266,7 +266,7 @@ async def test_get_token_usage_with_runs(client):
             tokens_input=10000,
             tokens_output=5000,
             tokens_total=15000,
-            started_at=datetime.now(UTC),
+            started_at=datetime.now(timezone.utc),
         )
         session.add(run)
         await session.commit()

--- a/dashboard/backend/tests/test_coordinator.py
+++ b/dashboard/backend/tests/test_coordinator.py
@@ -11,7 +11,7 @@ Covers:
 import json
 import os
 import tempfile
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
@@ -92,9 +92,9 @@ async def sample_data(setup_db):
             exit_code=0,
             result_summary="Fixed login validation, 5 tests passing",
             branch="autonomous/issue-42",
-            created_at=datetime(2026, 3, 12, 12, 0, 0, tzinfo=UTC),
-            started_at=datetime(2026, 3, 12, 12, 0, 0, tzinfo=UTC),
-            finished_at=datetime(2026, 3, 12, 12, 5, 0, tzinfo=UTC),
+            created_at=datetime(2026, 3, 12, 12, 0, 0, tzinfo=timezone.utc),
+            started_at=datetime(2026, 3, 12, 12, 0, 0, tzinfo=timezone.utc),
+            finished_at=datetime(2026, 3, 12, 12, 5, 0, tzinfo=timezone.utc),
             touched_files=json.dumps(["src/login.tsx", "src/login.test.tsx"]),
         )
         task2 = CoordinatorTask(
@@ -106,8 +106,8 @@ async def sample_data(setup_db):
             status="running",
             employee_index=1,
             depends_on=json.dumps(["task-run-20260312T120000Z-0"]),
-            created_at=datetime(2026, 3, 12, 12, 0, 0, tzinfo=UTC),
-            started_at=datetime(2026, 3, 12, 12, 5, 0, tzinfo=UTC),
+            created_at=datetime(2026, 3, 12, 12, 0, 0, tzinfo=timezone.utc),
+            started_at=datetime(2026, 3, 12, 12, 5, 0, tzinfo=timezone.utc),
         )
         session.add_all([task1, task2])
 

--- a/dashboard/backend/tests/test_plan_usage.py
+++ b/dashboard/backend/tests/test_plan_usage.py
@@ -6,7 +6,7 @@ Covers:
 - POST /api/plan-usage/snapshot — records a snapshot
 """
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -49,7 +49,7 @@ async def sample_runs(setup_db):
         session.add(project)
         await session.flush()
 
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
         runs = [
             Run(
                 run_id="usage-run-001",
@@ -160,7 +160,7 @@ async def test_get_plan_usage_history_with_snapshots(client):
     async with async_session() as session:
         for i in range(3):
             snapshot = PlanUsageHistory(
-                timestamp=datetime.now(UTC).isoformat(),
+                timestamp=datetime.now(timezone.utc).isoformat(),
                 detection_method="heuristic",
                 plan_tier="max_5x",
                 weekly_tokens_used=i * 10000,
@@ -182,7 +182,7 @@ async def test_get_plan_usage_history_limit(client):
     async with async_session() as session:
         for _i in range(5):
             snapshot = PlanUsageHistory(
-                timestamp=datetime.now(UTC).isoformat(),
+                timestamp=datetime.now(timezone.utc).isoformat(),
                 detection_method="heuristic",
                 plan_tier="max_5x",
                 weekly_tokens_used=0,

--- a/dashboard/backend/tests/test_plans.py
+++ b/dashboard/backend/tests/test_plans.py
@@ -12,7 +12,7 @@ Covers:
 - Status transition validation
 """
 
-from datetime import UTC
+from datetime import timezone
 
 import pytest
 import pytest_asyncio
@@ -74,7 +74,7 @@ def test_utcnow_returns_timezone_aware():
     """_utcnow() helper should return a timezone-aware datetime with UTC tzinfo."""
     dt = _utcnow()
     assert dt.tzinfo is not None, "_utcnow should return timezone-aware datetime"
-    assert dt.tzinfo == UTC
+    assert dt.tzinfo == timezone.utc
 
 
 def test_plan_created_at_default_is_utcnow():

--- a/dashboard/backend/tests/test_queue.py
+++ b/dashboard/backend/tests/test_queue.py
@@ -1,6 +1,6 @@
 """Tests for queue orphan recovery, purge, and state transitions."""
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -40,7 +40,7 @@ async def db(session_factory):
 # ---------------------------------------------------------------------------
 
 def _utcnow():
-    return datetime.now(UTC)
+    return datetime.now(timezone.utc)
 
 
 def _make_queue_item(db, **kwargs):

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -8,7 +8,7 @@ Covers:
 - 404 for missing run
 """
 
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import pytest_asyncio
@@ -51,7 +51,7 @@ async def sample_runs(setup_db):
         session.add(project)
         await session.flush()
 
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
         runs = [
             Run(
                 run_id="run-001",


### PR DESCRIPTION
## Summary
- PR #125 introduced Python 3.10+ (`X | None` unions) and 3.11+ (`datetime.UTC`) syntax that breaks on our Python 3.9 runtime
- Replaced `datetime.UTC` → `timezone.utc` across 16 files
- Added `from __future__ import annotations` to all backend modules
- Added `eval-type-backport` dependency for Pydantic v2 on Python <3.10

## Test plan
- [x] All 336 backend tests pass
- [x] Frontend builds cleanly
- [x] FastAPI app imports without errors
- [x] Service restarted and serving requests (health check OK)
- [x] Analyze mode fixes (PRs #135-137) verified intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)