### PR TITLE
feat: wire intelligence into live orchestration loop

### DIFF
--- a/agent/coordinator/__init__.py
+++ b/agent/coordinator/__init__.py
@@ -1,1 +1,7 @@
-"""Live-coordinating manager: real-time employee orchestration with task splitting."""
+"""Live-coordinating manager: real-time employee orchestration with task splitting.
+
+Submodules:
+  - decide: CLI decision gateway (select-mode, check-confidence, etc.)
+  - mode_selector: LLM-based complexity routing
+  - modes: Mode registry and escalation ladder
+"""

--- a/agent/coordinator/decide.py
+++ b/agent/coordinator/decide.py
@@ -1,0 +1,525 @@
+"""CLI decision gateway: bridges bash orchestration to Python intelligence.
+
+Usage from run-manager.sh:
+    python3 -m agent.coordinator.decide select-mode --issue-json <file> --config <file> --project-mode <mode>
+    python3 -m agent.coordinator.decide check-confidence --report-file <file> --config <file>
+    python3 -m agent.coordinator.decide check-escalation --report-file <file> --config <file> --queue-item-id <id>
+    python3 -m agent.coordinator.decide record-outcome --project-repo <repo> --issue-number <n> ...
+    python3 -m agent.coordinator.decide should-verify --report-file <file> --config <file>
+
+Each subcommand prints JSON to stdout and exits 0.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# Base URL for the dashboard API (webhook events + outcome recording)
+DASHBOARD_API = "http://127.0.0.1:8420"
+
+
+def _load_json(path: str) -> dict:
+    """Load a JSON file, returning empty dict on failure."""
+    try:
+        return json.loads(Path(path).read_text())
+    except Exception as e:
+        logger.warning("Failed to load %s: %s", path, e)
+        return {}
+
+
+def _config_get(config: dict, dotpath: str, default=None):
+    """Read a dot-separated path from a nested config dict."""
+    keys = dotpath.split(".")
+    current = config
+    for key in keys:
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            return default
+        if current is None:
+            return default
+    return current
+
+
+def _emit_event(run_id: str | None, event_type: str, event_data: dict) -> None:
+    """Fire-and-forget POST to the agent events API for audit trail."""
+    try:
+        import urllib.request
+        payload = json.dumps({
+            "workflow_id": run_id or "unknown",
+            "run_id": run_id,
+            "agent_id": "intelligence",
+            "event_type": event_type,
+            "event_data": json.dumps(event_data),
+        }).encode()
+        req = urllib.request.Request(
+            f"{DASHBOARD_API}/api/agent-events",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=3)
+    except Exception:
+        pass  # Best-effort audit, never block the decision
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: select-mode
+# ---------------------------------------------------------------------------
+
+def cmd_select_mode(args: argparse.Namespace) -> None:
+    """Select optimal mode/model/turns for an issue."""
+    issue = _load_json(args.issue_json)
+    config = _load_json(args.config) if args.config else {}
+    project_mode = args.project_mode or "full"
+
+    from agent.coordinator.mode_selector import (
+        ModeDecision,
+        default_mode_decision,
+        select_mode_from_labels,
+    )
+
+    # Check if auto mode selection is enabled
+    auto_enabled = _config_get(config, "intelligence.auto_mode_selection", False)
+    if not auto_enabled:
+        decision = default_mode_decision(project_mode)
+        _print_decision(decision, args.run_id)
+        return
+
+    # Tier 1: Label-based fast path
+    labels = issue.get("labels", [])
+    decision = select_mode_from_labels(labels)
+    if decision:
+        _emit_event(args.run_id, "intelligence.mode_selected", {
+            "mode": decision.mode,
+            "model": decision.model,
+            "max_turns": decision.max_turns,
+            "complexity_score": decision.complexity_score,
+            "source": decision.source,
+            "reasoning": decision.reasoning,
+        })
+        _print_decision(decision, args.run_id)
+        return
+
+    # Tier 2: Haiku complexity scoring
+    from agent.coordinator.mode_selector import build_complexity_prompt, parse_complexity_response
+    prompt = build_complexity_prompt(issue)
+
+    # Call Haiku via Claude CLI for complexity assessment
+    haiku_decision = _call_haiku(prompt)
+    if haiku_decision:
+        # Tier 3: Adaptive override (if enabled and enough data)
+        adaptive_enabled = _config_get(config, "intelligence.adaptive_scheduling", False)
+        if adaptive_enabled and haiku_decision.complexity_score:
+            adaptive_decision = _try_adaptive_override(
+                issue, haiku_decision, config
+            )
+            if adaptive_decision:
+                _emit_event(args.run_id, "intelligence.adaptive_override", {
+                    "haiku_mode": haiku_decision.mode,
+                    "haiku_model": haiku_decision.model,
+                    "adaptive_mode": adaptive_decision.mode,
+                    "adaptive_model": adaptive_decision.model,
+                    "sample_count": adaptive_decision.complexity_score,  # repurposed
+                    "reasoning": adaptive_decision.reasoning,
+                })
+                _emit_event(args.run_id, "intelligence.mode_selected", {
+                    "mode": adaptive_decision.mode,
+                    "model": adaptive_decision.model,
+                    "max_turns": adaptive_decision.max_turns,
+                    "complexity_score": haiku_decision.complexity_score,
+                    "source": adaptive_decision.source,
+                    "reasoning": adaptive_decision.reasoning,
+                })
+                _print_decision(adaptive_decision, args.run_id)
+                return
+
+        _emit_event(args.run_id, "intelligence.mode_selected", {
+            "mode": haiku_decision.mode,
+            "model": haiku_decision.model,
+            "max_turns": haiku_decision.max_turns,
+            "complexity_score": haiku_decision.complexity_score,
+            "source": haiku_decision.source,
+            "reasoning": haiku_decision.reasoning,
+        })
+        _print_decision(haiku_decision, args.run_id)
+        return
+
+    # Fallback to project default
+    decision = default_mode_decision(project_mode)
+    _emit_event(args.run_id, "intelligence.mode_selected", {
+        "mode": decision.mode, "model": decision.model,
+        "max_turns": decision.max_turns, "source": "default",
+        "reasoning": "Haiku assessment failed, using project default",
+    })
+    _print_decision(decision, args.run_id)
+
+
+def _call_haiku(prompt: str):
+    """Call Haiku via subprocess for complexity assessment."""
+    import subprocess
+    from agent.coordinator.mode_selector import parse_complexity_response
+
+    try:
+        result = subprocess.run(
+            ["claude", "-p", prompt, "--model", "claude-haiku-4-5-20251001",
+             "--max-turns", "1", "--no-input"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return parse_complexity_response(result.stdout)
+    except Exception as e:
+        logger.warning("Haiku call failed: %s", e)
+    return None
+
+
+def _try_adaptive_override(issue: dict, haiku_decision, config: dict):
+    """Tier 3: Check if historical data suggests a better config."""
+    from agent.coordinator.mode_selector import ModeDecision
+
+    # Determine issue type from labels
+    labels = issue.get("labels", [])
+    label_names = [
+        l.get("name", "") if isinstance(l, dict) else str(l) for l in labels
+    ]
+    issue_type = "feature"  # default
+    for name in label_names:
+        if name in ("bug", "fix", "hotfix"):
+            issue_type = "bug"
+            break
+        elif name in ("chore", "maintenance", "docs"):
+            issue_type = "chore"
+            break
+
+    try:
+        from dashboard.backend.app.services.adaptive_scheduler import predict_effort_sync
+        prediction = predict_effort_sync(
+            issue_type=issue_type,
+            complexity=haiku_decision.complexity_score,
+            db_path=_config_get(config, "dashboard.db_path")
+                    or "/var/lib/claude-agent-station/station.db",
+        )
+        if prediction and prediction.confidence > (haiku_decision.complexity_score or 3) / 5.0:
+            from agent.coordinator.modes import MODE_REGISTRY
+            spec = MODE_REGISTRY.get(prediction.mode)
+            return ModeDecision(
+                mode=prediction.mode,
+                model=prediction.model,
+                max_turns=spec.default_max_turns if spec else 100,
+                complexity_score=prediction.sample_count,
+                reasoning=f"Adaptive: {prediction.sample_count} samples, "
+                          f"{prediction.confidence:.0%} success rate",
+                source="adaptive",
+            )
+    except Exception as e:
+        logger.warning("Adaptive lookup failed: %s", e)
+
+    return None
+
+
+def _print_decision(decision, run_id: str | None = None) -> None:
+    """Print a ModeDecision as JSON to stdout."""
+    print(json.dumps({
+        "mode": decision.mode,
+        "model": decision.model,
+        "max_turns": decision.max_turns,
+        "complexity_score": decision.complexity_score,
+        "reasoning": decision.reasoning,
+        "source": decision.source,
+    }))
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: check-confidence
+# ---------------------------------------------------------------------------
+
+def cmd_check_confidence(args: argparse.Namespace) -> None:
+    """Check if an employee report passes the confidence gate for auto-PR."""
+    report = _load_json(args.report_file)
+    config = _load_json(args.config) if args.config else {}
+
+    confidence_enabled = _config_get(config, "intelligence.confidence_gating", False)
+    if not confidence_enabled:
+        print(json.dumps({"gate_passed": False, "reason": "confidence_gating disabled"}))
+        return
+
+    # Extract report data
+    confidence = float(report.get("confidence", 0))
+    tests_passed = report.get("tests_passed", False)
+    status = report.get("status", "")
+    mode = report.get("mode", "full")
+
+    # Get threshold from mode spec
+    from agent.coordinator.modes import MODE_REGISTRY
+    spec = MODE_REGISTRY.get(mode)
+    threshold = spec.confidence_threshold if spec else 0.9
+
+    gate_passed = (
+        confidence >= threshold
+        and tests_passed is True
+        and status == "success"
+    )
+
+    result = {
+        "gate_passed": gate_passed,
+        "confidence": confidence,
+        "threshold": threshold,
+        "tests_passed": tests_passed,
+        "status": status,
+        "mode": mode,
+    }
+
+    if not gate_passed:
+        reasons = []
+        if confidence < threshold:
+            reasons.append(f"confidence {confidence:.2f} < threshold {threshold:.2f}")
+        if not tests_passed:
+            reasons.append("tests not passed")
+        if status != "success":
+            reasons.append(f"status is '{status}', not 'success'")
+        result["reason"] = "; ".join(reasons)
+
+    event_type = "intelligence.confidence_gate_passed" if gate_passed else "intelligence.confidence_gate_failed"
+    _emit_event(args.run_id, event_type, result)
+
+    print(json.dumps(result))
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: check-escalation
+# ---------------------------------------------------------------------------
+
+def cmd_check_escalation(args: argparse.Namespace) -> None:
+    """Check if an employee report should trigger escalation."""
+    report = _load_json(args.report_file)
+    config = _load_json(args.config) if args.config else {}
+
+    deepening_enabled = _config_get(config, "intelligence.progressive_deepening", False)
+    if not deepening_enabled:
+        print(json.dumps({"should_escalate": False, "reason": "progressive_deepening disabled"}))
+        return
+
+    confidence = float(report.get("confidence", 0))
+    tests_passed = report.get("tests_passed", True)
+    status = report.get("status", "success")
+    mode = report.get("mode", "full")
+    current_rung = int(report.get("escalation_rung", 0))
+
+    from agent.coordinator.modes import MODE_REGISTRY, ESCALATION_LADDER, next_rung
+    spec = MODE_REGISTRY.get(mode)
+    threshold = spec.confidence_threshold if spec else 0.9
+
+    # Determine if escalation is needed
+    triggers = []
+    if confidence < threshold:
+        triggers.append(f"confidence {confidence:.2f} < threshold {threshold:.2f}")
+    if not tests_passed:
+        triggers.append("tests failed")
+    if status in ("partial", "failure", "failed"):
+        triggers.append(f"status: {status}")
+
+    should_escalate = len(triggers) > 0
+    rung_info = next_rung(current_rung)
+
+    if not rung_info:
+        should_escalate = False
+        triggers.append("already at max rung")
+
+    result = {
+        "should_escalate": should_escalate,
+        "current_rung": current_rung,
+        "triggers": triggers,
+    }
+
+    if should_escalate and rung_info:
+        result["next_rung"] = rung_info["rung"]
+        result["next_mode"] = rung_info["mode"]
+        result["next_model"] = rung_info["model"]
+        result["next_max_turns"] = rung_info["max_turns"]
+        result["next_thinking"] = rung_info["thinking"]
+        result["escalation_reason"] = "; ".join(triggers)
+
+        # Build handoff context
+        result["handoff_context"] = {
+            "previous_rung": current_rung,
+            "previous_mode": mode,
+            "previous_model": report.get("model", ""),
+            "previous_confidence": confidence,
+            "previous_branch": report.get("branch", ""),
+            "escalation_reason": "; ".join(triggers),
+            "failed_tests": report.get("failed_tests", []),
+            "context_for_next_employee": report.get("summary", ""),
+        }
+
+        _emit_event(args.run_id, "intelligence.escalation_triggered", {
+            "from_rung": current_rung,
+            "to_rung": rung_info["rung"],
+            "trigger_reason": "; ".join(triggers),
+            "queue_item_id": args.queue_item_id,
+        })
+    else:
+        result["reason"] = "; ".join(triggers) if triggers else "no triggers"
+
+    print(json.dumps(result))
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: record-outcome
+# ---------------------------------------------------------------------------
+
+def cmd_record_outcome(args: argparse.Namespace) -> None:
+    """Record a task outcome for the learning loop."""
+    success = args.verdict.upper() in ("APPROVE", "PR")
+
+    payload = {
+        "project_repo": args.project_repo,
+        "issue_number": int(args.issue_number) if args.issue_number else None,
+        "mode_used": args.mode or "full",
+        "model_used": args.model or "claude-sonnet-4-6",
+        "success": success,
+        "verdict": args.verdict,
+        "confidence_reported": float(args.confidence) if args.confidence else None,
+        "tokens_consumed": int(args.tokens) if args.tokens else None,
+        "duration_seconds": int(args.duration) if args.duration else None,
+        "complexity_score": int(args.complexity) if args.complexity else None,
+        "escalation_rung": int(args.escalation_rung) if args.escalation_rung else 0,
+    }
+
+    # POST to dashboard API
+    try:
+        import urllib.request
+        req_data = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            f"{DASHBOARD_API}/api/intelligence/outcomes",
+            data=req_data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=5)
+    except Exception as e:
+        logger.warning("Failed to record outcome: %s", e)
+
+    _emit_event(args.run_id, "intelligence.outcome_recorded", {
+        "verdict": args.verdict,
+        "confidence": args.confidence,
+        "mode": args.mode,
+        "tokens": args.tokens,
+        "success": success,
+    })
+
+    print(json.dumps({"recorded": True, **payload}))
+
+
+# ---------------------------------------------------------------------------
+# Subcommand: should-verify
+# ---------------------------------------------------------------------------
+
+def cmd_should_verify(args: argparse.Namespace) -> None:
+    """Check if independent verification is warranted."""
+    report = _load_json(args.report_file)
+    config = _load_json(args.config) if args.config else {}
+
+    verification_enabled = _config_get(config, "intelligence.independent_verification", False)
+    if not verification_enabled:
+        print(json.dumps({"should_verify": False, "reason": "independent_verification disabled"}))
+        return
+
+    # Risk criteria
+    files_changed = len(report.get("files_changed", []))
+    complexity = int(report.get("complexity_score", 0))
+    escalation_rung = int(report.get("escalation_rung", 0))
+    is_auto_pr = report.get("auto_pr", False)
+
+    should_verify = (
+        files_changed > 5
+        or escalation_rung > 0
+        or complexity >= 4
+        or is_auto_pr
+    )
+
+    reasons = []
+    if files_changed > 5:
+        reasons.append(f"cross-cutting: {files_changed} files changed")
+    if escalation_rung > 0:
+        reasons.append(f"escalated item (rung {escalation_rung})")
+    if complexity >= 4:
+        reasons.append(f"high complexity ({complexity})")
+    if is_auto_pr:
+        reasons.append("auto-PR candidate (no human in loop)")
+
+    result = {
+        "should_verify": should_verify,
+        "reasons": reasons,
+        "files_changed": files_changed,
+        "complexity": complexity,
+        "escalation_rung": escalation_rung,
+    }
+
+    print(json.dumps(result))
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="decide",
+        description="Intelligence decision gateway for agent orchestration",
+    )
+    parser.add_argument("--run-id", default=None, help="Current run ID for event correlation")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # select-mode
+    p_mode = sub.add_parser("select-mode", help="Select optimal mode/model/turns")
+    p_mode.add_argument("--issue-json", required=True, help="Path to issue JSON file")
+    p_mode.add_argument("--config", help="Path to config JSON file")
+    p_mode.add_argument("--project-mode", default="full", help="Project default mode")
+    p_mode.set_defaults(func=cmd_select_mode)
+
+    # check-confidence
+    p_conf = sub.add_parser("check-confidence", help="Check confidence gate for auto-PR")
+    p_conf.add_argument("--report-file", required=True, help="Path to employee report")
+    p_conf.add_argument("--config", help="Path to config JSON")
+    p_conf.set_defaults(func=cmd_check_confidence)
+
+    # check-escalation
+    p_esc = sub.add_parser("check-escalation", help="Check escalation triggers")
+    p_esc.add_argument("--report-file", required=True, help="Path to employee report")
+    p_esc.add_argument("--config", help="Path to config JSON")
+    p_esc.add_argument("--queue-item-id", help="Queue item ID")
+    p_esc.set_defaults(func=cmd_check_escalation)
+
+    # record-outcome
+    p_out = sub.add_parser("record-outcome", help="Record task outcome")
+    p_out.add_argument("--project-repo", required=True)
+    p_out.add_argument("--issue-number", default=None)
+    p_out.add_argument("--mode", default="full")
+    p_out.add_argument("--model", default="claude-sonnet-4-6")
+    p_out.add_argument("--verdict", required=True)
+    p_out.add_argument("--confidence", default=None)
+    p_out.add_argument("--tokens", default=None)
+    p_out.add_argument("--duration", default=None)
+    p_out.add_argument("--complexity", default=None)
+    p_out.add_argument("--escalation-rung", default="0")
+    p_out.set_defaults(func=cmd_record_outcome)
+
+    # should-verify
+    p_ver = sub.add_parser("should-verify", help="Check if verification is needed")
+    p_ver.add_argument("--report-file", required=True)
+    p_ver.add_argument("--config", help="Path to config JSON")
+    p_ver.set_defaults(func=cmd_should_verify)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/coordinator/modes.py
+++ b/agent/coordinator/modes.py
@@ -181,3 +181,21 @@ def starting_rung(complexity_score: int) -> int:
         return 1
     else:
         return 2
+
+
+def next_rung(current_rung: int) -> dict[str, str | int] | None:
+    """Return the next escalation rung config, or None if at max.
+
+    Returns dict with keys: rung, mode, model, thinking, max_turns.
+    """
+    next_idx = current_rung + 1
+    if next_idx >= len(ESCALATION_LADDER):
+        return None
+    step = ESCALATION_LADDER[next_idx]
+    return {
+        "rung": next_idx,
+        "mode": step["mode"],
+        "model": step["model"],
+        "thinking": step["thinking"],
+        "max_turns": step["max_turns"],
+    }

--- a/agent/coordinator/verifier.py
+++ b/agent/coordinator/verifier.py
@@ -1,0 +1,126 @@
+"""Independent verification: automated code review for high-risk changes.
+
+Spawns a reviewer agent (reviewer.md prompt) on the branch diff to provide
+structured feedback. Only triggered when risk criteria are met:
+  - Changes touch > 5 files (cross-cutting)
+  - Escalated items (already failed once)
+  - Complexity score >= 4
+  - Auto-PR candidates (no human in the loop otherwise)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def run_verification(
+    workspace: str,
+    branch: str,
+    base_branch: str = "main",
+    repo: str = "",
+    report_file: str = "",
+    prompt_dir: str = "",
+) -> dict:
+    """Run independent verification on a branch diff.
+
+    Returns a structured verification result:
+        {
+            "verified": bool,
+            "issues": [{"severity": "critical|warning|info", "description": "...", "file": "..."}],
+            "summary": "...",
+            "recommendation": "approve|revoke_auto_pr|needs_review",
+        }
+    """
+    # Get the diff to review
+    try:
+        diff_result = subprocess.run(
+            ["git", "-C", workspace, "diff", f"{base_branch}...{branch}"],
+            capture_output=True, text=True, timeout=30,
+        )
+        if diff_result.returncode != 0:
+            return {"verified": False, "issues": [], "summary": "Failed to get diff",
+                    "recommendation": "needs_review"}
+        diff_text = diff_result.stdout
+    except Exception as e:
+        logger.warning("Failed to get diff: %s", e)
+        return {"verified": False, "issues": [], "summary": str(e),
+                "recommendation": "needs_review"}
+
+    if not diff_text.strip():
+        return {"verified": True, "issues": [], "summary": "No changes to review",
+                "recommendation": "approve"}
+
+    # Truncate diff for reviewer context (max ~10K chars)
+    if len(diff_text) > 10000:
+        diff_text = diff_text[:10000] + "\n\n... (diff truncated, review remaining files manually)"
+
+    # Build reviewer prompt
+    reviewer_prompt = f"""Review this code diff for a pull request.
+
+Repository: {repo}
+Branch: {branch}
+Base: {base_branch}
+
+```diff
+{diff_text}
+```
+
+Analyze the diff for:
+1. Critical bugs or logic errors
+2. Security vulnerabilities (injection, auth bypass, secrets exposure)
+3. Missing error handling for failure scenarios
+4. Breaking changes to public APIs
+5. Test coverage gaps for new code paths
+
+Output JSON only:
+{{"verified": true/false, "issues": [{{"severity": "critical|warning|info", "description": "...", "file": "...", "line": null}}], "summary": "one-line summary", "recommendation": "approve|revoke_auto_pr|needs_review"}}
+
+If there are no critical issues, set verified=true and recommendation="approve".
+Only flag genuine problems, not style preferences."""
+
+    # Run reviewer via Claude CLI
+    try:
+        # Use reviewer prompt file if available, otherwise inline
+        reviewer_cmd = [
+            "claude", "-p", reviewer_prompt,
+            "--model", "claude-sonnet-4-6",
+            "--max-turns", "1",
+            "--no-input",
+        ]
+        prompt_file = Path(prompt_dir) / "reviewer.md" if prompt_dir else None
+        if prompt_file and prompt_file.exists():
+            reviewer_cmd.extend(["--system-prompt-file", str(prompt_file)])
+
+        result = subprocess.run(
+            reviewer_cmd,
+            capture_output=True, text=True, timeout=120,
+            cwd=workspace,
+        )
+
+        if result.returncode == 0 and result.stdout.strip():
+            # Parse JSON from response
+            text = result.stdout.strip()
+            start = text.find("{")
+            end = text.rfind("}") + 1
+            if start != -1 and end > 0:
+                review = json.loads(text[start:end])
+                return {
+                    "verified": review.get("verified", False),
+                    "issues": review.get("issues", []),
+                    "summary": review.get("summary", ""),
+                    "recommendation": review.get("recommendation", "needs_review"),
+                }
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse reviewer response")
+    except subprocess.TimeoutExpired:
+        logger.warning("Reviewer timed out")
+    except Exception as e:
+        logger.warning("Verification failed: %s", e)
+
+    return {"verified": False, "issues": [], "summary": "Verification process failed",
+            "recommendation": "needs_review"}

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -698,10 +698,19 @@ run_employee() {
     local repo="$1" workspace="$2" project_index="$3"
     local employee_index="${4:-0}"
     local max_turns_override="${5:-}"
+    local mode_override="${6:-}"
+    local model_override="${7:-}"
+    local turns_override="${8:-}"
+    local escalation_context_file="${9:-}"
     local name
     name=$(repo_name "$repo")
     local mode
     mode=$(get_project_field "$project_index" "mode" 2>/dev/null || echo "full")
+    # Intelligence: apply mode override from decide.py
+    if [ -n "$mode_override" ]; then
+        log_info "  Intelligence override: mode=$mode_override (was $mode)"
+        mode="$mode_override"
+    fi
     local custom_instructions
     custom_instructions=$(get_project_field "$project_index" "custom_instructions" 2>/dev/null || echo "")
 
@@ -740,6 +749,16 @@ run_employee() {
     if [ -n "$max_turns_override" ]; then
         max_turns="$max_turns_override"
         log_info "  Budget-adjusted turns: $max_turns"
+    fi
+
+    # Intelligence: apply model/turns overrides from decide.py
+    if [ -n "$model_override" ]; then
+        log_info "  Intelligence override: model=$model_override (was $model)"
+        model="$model_override"
+    fi
+    if [ -n "$turns_override" ]; then
+        log_info "  Intelligence override: turns=$turns_override (was $max_turns)"
+        max_turns="$turns_override"
     fi
 
     # Mode-specific model and turn overrides from config (with sensible defaults)
@@ -1018,6 +1037,28 @@ Remember: commit locally but NEVER push. The manager will review and push if app
             fi
         fi
         fi  # end plan_file check
+    fi
+
+    # Intelligence: append escalation context if this is an escalated run
+    if [ -n "$escalation_context_file" ] && [ -f "$escalation_context_file" ]; then
+        local esc_ctx
+        esc_ctx=$(cat "$escalation_context_file")
+        log_info "  Injecting escalation context from $escalation_context_file"
+        employee_prompt="$employee_prompt
+
+## ESCALATION_CONTEXT: Previous Attempt Failed — Building On Prior Work
+
+A previous employee attempted this task at a lower capability level and did not succeed.
+Use the context below to understand what was tried and what went wrong. Build on the
+previous work rather than starting from scratch.
+
+\`\`\`json
+$esc_ctx
+\`\`\`
+
+Focus on the areas that the previous attempt struggled with. The branch from the prior
+attempt may still exist — check if you can continue from it."
+        rm -f "$escalation_context_file"
     fi
 
     # Append custom instructions if configured for this project
@@ -1411,6 +1452,13 @@ collect_employee_reports() {
             continue
         fi
 
+        # Skip projects that passed the confidence gate (auto-PR'd)
+        if [ -f "/tmp/claude-agent-auto-pr-${RUN_ID}.list" ]; then
+            if grep -qF "$repo" "/tmp/claude-agent-auto-pr-${RUN_ID}.list" 2>/dev/null; then
+                continue
+            fi
+        fi
+
         local name
         name=$(repo_name "$repo")
         local workspace="$WORKSPACES_DIR/$name"
@@ -1716,6 +1764,31 @@ print(json.dumps(v))
         local escaped_reasoning
         escaped_reasoning=$(echo "$reasoning" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip())[1:-1])" 2>/dev/null || echo "$reasoning")
         webhook_event "verdict_execute" "\"project\":\"$project\",\"verdict\":\"$verdict\",\"issue_number\":\"$issue_number\",\"branch\":\"$branch\",\"reasoning\":\"$escaped_reasoning\""
+
+        # Intelligence: record outcome for the learning loop
+        local _report_confidence="" _report_tokens="" _report_duration="" _report_complexity="" _report_mode_used="" _report_model_used="" _report_esc_rung="0"
+        if [ -f "$workspace/.claude-employee-report.json" ]; then
+            _report_confidence=$(python3 -c "import json; print(json.load(open('$workspace/.claude-employee-report.json')).get('confidence',''))" 2>/dev/null || echo "")
+            _report_tokens=$(python3 -c "import json; print(json.load(open('$workspace/.claude-employee-report.json')).get('tokens_total',''))" 2>/dev/null || echo "")
+            _report_duration=$(python3 -c "import json; print(json.load(open('$workspace/.claude-employee-report.json')).get('duration_seconds',''))" 2>/dev/null || echo "")
+            _report_complexity=$(python3 -c "import json; print(json.load(open('$workspace/.claude-employee-report.json')).get('complexity_score',''))" 2>/dev/null || echo "")
+            _report_mode_used=$(python3 -c "import json; print(json.load(open('$workspace/.claude-employee-report.json')).get('mode',''))" 2>/dev/null || echo "")
+            _report_model_used=$(python3 -c "import json; print(json.load(open('$workspace/.claude-employee-report.json')).get('model',''))" 2>/dev/null || echo "")
+            _report_esc_rung=$(python3 -c "import json; print(json.load(open('$workspace/.claude-employee-report.json')).get('escalation_rung',0))" 2>/dev/null || echo "0")
+        fi
+        python3 -m agent.coordinator.decide --run-id "$RUN_ID" \
+            record-outcome \
+            --project-repo "$project" \
+            --issue-number "${issue_number:-}" \
+            --mode "${_report_mode_used:-${verdict_mode:-full}}" \
+            --model "${_report_model_used:-}" \
+            --verdict "$verdict" \
+            --confidence "${_report_confidence:-}" \
+            --tokens "${_report_tokens:-}" \
+            --duration "${_report_duration:-}" \
+            --complexity "${_report_complexity:-}" \
+            --escalation-rung "${_report_esc_rung:-0}" \
+            >/dev/null 2>&1 &
 
         if [ ! -d "$workspace/.git" ]; then
             log_error "Workspace not found: $workspace"
@@ -2394,18 +2467,50 @@ print(f'Wrote {len(assignments)} assignments')
             local employee_turns
             employee_turns=$(calculate_employee_budget "$total_employees" "$priority")
 
+            # Intelligence: per-issue mode selection via decide.py
+            local intel_mode="" intel_model="" intel_turns="" intel_esc_file=""
+            local auto_mode_enabled
+            auto_mode_enabled=$(json_get "$CONFIG_FILE" "intelligence.auto_mode_selection" 2>/dev/null || echo "false")
+            if [ "$auto_mode_enabled" = "true" ]; then
+                # Find issue JSON for this employee (from assignment or workspace)
+                local issue_json_file="$workspace/.claude-assignment-${ei}.json"
+                if [ ! -f "$issue_json_file" ]; then
+                    issue_json_file="$workspace/.claude-issue.json"
+                fi
+                if [ -f "$issue_json_file" ]; then
+                    local decide_result
+                    decide_result=$(python3 -m agent.coordinator.decide --run-id "$RUN_ID" \
+                        select-mode --issue-json "$issue_json_file" \
+                        --config "$CONFIG_FILE" --project-mode "$mode_for_project" 2>/dev/null || echo "")
+                    if [ -n "$decide_result" ]; then
+                        intel_mode=$(echo "$decide_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('mode',''))" 2>/dev/null || echo "")
+                        intel_model=$(echo "$decide_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('model',''))" 2>/dev/null || echo "")
+                        intel_turns=$(echo "$decide_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('max_turns',''))" 2>/dev/null || echo "")
+                        local intel_score
+                        intel_score=$(echo "$decide_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('complexity_score',''))" 2>/dev/null || echo "")
+                        log_info "  Intelligence decision: mode=$intel_mode model=$intel_model turns=$intel_turns complexity=$intel_score"
+                        # Update queue item with complexity score and mode
+                        local _iqid
+                        _iqid=$(queue_find_item "$repo" "$ei")
+                        if [ -n "$_iqid" ] && [ -n "$intel_score" ]; then
+                            queue_api PUT "/api/queue/$_iqid" "{\"mode\":\"$intel_mode\",\"complexity_score\":$intel_score}" >/dev/null 2>&1 &
+                        fi
+                    fi
+                fi
+            fi
+
             if [ "$is_parallel" = true ]; then
                 # Parallel mode: wait for a slot, then spawn in background
                 wait_for_slot "$max_concurrent"
 
                 log_info "  Spawning employee $ei for $repo in background (budget: $employee_turns turns)"
-                run_employee "$repo" "$workspace" "$i" "$ei" "$employee_turns" &
+                run_employee "$repo" "$workspace" "$i" "$ei" "$employee_turns" "$intel_mode" "$intel_model" "$intel_turns" "$intel_esc_file" &
                 CHILD_PIDS+=($!)
                 has_work=true
             else
                 # Sequential mode (backward compatible): run blocking
                 log_info "  Running employee $ei for $repo sequentially (budget: $employee_turns turns)"
-                run_employee "$repo" "$workspace" "$i" "$ei" "$employee_turns"
+                run_employee "$repo" "$workspace" "$i" "$ei" "$employee_turns" "$intel_mode" "$intel_model" "$intel_turns" "$intel_esc_file"
                 has_work=true
 
                 # Pause between employees in sequential mode
@@ -2463,6 +2568,171 @@ print(f'Wrote {len(assignments)} assignments')
         rm -f "$main_ws_wt"/.claude-plan-feedback-*.json 2>/dev/null || true
         # Note: .claude-approved-plan-*.json is cleaned up AFTER manager review (needed for cross-reference)
     done
+
+    # ---- PHASE 1.7: Intelligence — Confidence Gate + Escalation ----
+    # For each employee report, check if it passes the confidence gate (auto-PR)
+    # or needs escalation (progressive deepening). Reports that pass the gate
+    # are excluded from manager review.
+    local -a auto_pr_projects=()  # Projects that passed confidence gate
+
+    for ((i = 0; i < project_count; i++)); do
+        local repo_cg enabled_cg
+        repo_cg=$(get_project_field "$i" "repo")
+        enabled_cg=$(get_project_field "$i" "enabled" 2>/dev/null || echo "true")
+        [ "$enabled_cg" = "false" ] && continue
+
+        local name_cg
+        name_cg=$(repo_name "$repo_cg")
+        local ws_cg="$WORKSPACES_DIR/$name_cg"
+
+        # Check main report and indexed reports
+        for report_cg in "$ws_cg"/.claude-employee-report*.json; do
+            [ -f "$report_cg" ] || continue
+
+            # --- Confidence gate: auto-PR for high-confidence work ---
+            local conf_result
+            conf_result=$(python3 -m agent.coordinator.decide --run-id "$RUN_ID" \
+                check-confidence --report-file "$report_cg" --config "$CONFIG_FILE" 2>/dev/null || echo "")
+            if [ -n "$conf_result" ]; then
+                local gate_passed
+                gate_passed=$(echo "$conf_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('gate_passed',False))" 2>/dev/null || echo "False")
+                if [ "$gate_passed" = "True" ]; then
+                    local conf_branch conf_issue conf_confidence
+                    conf_branch=$(python3 -c "import json; print(json.load(open('$report_cg')).get('branch',''))" 2>/dev/null || echo "")
+                    conf_issue=$(python3 -c "import json; print(json.load(open('$report_cg')).get('issue_number',''))" 2>/dev/null || echo "")
+                    conf_confidence=$(echo "$conf_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('confidence',0))" 2>/dev/null || echo "0")
+
+                    if [ -n "$conf_branch" ] && [ "$conf_branch" != "main" ]; then
+                        log_info "  Confidence gate PASSED for $repo_cg (confidence=$conf_confidence)"
+                        cd "$ws_cg"
+
+                        # Push and create PR with [auto-pr] tag
+                        if git push origin "$conf_branch" 2>/dev/null; then
+                            local pr_url
+                            pr_url=$(gh pr create --repo "$repo_cg" --head "$conf_branch" \
+                                --title "[auto-pr] Issue #${conf_issue}" \
+                                --body "## Auto-PR (Confidence Gate)
+
+Confidence: **${conf_confidence}** (above threshold)
+Tests: Passed
+Mode: $(python3 -c "import json; print(json.load(open('$report_cg')).get('mode',''))" 2>/dev/null || echo "unknown")
+
+This PR was auto-created because the employee's work passed the confidence gate.
+Human review is still required for merge.
+
+---
+Run: $RUN_ID | \`[auto-pr]\`" 2>/dev/null || echo "")
+                            if [ -n "$pr_url" ]; then
+                                log_ok "  Auto-PR created: $pr_url"
+                                webhook_event "intelligence.confidence_gate_passed" "\"project\":\"$repo_cg\",\"confidence\":$conf_confidence,\"branch\":\"$conf_branch\",\"pr_url\":\"$pr_url\""
+                                auto_pr_projects+=("$repo_cg")
+                            fi
+                        else
+                            log_warn "  Failed to push $conf_branch for auto-PR"
+                        fi
+                    fi
+                fi
+            fi
+
+            # --- Escalation: progressive deepening for low-confidence work ---
+            local esc_result
+            esc_result=$(python3 -m agent.coordinator.decide --run-id "$RUN_ID" \
+                check-escalation --report-file "$report_cg" --config "$CONFIG_FILE" 2>/dev/null || echo "")
+            if [ -n "$esc_result" ]; then
+                local should_escalate
+                should_escalate=$(echo "$esc_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('should_escalate',False))" 2>/dev/null || echo "False")
+                if [ "$should_escalate" = "True" ]; then
+                    local esc_mode esc_model esc_turns esc_rung
+                    esc_mode=$(echo "$esc_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('next_mode',''))" 2>/dev/null || echo "")
+                    esc_model=$(echo "$esc_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('next_model',''))" 2>/dev/null || echo "")
+                    esc_turns=$(echo "$esc_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('next_max_turns',''))" 2>/dev/null || echo "")
+                    esc_rung=$(echo "$esc_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('next_rung',''))" 2>/dev/null || echo "")
+
+                    log_info "  ESCALATION triggered for $repo_cg: rung $esc_rung, mode=$esc_mode, model=$esc_model"
+
+                    # Write handoff context file for the escalated employee
+                    local esc_ctx_file="$ws_cg/.claude-escalation-context.json"
+                    echo "$esc_result" | python3 -c "import json,sys; json.dump(json.load(sys.stdin).get('handoff_context',{}), open('$esc_ctx_file','w'), indent=2)" 2>/dev/null
+
+                    # Re-run employee immediately with escalated config
+                    log_info "  Re-running employee with escalated config (rung $esc_rung)"
+                    run_employee "$repo_cg" "$ws_cg" "$i" "0" "$esc_turns" "$esc_mode" "$esc_model" "$esc_turns" "$esc_ctx_file"
+                    has_work=true
+
+                    # Skip this project from manager review — the escalated run will be reviewed
+                    auto_pr_projects+=("$repo_cg")
+                fi
+            fi
+        done
+    done
+
+    # ---- PHASE 1.8: Intelligence — Independent Verification ----
+    # For auto-PR candidates and high-risk changes, run an independent reviewer.
+    # If the reviewer flags critical issues, revoke the auto-PR and send to manager.
+    local verification_enabled
+    verification_enabled=$(json_get "$CONFIG_FILE" "intelligence.independent_verification" 2>/dev/null || echo "false")
+    if [ "$verification_enabled" = "true" ]; then
+        local -a verified_revokes=()
+        for ((i = 0; i < project_count; i++)); do
+            local repo_vf
+            repo_vf=$(get_project_field "$i" "repo")
+            local name_vf
+            name_vf=$(repo_name "$repo_vf")
+            local ws_vf="$WORKSPACES_DIR/$name_vf"
+
+            for report_vf in "$ws_vf"/.claude-employee-report*.json; do
+                [ -f "$report_vf" ] || continue
+
+                local verify_result
+                verify_result=$(python3 -m agent.coordinator.decide --run-id "$RUN_ID" \
+                    should-verify --report-file "$report_vf" --config "$CONFIG_FILE" 2>/dev/null || echo "")
+                if [ -n "$verify_result" ]; then
+                    local should_verify
+                    should_verify=$(echo "$verify_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('should_verify',False))" 2>/dev/null || echo "False")
+                    if [ "$should_verify" = "True" ]; then
+                        local vf_branch
+                        vf_branch=$(python3 -c "import json; print(json.load(open('$report_vf')).get('branch',''))" 2>/dev/null || echo "")
+                        log_info "  Running independent verification for $repo_vf ($vf_branch)"
+
+                        # Run the verifier
+                        local vf_result
+                        vf_result=$(python3 -c "
+import json
+from agent.coordinator.verifier import run_verification
+result = run_verification('$ws_vf', '$vf_branch', 'main', '$repo_vf')
+print(json.dumps(result))
+" 2>/dev/null || echo "")
+
+                        if [ -n "$vf_result" ]; then
+                            local vf_recommendation
+                            vf_recommendation=$(echo "$vf_result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('recommendation','needs_review'))" 2>/dev/null || echo "needs_review")
+                            if [ "$vf_recommendation" = "revoke_auto_pr" ]; then
+                                log_warn "  Verification REVOKED auto-PR for $repo_vf"
+                                verified_revokes+=("$repo_vf")
+                            else
+                                log_info "  Verification result: $vf_recommendation"
+                            fi
+                        fi
+                    fi
+                fi
+            done
+        done
+
+        # Remove revoked projects from auto-PR list
+        for revoked in "${verified_revokes[@]}"; do
+            local -a new_auto_pr=()
+            for ap in "${auto_pr_projects[@]}"; do
+                [ "$ap" != "$revoked" ] && new_auto_pr+=("$ap")
+            done
+            auto_pr_projects=("${new_auto_pr[@]}")
+        done
+    fi
+
+    # Write auto-PR project list for collect_employee_reports to skip
+    if [ ${#auto_pr_projects[@]} -gt 0 ]; then
+        printf '%s\n' "${auto_pr_projects[@]}" > "/tmp/claude-agent-auto-pr-${RUN_ID}.list"
+        log_info "Auto-PR/escalated projects (skipping manager review): ${auto_pr_projects[*]}"
+    fi
 
     # ---- PHASE 2: Manager review ----
 

--- a/dashboard/backend/app/main.py
+++ b/dashboard/backend/app/main.py
@@ -24,6 +24,7 @@ from app.routers import (
     events,
     github_webhook,
     health,
+    intelligence,
     logs,
     oauth,
     plan_usage,
@@ -163,6 +164,7 @@ app.include_router(plan_usage.router, dependencies=_auth)
 app.include_router(prompts.router, dependencies=_auth)
 app.include_router(queue.router, dependencies=_auth)
 app.include_router(agent_events.router, dependencies=_auth)
+app.include_router(intelligence.router, dependencies=_auth)
 
 # GitHub webhook: has own auth via HMAC signature verification
 app.include_router(github_webhook.router)

--- a/dashboard/backend/app/routers/intelligence.py
+++ b/dashboard/backend/app/routers/intelligence.py
@@ -1,0 +1,215 @@
+"""Intelligence API: insights, outcomes, and decision data."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_db
+from app.models import AgentEvent, TaskOutcome
+from app.schemas import TaskOutcomeCreate, TaskOutcomeOut
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/intelligence", tags=["intelligence"])
+
+
+@router.get("/insights")
+async def get_insights(db: AsyncSession = Depends(get_db)):
+    """Return intelligence learning loop insights.
+
+    Includes:
+    - Success rates by mode/model combination
+    - Confidence calibration (reported vs actual)
+    - Token efficiency trends
+    - Sample counts
+    """
+    # Success rates by mode/model
+    mode_result = await db.execute(
+        text("""
+            SELECT mode_used, model_used,
+                   COUNT(*) as total,
+                   SUM(CASE WHEN success THEN 1 ELSE 0 END) as successes,
+                   AVG(CASE WHEN success THEN 1.0 ELSE 0.0 END) as success_rate,
+                   AVG(tokens_consumed) as avg_tokens,
+                   AVG(duration_seconds) as avg_duration
+            FROM task_outcomes
+            GROUP BY mode_used, model_used
+            ORDER BY total DESC
+        """)
+    )
+    success_rates = [
+        {
+            "mode": row.mode_used,
+            "model": row.model_used,
+            "total": row.total,
+            "successes": row.successes,
+            "success_rate": round(row.success_rate, 3) if row.success_rate else 0,
+            "avg_tokens": int(row.avg_tokens) if row.avg_tokens else None,
+            "avg_duration": int(row.avg_duration) if row.avg_duration else None,
+        }
+        for row in mode_result.all()
+    ]
+
+    # Confidence calibration: compare reported confidence vs actual success
+    cal_result = await db.execute(
+        text("""
+            SELECT
+                CASE
+                    WHEN confidence_reported < 0.5 THEN '0.0-0.5'
+                    WHEN confidence_reported < 0.7 THEN '0.5-0.7'
+                    WHEN confidence_reported < 0.85 THEN '0.7-0.85'
+                    WHEN confidence_reported < 0.95 THEN '0.85-0.95'
+                    ELSE '0.95-1.0'
+                END as confidence_bucket,
+                COUNT(*) as total,
+                AVG(CASE WHEN success THEN 1.0 ELSE 0.0 END) as actual_success_rate,
+                AVG(confidence_reported) as avg_reported_confidence
+            FROM task_outcomes
+            WHERE confidence_reported IS NOT NULL
+            GROUP BY confidence_bucket
+            ORDER BY avg_reported_confidence
+        """)
+    )
+    calibration = [
+        {
+            "bucket": row.confidence_bucket,
+            "total": row.total,
+            "actual_success_rate": round(row.actual_success_rate, 3),
+            "avg_reported_confidence": round(row.avg_reported_confidence, 3),
+        }
+        for row in cal_result.all()
+    ]
+
+    # Token efficiency: avg tokens per success by mode
+    eff_result = await db.execute(
+        text("""
+            SELECT mode_used,
+                   AVG(CASE WHEN success THEN tokens_consumed END) as avg_tokens_success,
+                   AVG(CASE WHEN NOT success THEN tokens_consumed END) as avg_tokens_failure,
+                   COUNT(*) as total
+            FROM task_outcomes
+            WHERE tokens_consumed IS NOT NULL
+            GROUP BY mode_used
+            ORDER BY total DESC
+        """)
+    )
+    token_efficiency = [
+        {
+            "mode": row.mode_used,
+            "avg_tokens_success": int(row.avg_tokens_success) if row.avg_tokens_success else None,
+            "avg_tokens_failure": int(row.avg_tokens_failure) if row.avg_tokens_failure else None,
+            "total": row.total,
+        }
+        for row in eff_result.all()
+    ]
+
+    # Escalation stats
+    esc_result = await db.execute(
+        text("""
+            SELECT escalation_rung,
+                   COUNT(*) as total,
+                   AVG(CASE WHEN success THEN 1.0 ELSE 0.0 END) as success_rate
+            FROM task_outcomes
+            GROUP BY escalation_rung
+            ORDER BY escalation_rung
+        """)
+    )
+    escalation_stats = [
+        {
+            "rung": row.escalation_rung,
+            "total": row.total,
+            "success_rate": round(row.success_rate, 3),
+        }
+        for row in esc_result.all()
+    ]
+
+    # Total sample count
+    total_result = await db.execute(
+        select(func.count(TaskOutcome.id))
+    )
+    total_samples = total_result.scalar() or 0
+
+    # Recent intelligence events count
+    intel_events_result = await db.execute(
+        select(func.count(AgentEvent.event_id)).where(
+            AgentEvent.event_type.like("intelligence.%")
+        )
+    )
+    intel_event_count = intel_events_result.scalar() or 0
+
+    return {
+        "success_rates": success_rates,
+        "calibration": calibration,
+        "token_efficiency": token_efficiency,
+        "escalation_stats": escalation_stats,
+        "total_samples": total_samples,
+        "intelligence_event_count": intel_event_count,
+    }
+
+
+@router.post("/outcomes", status_code=201, response_model=TaskOutcomeOut)
+async def record_outcome(
+    data: TaskOutcomeCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    """Record a task outcome for the learning loop."""
+    outcome = TaskOutcome(
+        queue_item_id=data.queue_item_id,
+        project_repo=data.project_repo,
+        issue_number=data.issue_number,
+        issue_type=data.issue_type,
+        complexity_score=data.complexity_score,
+        mode_used=data.mode_used,
+        model_used=data.model_used,
+        escalation_rung=data.escalation_rung,
+        prompt_version=data.prompt_version,
+        confidence_reported=data.confidence_reported,
+        success=data.success,
+        tests_passed=data.tests_passed,
+        verdict=data.verdict,
+        failure_category=data.failure_category,
+        tokens_consumed=data.tokens_consumed,
+        duration_seconds=data.duration_seconds,
+    )
+    db.add(outcome)
+    await db.commit()
+    await db.refresh(outcome)
+
+    logger.info(
+        "Outcome recorded: %s mode=%s verdict=%s success=%s",
+        data.project_repo, data.mode_used, data.verdict, data.success,
+    )
+    return TaskOutcomeOut.model_validate(outcome)
+
+
+@router.get("/decisions")
+async def list_intelligence_decisions(
+    run_id: str | None = None,
+    limit: int = 50,
+    db: AsyncSession = Depends(get_db),
+):
+    """List recent intelligence decisions (filtered agent events)."""
+    q = select(AgentEvent).where(
+        AgentEvent.event_type.like("intelligence.%")
+    )
+    if run_id:
+        q = q.where(AgentEvent.run_id == run_id)
+    q = q.order_by(AgentEvent.created_at.desc()).limit(limit)
+
+    result = await db.execute(q)
+    events = result.scalars().all()
+    return [
+        {
+            "event_id": e.event_id,
+            "workflow_id": e.workflow_id,
+            "run_id": e.run_id,
+            "event_type": e.event_type,
+            "event_data": e.event_data,
+            "created_at": e.created_at.isoformat() if e.created_at else None,
+        }
+        for e in events
+    ]

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -13,9 +13,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.dependencies import get_db
-from app.models import CoordinatorMessage, CoordinatorTask, Plan, Project, QueueItem, Run
+from app.models import AgentEvent, CoordinatorMessage, CoordinatorTask, Plan, Project, QueueItem, Run
 from app.schemas import (
     ActiveEmployeeOut,
+    AgentEventOut,
     CoordinatorMessageOut,
     CoordinatorTaskOut,
     PlanOut,
@@ -164,6 +165,15 @@ async def get_run_full_context(run_id: str, db: AsyncSession = Depends(get_db)):
         if project:
             project_repo = project.repo
 
+    # 7. Fetch intelligence decisions (agent events with intelligence.* type)
+    intel_result = await db.execute(
+        select(AgentEvent)
+        .where(AgentEvent.run_id == run_id)
+        .where(AgentEvent.event_type.like("intelligence.%"))
+        .order_by(AgentEvent.created_at.asc())
+    )
+    intel_events = intel_result.scalars().all()
+
     return RunFullContext(
         run=RunOut.model_validate(run),
         coordinator_tasks=[CoordinatorTaskOut.model_validate(t) for t in tasks],
@@ -171,6 +181,7 @@ async def get_run_full_context(run_id: str, db: AsyncSession = Depends(get_db)):
         queue_item=QueueItemOut.model_validate(queue_item) if queue_item else None,
         plan=PlanOut.model_validate(plan) if plan else None,
         project_repo=project_repo,
+        intelligence_decisions=[AgentEventOut.model_validate(e) for e in intel_events],
     )
 
 

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -427,7 +427,7 @@ class AnalyticsResponse(BaseModel):
 # --- Unified Run Context ---
 
 class RunFullContext(BaseModel):
-    """Unified run context: run + coordinator tasks + queue item + plan.
+    """Unified run context: run + coordinator tasks + queue item + plan + intelligence.
 
     Powers the unified Run Detail view (AC2) by returning all related
     data in a single response instead of requiring 4+ separate API calls.
@@ -438,6 +438,7 @@ class RunFullContext(BaseModel):
     queue_item: QueueItemOut | None = None
     plan: PlanOut | None = None
     project_repo: str | None = None
+    intelligence_decisions: list[AgentEventOut] = []
 
 
 # --- Agent Events ---

--- a/dashboard/backend/app/services/adaptive_scheduler.py
+++ b/dashboard/backend/app/services/adaptive_scheduler.py
@@ -64,6 +64,54 @@ async def predict_effort(
     )
 
 
+def predict_effort_sync(
+    issue_type: str,
+    complexity: int,
+    db_path: str = "/var/lib/claude-agent-station/station.db",
+) -> EffortPrediction | None:
+    """Synchronous version of predict_effort for CLI use (no async).
+
+    Uses plain sqlite3 instead of SQLAlchemy async session.
+    """
+    import sqlite3
+    try:
+        conn = sqlite3.connect(db_path, timeout=5)
+        conn.row_factory = sqlite3.Row
+        cursor = conn.execute(
+            """
+            SELECT mode_used, model_used,
+                   AVG(CASE WHEN success THEN 1.0 ELSE 0.0 END) as success_rate,
+                   AVG(tokens_consumed) as avg_tokens,
+                   AVG(duration_seconds) as avg_duration,
+                   COUNT(*) as sample_count
+            FROM task_outcomes
+            WHERE issue_type = ? AND complexity_score = ?
+            GROUP BY mode_used, model_used
+            HAVING COUNT(*) >= ?
+            ORDER BY success_rate DESC, avg_tokens ASC
+            LIMIT 1
+            """,
+            (issue_type, complexity, MIN_SAMPLES),
+        )
+        row = cursor.fetchone()
+        conn.close()
+
+        if not row or row["success_rate"] < 0.7:
+            return None
+
+        return EffortPrediction(
+            mode=row["mode_used"],
+            model=row["model_used"],
+            predicted_tokens=row["avg_tokens"],
+            predicted_duration=row["avg_duration"],
+            confidence=row["success_rate"],
+            sample_count=row["sample_count"],
+        )
+    except Exception as e:
+        logger.warning("predict_effort_sync failed: %s", e)
+        return None
+
+
 async def get_project_success_rates(
     project_repo: str,
     db: AsyncSession,

--- a/dashboard/frontend/src/components/ConfidenceCalibration.svelte
+++ b/dashboard/frontend/src/components/ConfidenceCalibration.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { ConfidenceBucket } from '../lib/types';
+  import GlassCard from './GlassCard.svelte';
+
+  interface Props {
+    data: ConfidenceBucket[];
+  }
+
+  let { data }: Props = $props();
+
+  // Perfect calibration line: reported confidence === actual success rate
+  // If actual > reported, the model is underconfident (good)
+  // If actual < reported, the model is overconfident (bad)
+</script>
+
+<GlassCard class="p-3">
+  <h4 class="text-xs font-medium text-text mb-2">Confidence Calibration</h4>
+  <div class="space-y-1.5">
+    {#each data as bucket}
+      {@const gap = bucket.actual_success_rate - bucket.avg_reported_confidence}
+      <div class="flex items-center gap-2 text-[11px]">
+        <span class="text-text-dim w-[55px] text-right font-data">{bucket.bucket}</span>
+        <div class="flex-1 flex items-center gap-1">
+          <!-- Reported confidence bar (dim) -->
+          <div class="relative w-full h-3 bg-white/[0.03] rounded overflow-hidden">
+            <div
+              class="absolute inset-y-0 left-0 bg-info/20 rounded"
+              style="width: {bucket.avg_reported_confidence * 100}%"
+            ></div>
+            <!-- Actual success bar (bright, overlaid) -->
+            <div
+              class="absolute inset-y-0 left-0 rounded {gap >= 0 ? 'bg-approve/40' : 'bg-reject/40'}"
+              style="width: {bucket.actual_success_rate * 100}%"
+            ></div>
+          </div>
+        </div>
+        <span class="font-data w-[32px] text-right {gap >= 0 ? 'text-approve' : 'text-reject'}">
+          {(bucket.actual_success_rate * 100).toFixed(0)}%
+        </span>
+        <span class="text-text-muted font-data w-[20px] text-right">{bucket.total}</span>
+      </div>
+    {/each}
+  </div>
+  <div class="flex justify-between text-[9px] text-text-muted mt-1.5">
+    <span>Reported confidence</span>
+    <span>Actual success | n</span>
+  </div>
+</GlassCard>

--- a/dashboard/frontend/src/components/EscalationTimeline.svelte
+++ b/dashboard/frontend/src/components/EscalationTimeline.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import type { EscalationStat } from '../lib/types';
+  import GlassCard from './GlassCard.svelte';
+
+  interface Props {
+    data: EscalationStat[];
+  }
+
+  let { data }: Props = $props();
+
+  const rungLabels: Record<number, string> = {
+    0: 'Fix (Sonnet)',
+    1: 'Full (Sonnet+)',
+    2: 'Full (Opus)',
+    3: 'Full (Opus+)',
+  };
+</script>
+
+<GlassCard class="p-3">
+  <h4 class="text-xs font-medium text-text mb-2">Escalation Ladder</h4>
+  <div class="flex items-end gap-1">
+    {#each data as stat, idx}
+      <div class="flex-1 flex flex-col items-center gap-1">
+        <!-- Bar -->
+        <div class="w-full flex flex-col items-center">
+          <span class="text-[10px] font-data {stat.success_rate >= 0.7 ? 'text-approve' : stat.success_rate >= 0.4 ? 'text-warning' : 'text-reject'}">
+            {(stat.success_rate * 100).toFixed(0)}%
+          </span>
+          <div
+            class="w-full rounded-t transition-all {
+              stat.success_rate >= 0.7 ? 'bg-approve/30' : stat.success_rate >= 0.4 ? 'bg-warning/30' : 'bg-reject/30'
+            }"
+            style="height: {Math.max(stat.success_rate * 60, 4)}px"
+          ></div>
+        </div>
+        <!-- Connector line -->
+        {#if idx < data.length - 1}
+          <div class="absolute"></div>
+        {/if}
+        <!-- Rung label -->
+        <div class="text-center">
+          <div class="text-[10px] font-data text-text-dim">{stat.total}</div>
+          <div class="text-[9px] text-text-muted truncate max-w-[60px]">{rungLabels[stat.rung] ?? `Rung ${stat.rung}`}</div>
+        </div>
+      </div>
+    {/each}
+  </div>
+</GlassCard>

--- a/dashboard/frontend/src/components/IntelligencePanel.svelte
+++ b/dashboard/frontend/src/components/IntelligencePanel.svelte
@@ -1,0 +1,189 @@
+<script lang="ts">
+  import { getIntelligenceInsights, getIntelligenceDecisions, getBackpressure } from '../lib/api';
+  import type { IntelligenceInsights, IntelligenceDecision, BackpressureStatus } from '../lib/types';
+  import GlassCard from './GlassCard.svelte';
+  import EscalationTimeline from './EscalationTimeline.svelte';
+  import ConfidenceCalibration from './ConfidenceCalibration.svelte';
+
+  let insights = $state<IntelligenceInsights | null>(null);
+  let decisions = $state<IntelligenceDecision[]>([]);
+  let pressure = $state<BackpressureStatus | null>(null);
+  let expanded = $state(false);
+  let loading = $state(false);
+
+  async function loadData() {
+    loading = true;
+    try {
+      const [insightsRes, decisionsRes, pressureRes] = await Promise.allSettled([
+        getIntelligenceInsights(),
+        getIntelligenceDecisions({ limit: 10 }),
+        getBackpressure(),
+      ]);
+      if (insightsRes.status === 'fulfilled') insights = insightsRes.value;
+      if (decisionsRes.status === 'fulfilled') decisions = decisionsRes.value;
+      if (pressureRes.status === 'fulfilled') pressure = pressureRes.value;
+    } catch { /* silent */ }
+    finally { loading = false; }
+  }
+
+  function toggle() {
+    expanded = !expanded;
+    if (expanded && !insights) loadData();
+  }
+
+  function pressureColor(level: string): string {
+    switch (level) {
+      case 'GREEN': return 'text-approve';
+      case 'YELLOW': return 'text-warning';
+      case 'RED': return 'text-reject';
+      case 'BLACK': return 'text-reject animate-pulse';
+      default: return 'text-text-dim';
+    }
+  }
+
+  function eventTypeLabel(type: string): string {
+    const labels: Record<string, string> = {
+      'intelligence.mode_selected': 'Mode Selected',
+      'intelligence.confidence_gate_passed': 'Auto-PR Approved',
+      'intelligence.confidence_gate_failed': 'Gate Failed',
+      'intelligence.escalation_triggered': 'Escalation',
+      'intelligence.adaptive_override': 'Adaptive Override',
+      'intelligence.outcome_recorded': 'Outcome',
+    };
+    return labels[type] || type.replace('intelligence.', '');
+  }
+
+  function parseEventData(data: string): Record<string, unknown> {
+    try { return JSON.parse(data); }
+    catch { return {}; }
+  }
+
+  $effect(() => {
+    if (expanded) {
+      loadData();
+      const interval = setInterval(loadData, 30000);
+      return () => clearInterval(interval);
+    }
+  });
+</script>
+
+<div>
+  <button
+    onclick={toggle}
+    class="w-full text-left text-xs text-text-dim hover:text-text cursor-pointer flex items-center gap-1.5 py-1"
+  >
+    <span class="text-[10px]">{expanded ? '▾' : '▸'}</span>
+    Intelligence
+    {#if insights}
+      <span class="text-text-muted">({insights.total_samples} samples)</span>
+    {/if}
+    {#if pressure}
+      <span class="ml-auto {pressureColor(pressure.level)} text-[10px] font-data">{pressure.level}</span>
+    {/if}
+  </button>
+
+  {#if expanded}
+    <div class="space-y-3 mt-2 animate-fade-in-up">
+      <!-- Backpressure Gauge -->
+      {#if pressure}
+        <GlassCard class="p-3">
+          <div class="flex items-center justify-between mb-2">
+            <span class="text-xs font-medium text-text">Backpressure</span>
+            <span class="text-xs font-data {pressureColor(pressure.level)}">{pressure.level}</span>
+          </div>
+          <div class="w-full h-1.5 bg-white/[0.05] rounded-full overflow-hidden">
+            <div
+              class="h-full rounded-full transition-all duration-500 {
+                pressure.level === 'GREEN' ? 'bg-approve' :
+                pressure.level === 'YELLOW' ? 'bg-warning' : 'bg-reject'
+              }"
+              style="width: {Math.min(pressure.usage_percent, 100)}%"
+            ></div>
+          </div>
+          <div class="flex justify-between text-[10px] text-text-muted mt-1 font-data">
+            <span>{Math.round(pressure.usage_percent)}% usage</span>
+            <span>{pressure.effective_concurrent}/{pressure.max_concurrent} concurrent</span>
+          </div>
+        </GlassCard>
+      {/if}
+
+      <!-- Success Rates by Mode -->
+      {#if insights && insights.success_rates.length > 0}
+        <GlassCard class="p-3">
+          <h4 class="text-xs font-medium text-text mb-2">Success Rate by Mode</h4>
+          <div class="space-y-1.5">
+            {#each insights.success_rates as rate}
+              <div class="flex items-center justify-between text-[11px]">
+                <div class="flex items-center gap-1.5">
+                  <span class="px-1.5 py-0.5 rounded text-[10px] bg-info/15 text-info">{rate.mode}</span>
+                  <span class="text-text-muted truncate max-w-[120px]">{rate.model.split('-').slice(-2).join('-')}</span>
+                </div>
+                <div class="flex items-center gap-2 font-data">
+                  <span class="{rate.success_rate >= 0.7 ? 'text-approve' : rate.success_rate >= 0.4 ? 'text-warning' : 'text-reject'}">
+                    {(rate.success_rate * 100).toFixed(0)}%
+                  </span>
+                  <span class="text-text-muted">{rate.total} runs</span>
+                </div>
+              </div>
+            {/each}
+          </div>
+        </GlassCard>
+      {/if}
+
+      <!-- Confidence Calibration -->
+      {#if insights && insights.calibration.length > 0}
+        <ConfidenceCalibration data={insights.calibration} />
+      {/if}
+
+      <!-- Escalation Stats -->
+      {#if insights && insights.escalation_stats.length > 1}
+        <EscalationTimeline data={insights.escalation_stats} />
+      {/if}
+
+      <!-- Recent Decisions -->
+      {#if decisions.length > 0}
+        <GlassCard class="p-3">
+          <h4 class="text-xs font-medium text-text mb-2">Recent Decisions</h4>
+          <div class="space-y-1.5 max-h-[200px] overflow-auto">
+            {#each decisions as decision}
+              {@const eventData = parseEventData(decision.event_data)}
+              <div class="flex items-start gap-2 text-[11px] py-1 border-b border-border/20 last:border-0">
+                <span class="px-1.5 py-0.5 rounded text-[10px] whitespace-nowrap {
+                  decision.event_type.includes('passed') ? 'bg-approve/15 text-approve' :
+                  decision.event_type.includes('escalation') ? 'bg-warning/15 text-warning' :
+                  decision.event_type.includes('failed') ? 'bg-reject/15 text-reject' :
+                  'bg-info/15 text-info'
+                }">
+                  {eventTypeLabel(decision.event_type)}
+                </span>
+                <div class="flex-1 min-w-0">
+                  {#if eventData.mode}
+                    <span class="text-text-dim">{eventData.mode}</span>
+                  {/if}
+                  {#if eventData.reasoning}
+                    <span class="text-text-muted truncate block">{eventData.reasoning}</span>
+                  {/if}
+                  {#if eventData.confidence}
+                    <span class="text-text-muted font-data">conf: {eventData.confidence}</span>
+                  {/if}
+                </div>
+                {#if decision.created_at}
+                  <span class="text-[10px] text-text-muted font-data whitespace-nowrap">
+                    {new Date(decision.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                  </span>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        </GlassCard>
+      {/if}
+
+      <!-- Learning Status -->
+      {#if insights}
+        <div class="text-[10px] text-text-muted text-center font-data">
+          Learning loop: {insights.total_samples} samples | {insights.intelligence_event_count} events
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { Project, ProjectCreate, ProjectUpdate, Run, RunList, RunFullContext, ActiveEmployeeData, Plan, PlanList, SystemStatus, AuthStatus, LogSearchResult, RunLogs, UsageData, TokenUsageData, OAuthStartResponse, OAuthCallbackResponse, CoordinatorTask, CoordinatorTaskDetail, CoordinatorDAG, CoordinatorMessage, AnalyticsData, DiffResult, QueueItem, QueueItemList, QueueStats } from './types';
+import type { Project, ProjectCreate, ProjectUpdate, Run, RunList, RunFullContext, ActiveEmployeeData, Plan, PlanList, SystemStatus, AuthStatus, LogSearchResult, RunLogs, UsageData, TokenUsageData, OAuthStartResponse, OAuthCallbackResponse, CoordinatorTask, CoordinatorTaskDetail, CoordinatorDAG, CoordinatorMessage, AnalyticsData, DiffResult, QueueItem, QueueItemList, QueueStats, IntelligenceInsights, IntelligenceDecision, BackpressureStatus } from './types';
 
 const BASE = import.meta.env.VITE_API_URL || '';
 
@@ -210,3 +210,13 @@ export const sendGuidance = (data: { run_id: string; employee_index: number; gui
     method: 'POST',
     body: JSON.stringify(data),
   });
+
+// Intelligence
+export const getIntelligenceInsights = () => request<IntelligenceInsights>('/api/intelligence/insights');
+export const getIntelligenceDecisions = (params?: { run_id?: string; limit?: number }) => {
+  const q = new URLSearchParams();
+  if (params?.run_id) q.set('run_id', params.run_id);
+  if (params?.limit) q.set('limit', String(params.limit));
+  return request<IntelligenceDecision[]>(`/api/intelligence/decisions?${q}`);
+};
+export const getBackpressure = () => request<BackpressureStatus>('/api/queue/pressure');

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -429,6 +429,57 @@ export interface RunFullContext {
   queue_item: QueueItem | null;
   plan: Plan | null;
   project_repo: string | null;
+  intelligence_decisions: AgentEvent[];
+}
+
+// --- Intelligence ---
+
+export interface IntelligenceInsights {
+  success_rates: ModeSuccessRate[];
+  calibration: ConfidenceBucket[];
+  token_efficiency: TokenEfficiency[];
+  escalation_stats: EscalationStat[];
+  total_samples: number;
+  intelligence_event_count: number;
+}
+
+export interface ModeSuccessRate {
+  mode: string;
+  model: string;
+  total: number;
+  successes: number;
+  success_rate: number;
+  avg_tokens: number | null;
+  avg_duration: number | null;
+}
+
+export interface ConfidenceBucket {
+  bucket: string;
+  total: number;
+  actual_success_rate: number;
+  avg_reported_confidence: number;
+}
+
+export interface TokenEfficiency {
+  mode: string;
+  avg_tokens_success: number | null;
+  avg_tokens_failure: number | null;
+  total: number;
+}
+
+export interface EscalationStat {
+  rung: number;
+  total: number;
+  success_rate: number;
+}
+
+export interface IntelligenceDecision {
+  event_id: number;
+  workflow_id: string;
+  run_id: string | null;
+  event_type: string;
+  event_data: string;
+  created_at: string | null;
 }
 
 export interface AnalyticsData {

--- a/dashboard/frontend/src/pages/CommandCenterPage.svelte
+++ b/dashboard/frontend/src/pages/CommandCenterPage.svelte
@@ -7,6 +7,7 @@
   import MetricPanel from '../components/MetricPanel.svelte';
   import GlassCard from '../components/GlassCard.svelte';
   import StatusOrb from '../components/StatusOrb.svelte';
+  import IntelligencePanel from '../components/IntelligencePanel.svelte';
   import { formatTokens, formatDuration } from '../lib/format';
 
   let systemStatus = $state<SystemStatus | null>(null);
@@ -169,6 +170,9 @@
       </div>
     </GlassCard>
   </div>
+
+  <!-- Intelligence (collapsible) -->
+  <IntelligencePanel />
 
   <!-- Analytics (collapsible) -->
   <button

--- a/dashboard/frontend/src/pages/ConfigPage.svelte
+++ b/dashboard/frontend/src/pages/ConfigPage.svelte
@@ -103,6 +103,12 @@
   let logDir = $state('');
   let digestDir = $state('');
   let snapshot = $state<StationConfig>({});
+  // Intelligence feature flags
+  let intelAutoMode = $state(false);
+  let intelProgressiveDeepening = $state(false);
+  let intelConfidenceGating = $state(false);
+  let intelIndependentVerification = $state(false);
+  let intelAdaptiveScheduling = $state(false);
 
   function applyConfig(cfg: StationConfig) {
     employeeModel = cfg.models?.employee ?? '';
@@ -130,6 +136,11 @@
     telegramChatId = cfg.notifications?.telegram_chat_id ?? '';
     logDir = cfg.logging?.log_dir ?? '';
     digestDir = cfg.logging?.digest_dir ?? '';
+    intelAutoMode = cfg.intelligence?.auto_mode_selection ?? false;
+    intelProgressiveDeepening = cfg.intelligence?.progressive_deepening ?? false;
+    intelConfidenceGating = cfg.intelligence?.confidence_gating ?? false;
+    intelIndependentVerification = cfg.intelligence?.independent_verification ?? false;
+    intelAdaptiveScheduling = cfg.intelligence?.adaptive_scheduling ?? false;
   }
 
   async function loadConfig() {
@@ -159,6 +170,13 @@
         max_manager_turns: maxManagerTurns, max_concurrent_employees: maxConcurrentEmployees,
         max_employees_per_project: maxEmployeesPerProject,
         token_budget_strategy: tokenBudgetStrategy || undefined,
+      },
+      intelligence: {
+        auto_mode_selection: intelAutoMode,
+        progressive_deepening: intelProgressiveDeepening,
+        confidence_gating: intelConfidenceGating,
+        independent_verification: intelIndependentVerification,
+        adaptive_scheduling: intelAdaptiveScheduling,
       },
       schedule: schedule || undefined,
       notifications: {
@@ -433,6 +451,48 @@
               <option value="priority_weighted">Priority Weighted</option>
             </select>
           </div>
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="purple" class="p-4">
+        <h3 class="text-sm font-semibold mb-1">Intelligence Features</h3>
+        <p class="text-xs text-text-dim mb-3">Adaptive intelligence that improves with every run. All features default to off.</p>
+        <div class="space-y-2">
+          <label class="flex items-center justify-between text-sm text-text cursor-pointer">
+            <div>
+              <span class="text-xs">Auto Mode Selection</span>
+              <p class="text-[10px] text-text-muted">Route issues to optimal mode/model via labels + Haiku scoring</p>
+            </div>
+            <input type="checkbox" bind:checked={intelAutoMode} class="w-4 h-4 accent-info cursor-pointer" />
+          </label>
+          <label class="flex items-center justify-between text-sm text-text cursor-pointer">
+            <div>
+              <span class="text-xs">Progressive Deepening</span>
+              <p class="text-[10px] text-text-muted">Escalate to stronger models when initial attempt fails</p>
+            </div>
+            <input type="checkbox" bind:checked={intelProgressiveDeepening} class="w-4 h-4 accent-info cursor-pointer" />
+          </label>
+          <label class="flex items-center justify-between text-sm text-text cursor-pointer">
+            <div>
+              <span class="text-xs">Confidence Gating</span>
+              <p class="text-[10px] text-text-muted">Auto-create PRs for high-confidence, test-passing work (skip manager review)</p>
+            </div>
+            <input type="checkbox" bind:checked={intelConfidenceGating} class="w-4 h-4 accent-info cursor-pointer" />
+          </label>
+          <label class="flex items-center justify-between text-sm text-text cursor-pointer">
+            <div>
+              <span class="text-xs">Adaptive Scheduling</span>
+              <p class="text-[10px] text-text-muted">Learn from outcomes to optimize future mode/model selection</p>
+            </div>
+            <input type="checkbox" bind:checked={intelAdaptiveScheduling} class="w-4 h-4 accent-info cursor-pointer" />
+          </label>
+          <label class="flex items-center justify-between text-sm text-text cursor-pointer">
+            <div>
+              <span class="text-xs">Independent Verification</span>
+              <p class="text-[10px] text-text-muted">Automated code review for high-risk changes (cost-intensive)</p>
+            </div>
+            <input type="checkbox" bind:checked={intelIndependentVerification} class="w-4 h-4 accent-info cursor-pointer" />
+          </label>
         </div>
       </GlassCard>
 


### PR DESCRIPTION
## Summary

- **Decision Bridge**: CLI gateway (`decide.py`) with 5 subcommands bridges bash orchestration to Python intelligence — only ~85 new lines in `run-manager.sh`
- **Auto Mode Selection**: Per-issue routing via labels (Tier 1) + Haiku complexity scoring (Tier 2) + adaptive historical lookup (Tier 3)
- **Confidence-Gated Auto-PR**: High-confidence, test-passing work auto-creates PRs, skipping expensive manager review (~15-30K token savings per auto-PR)
- **Progressive Deepening**: Escalation ladder (fix→full/Sonnet→full/Opus→full/Opus+) triggers on low confidence or test failures
- **Learning Loop**: `predict_effort_sync()` enables zero-LLM-cost adaptive scheduling from accumulated outcomes
- **Independent Verification**: Automated code review for cross-cutting changes, escalated items, and auto-PR candidates
- **Audit Trail**: Every intelligence decision recorded as `intelligence.*` agent events, surfaced in `RunFullContext`
- **Frontend Dashboard**: IntelligencePanel (backpressure gauge, success rates, calibration chart, escalation timeline, decision log) + intelligence feature toggles on ConfigPage
- **REST API**: `GET /api/intelligence/insights`, `POST /api/intelligence/outcomes`, `GET /api/intelligence/decisions`

All features behind config flags defaulting to `false`. Fully backward compatible.

## Test plan

- [ ] Enable `auto_mode_selection` in config → create issue with `mode/fix` label → verify Tier 1 fast path
- [ ] Create unlabeled issue → verify Haiku complexity scoring returns decision
- [ ] Enable `confidence_gating` → run high-confidence fix → verify auto-PR created without manager review
- [ ] Enable `progressive_deepening` → run complex issue at fix mode → verify escalation triggers
- [ ] After 5+ runs with outcome recording, verify `/api/intelligence/insights` returns meaningful stats
- [ ] Verify ConfigPage intelligence toggles save correctly
- [ ] Verify CommandCenterPage shows IntelligencePanel
- [ ] Disable all features → verify behavior unchanged (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)