### PR TITLE
hotfix: mode gate blocks analyze/plan employees from running

### DIFF
--- a/agent/coordinator/scheduler.py
+++ b/agent/coordinator/scheduler.py
@@ -458,18 +458,9 @@ async def _run_and_monitor(
                 post_task_event(config, "task_failed", task)
                 return task.id
 
-        # --- Mode gate: analyze/plan modes must NOT proceed to implementation ---
-        if config.project_mode in ("analyze", "plan"):
-            logger.info(
-                "MODE GATE: Skipping implementation for employee %d, task '%s' "
-                "(mode=%s — implementation not permitted)",
-                employee_index, task.title, config.project_mode,
-            )
-            await dag.mark_completed(task.id, exit_code=0)
-            post_task_event(config, "task_completed", task)
-            return task.id
-
         # Start employee subprocess (with approved plan if available)
+        # Note: analyze/plan mode enforcement is handled by employee_runner.py
+        # which selects analyst.md prompt and disallows write tools.
         employee_task = asyncio.create_task(
             run_employee(task, config, employee_index, approved_plan=approved_plan)
         )

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -2345,11 +2345,8 @@ print(f'Wrote {len(assignments)} assignments')
             fi
             # ---- End plan review gate ----
 
-            # ---- Mode gate: analyze/plan modes must NOT proceed to implementation ----
-            if [ "$mode_for_project" = "analyze" ] || [ "$mode_for_project" = "plan" ]; then
-                log_info "Skipping implementation for $repo employee $ei (mode=$mode_for_project — implementation not permitted)"
-                continue
-            fi
+            # Note: analyze/plan mode enforcement is handled by prompt selection
+            # above (analyst.md / plan prompt) and disallowed tools in the CLI call.
 
             # Calculate per-employee turn budget
             local employee_turns


### PR DESCRIPTION
## Summary
- The mode gate added in PRs #135/#136 was too aggressive — it blocked ALL tasks for analyze/plan mode projects, including the analyze task itself
- Employees in analyze mode completed in 0ms without ever executing
- This is why the agent appeared stuck: it ran, "completed" instantly, then the manager reviewed an empty report

## Root Cause
`scheduler.py:462` and `run-manager.sh:2349` unconditionally skipped execution for any task in analyze/plan mode. But defense-in-depth is already correctly handled by:
- **Prompt selection**: `analyst.md` for analyze mode, plan prompt for plan mode
- **Tool restrictions**: `--disallowedTools Edit,Write,NotebookEdit` enforced at CLI level
- Both bash and Python paths enforce these independently

## Fix
Removed the redundant mode gate from both paths. Analyze/plan employees now execute with read-only restrictions enforced by prompt + tool restrictions.

## Test plan
- [x] All 336 backend tests pass
- [x] Verified bash path has `--disallowedTools` for analyze/plan (line 996-998)
- [x] Verified Python path has `disallowed_tools` for analyze/plan (employee_runner.py:569-573)
- [x] Verified prompt selection uses `analyst.md` for analyze mode in both paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)