### PR TITLE
fix: multi-employee visibility across all execution paths

### DIFF
--- a/agent/coordinator/reporter.py
+++ b/agent/coordinator/reporter.py
@@ -62,6 +62,42 @@ def post_task_event(config: CoordinatorConfig, event: str, task: Task) -> None:
     })
 
 
+def post_employee_start(config: CoordinatorConfig, task: Task) -> None:
+    """Send employee_start event to create a Run record for this employee.
+
+    Each employee gets a unique run_id so the dashboard can track them
+    individually. Employee 0 uses the master run_id; others get a suffix.
+    """
+    run_id = f"run-{config.run_id}"
+    ei = task.employee_index or 0
+    if ei > 0:
+        run_id = f"run-{config.run_id}-e{ei}"
+
+    post_event(config, "employee_start", {
+        "run_id": run_id,  # Override the default run_id
+        "project": task.project_repo,
+        "mode": getattr(config, "project_mode", "full"),
+        "employee_index": ei,
+        "concurrent_group_id": config.concurrent_group_id or f"run-{config.run_id}",
+    })
+
+
+def post_employee_complete(config: CoordinatorConfig, task: Task, exit_code: int = 0) -> None:
+    """Send employee_complete event to update the Run record for this employee."""
+    run_id = f"run-{config.run_id}"
+    ei = task.employee_index or 0
+    if ei > 0:
+        run_id = f"run-{config.run_id}-e{ei}"
+
+    post_event(config, "employee_complete", {
+        "run_id": run_id,  # Override the default run_id
+        "project": task.project_repo,
+        "exit_code": exit_code,
+        "employee_index": ei,
+        "concurrent_group_id": config.concurrent_group_id or f"run-{config.run_id}",
+    })
+
+
 def post_conflict(config: CoordinatorConfig, file_path: str, employee_a: int, employee_b: int, project: str) -> None:
     """POST a conflict detection event."""
     post_event(config, "conflict_detected", {

--- a/agent/coordinator/scheduler.py
+++ b/agent/coordinator/scheduler.py
@@ -352,6 +352,9 @@ async def run_scheduler(dag: TaskDAG, config: CoordinatorConfig) -> None:
             task.employee_index = employee_index
             task_workspaces[task.id] = workspace
             post_task_event(config, "task_started", task)
+            # Also send employee_start to create a Run record for the dashboard
+            from agent.coordinator.reporter import post_employee_start
+            post_employee_start(config, task)
 
             # Create activity tracker and stop event
             activity = EmployeeActivity(
@@ -530,6 +533,10 @@ async def _run_and_monitor(
 
     finally:
         semaphore.release()
+        # Send employee_complete to update the Run record in the dashboard
+        from agent.coordinator.reporter import post_employee_complete
+        exit_code_final = result.exit_code if result else 1
+        post_employee_complete(config, task, exit_code_final)
 
     return task.id
 

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -2311,7 +2311,9 @@ for item in data.get('items', []):
 
         # Build assignments JSON for the coordinator
         local assignments_json="$LOG_DIR/run-${RUN_ID}-assignments.json"
-        python3 -c "
+        local agent_dir_for_py
+        agent_dir_for_py="$(cd "$SCRIPT_DIR/.." && pwd)"
+        PYTHONPATH="$agent_dir_for_py/.." python3 -c "
 import json, sys
 config = json.load(open('$CONFIG_FILE'))
 projects = config.get('projects', [])
@@ -2319,12 +2321,19 @@ assignments = []
 max_per = int('$max_per_project')
 workspaces_dir = '$WORKSPACES_DIR'
 
+# Load multi_employee flag from ModeSpec registry
+try:
+    from agent.coordinator.modes import MODE_REGISTRY
+    multi_employee_modes = {name for name, spec in MODE_REGISTRY.items() if spec.multi_employee}
+except Exception:
+    multi_employee_modes = {'full'}  # Fallback if modes.py not importable
+
 for i, proj in enumerate(projects):
     if not proj.get('enabled', True):
         continue
     repo = proj['repo']
     mode = proj.get('mode', 'full')
-    employees = max_per if mode == 'full' else 1
+    employees = max_per if mode in multi_employee_modes else 1
     repo_name = repo.split('/')[-1] if '/' in repo else repo
     workspace = f'{workspaces_dir}/{repo_name}'
 

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -72,12 +72,17 @@ async def list_runs(
 
 @router.get("/active-employees", response_model=list[ActiveEmployeeOut])
 async def get_active_employees(db: AsyncSession = Depends(get_db)):
-    """Return all currently running employee/agent runs for workspace visualization."""
+    """Return all currently running employee/agent runs for workspace visualization.
+
+    Queries Run records first. If only 1 Run is found but there are multiple
+    running CoordinatorTasks, synthesize additional ActiveEmployeeOut entries
+    from the coordinator tasks (handles the coordinated multi-employee path).
+    """
     result = await db.execute(
         select(Run).where(Run.status == "running").where(Run.project_id.isnot(None))
     )
     runs = result.scalars().all()
-    return [
+    employees = [
         ActiveEmployeeOut(
             run_id=r.run_id,
             project_id=r.project_id,
@@ -92,6 +97,46 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
         )
         for r in runs
     ]
+
+    # Fallback: check for running coordinator tasks that don't have Run records.
+    # This covers the coordinated path where the Python coordinator spawns
+    # employees via task_started events instead of employee_start events.
+    if len(employees) <= 1:
+        coord_result = await db.execute(
+            select(CoordinatorTask).where(CoordinatorTask.status == "running")
+        )
+        coord_tasks = coord_result.scalars().all()
+
+        # Only synthesize if we have coordinator tasks beyond what's already shown
+        seen_indices = {e.employee_index for e in employees}
+        for ct in coord_tasks:
+            if ct.employee_index in seen_indices:
+                continue
+            seen_indices.add(ct.employee_index)
+
+            # Find the project_id from the first run (they share the same project)
+            project_id = employees[0].project_id if employees else None
+            if not project_id:
+                proj_result = await db.execute(
+                    select(Project).where(Project.repo == ct.project_repo)
+                )
+                proj = proj_result.scalar_one_or_none()
+                project_id = proj.id if proj else 0
+
+            employees.append(ActiveEmployeeOut(
+                run_id=ct.run_id,
+                project_id=project_id,
+                mode="employee",
+                status="running",
+                issue_number=ct.issue_number,
+                turns=None,
+                employee_index=ct.employee_index,
+                concurrent_group_id=ct.run_id,
+                model=None,
+                branch=ct.branch,
+            ))
+
+    return employees
 
 
 @router.get("/latest", response_model=Optional[RunOut])


### PR DESCRIPTION
## Summary

Three root causes prevented multiple employees from showing in the dashboard, even with `max_employees_per_project=4`:

- **Coordinated path missing webhook events**: The Python coordinator sent `task_started` events (creating CoordinatorTask records) but never `employee_start` events (which create Run records). The dashboard's active-employees endpoint only queried Run records, making coordinator-spawned employees invisible. **Fixed** by adding `post_employee_start()` / `post_employee_complete()` in the scheduler.

- **Hardcoded mode check**: The assignments builder only gave multiple employees to `mode == 'full'`, ignoring `ModeSpec.multi_employee`. **Fixed** by reading the mode registry.

- **No fallback in active-employees API**: Added CoordinatorTask-based fallback to synthesize additional active employee entries when Run records are missing.

## Test plan

- [ ] Run with `max_employees_per_project=4`, project mode "full" → verify 4 Dev-N agents appear
- [ ] Run with coordinated mode (max_concurrent > 1) → verify employees visible during execution
- [ ] Run with single employee config → verify backward compatible (still shows Dev-0 + Manager)
- [ ] Check `/api/runs/active-employees` returns correct count during parallel execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)