### PR TITLE
fix: Python 3.9 compat for queue claim endpoint

### DIFF
--- a/dashboard/backend/app/routers/queue.py
+++ b/dashboard/backend/app/routers/queue.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from typing import Optional
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -209,7 +210,7 @@ async def create_queue_item(
     return QueueItemOut.model_validate(item)
 
 
-@router.post("/claim", response_model=QueueItemOut | None)
+@router.post("/claim", response_model=Optional[QueueItemOut])
 async def claim_work(
     employee_index: int = Query(...),
     run_id: str = Query(...),


### PR DESCRIPTION
## Summary
- `response_model=QueueItemOut | None` in the `/claim` endpoint uses Python 3.10+ union syntax, crashing the dashboard on Python 3.9
- Changed to `Optional[QueueItemOut]` for compatibility

## Test plan
- [x] Dashboard starts successfully on Python 3.9.25
- [x] All backend imports pass (`from app.main import app`)
- [x] `/api/queue/claim` endpoint responds correctly
- [x] All other new PR #144 endpoints verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)