### PR TITLE
fix: multi-employee visibility across all modes

### DIFF
--- a/agent/coordinator/decomposer.py
+++ b/agent/coordinator/decomposer.py
@@ -101,20 +101,36 @@ async def decompose_issue(
     """
     effective_run_id = run_id or config.run_id
 
-    # For analyze mode, create a single read-only analysis task
+    # For analyze mode, create parallel analysis tasks (one per employee)
     if config.project_mode == "analyze":
-        logger.info("Analyze mode — creating read-only analysis task")
-        title = (
-            f"Analyze codebase for issue #{issue_number}"
-            if issue_number
-            else "Analyze codebase"
-        )
-        return await TaskDAG.single_task(
-            effective_run_id, repo, session_factory,
-            title=title,
-            description=issue_body[:2000],
-            issue_number=issue_number,
-        )
+        if employee_count <= 1:
+            logger.info("Analyze mode (single employee) — creating read-only analysis task")
+            title = (
+                f"Analyze codebase for issue #{issue_number}"
+                if issue_number
+                else "Analyze codebase"
+            )
+            return await TaskDAG.single_task(
+                effective_run_id, repo, session_factory,
+                title=title,
+                description=issue_body[:2000],
+                issue_number=issue_number,
+            )
+        # Multi-employee analyze: create N independent parallel tasks
+        logger.info("Analyze mode (%d employees) — creating parallel analysis tasks", employee_count)
+        dag = TaskDAG(effective_run_id, repo, session_factory)
+        for i in range(employee_count):
+            title = (
+                f"Analyze codebase (employee {i}) for issue #{issue_number}"
+                if issue_number
+                else f"Analyze codebase (employee {i})"
+            )
+            await dag.add_task(
+                title=title,
+                description=issue_body[:2000],
+                issue_number=issue_number,
+            )
+        return dag
 
     # For single employee, skip decomposition
     if employee_count <= 1:

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -2321,19 +2321,12 @@ assignments = []
 max_per = int('$max_per_project')
 workspaces_dir = '$WORKSPACES_DIR'
 
-# Load multi_employee flag from ModeSpec registry
-try:
-    from agent.coordinator.modes import MODE_REGISTRY
-    multi_employee_modes = {name for name, spec in MODE_REGISTRY.items() if spec.multi_employee}
-except Exception:
-    multi_employee_modes = {'full'}  # Fallback if modes.py not importable
-
 for i, proj in enumerate(projects):
     if not proj.get('enabled', True):
         continue
     repo = proj['repo']
     mode = proj.get('mode', 'full')
-    employees = max_per if mode in multi_employee_modes else 1
+    employees = max_per
     repo_name = repo.split('/')[-1] if '/' in repo else repo
     workspace = f'{workspaces_dir}/{repo_name}'
 
@@ -2396,10 +2389,6 @@ print(f'Wrote {len(assignments)} assignments')
         local mode_for_project
         mode_for_project=$(get_project_field "$i" "mode" 2>/dev/null || echo "full")
         local employees_this_project=$max_per_project
-        # Analyze/plan modes only use 1 employee
-        if [ "$mode_for_project" = "analyze" ] || [ "$mode_for_project" = "plan" ]; then
-            employees_this_project=1
-        fi
 
         for ((ei = 0; ei < employees_this_project; ei++)); do
             log_info "Project $((i+1))/$project_count: $repo (priority: $priority, employee: $ei)"

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -79,7 +79,7 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
     from the coordinator tasks (handles the coordinated multi-employee path).
     """
     result = await db.execute(
-        select(Run).where(Run.status == "running").where(Run.project_id.isnot(None))
+        select(Run).where(Run.status == "running")
     )
     runs = result.scalars().all()
     employees = [

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -81,7 +81,7 @@ class RunList(BaseModel):
 class ActiveEmployeeOut(BaseModel):
     """A currently-running agent/employee for the workspace visualization."""
     run_id: str
-    project_id: int
+    project_id: int | None = None
     mode: str
     status: str
     issue_number: int | None = None

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -7,8 +7,9 @@
 import { LogWebSocket } from './ws';
 import { parseLogLine, formatToolInput, truncate } from './log-parser';
 import type { ParsedLogEvent } from './log-parser';
-import { getActiveEmployees, getLatestRun, listPlans, getStoredApiKey } from './api';
+import { getActiveEmployees, getLatestRun, listPlans, listRuns, getStoredApiKey } from './api';
 import type { ActiveEmployeeData, Run } from './types';
+import { AgentEventStream } from './event-stream';
 
 // --- Agent Identity ---
 
@@ -121,7 +122,7 @@ export const agentPresence = $state<AgentPresenceState>({
 // --- Internal ---
 
 let ws: LogWebSocket | null = null;
-let sse: EventSource | null = null;
+let sse: AgentEventStream | null = null;
 let currentToolTimer: ReturnType<typeof setTimeout> | null = null;
 let sampleTimer: ReturnType<typeof setInterval> | null = null;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -275,29 +276,11 @@ function handleWsMessage(data: string) {
 // --- SSE handler ---
 
 function connectSSE() {
-  const base = import.meta.env.VITE_API_URL || '';
-  const apiKey = getStoredApiKey();
-  const sseUrl = apiKey
-    ? `${base}/api/events/stream?token=${encodeURIComponent(apiKey)}`
-    : `${base}/api/events/stream`;
-  sse = new EventSource(sseUrl);
-
-  sse.onopen = () => {
-    agentPresence.sseConnected = true;
-  };
-
-  sse.onerror = () => {
-    agentPresence.sseConnected = false;
-  };
-
-  sse.onmessage = (event) => {
-    try {
-      const data = JSON.parse(event.data);
-      handleSSEEvent(data);
-    } catch {
-      // ignore parse errors
-    }
-  };
+  sse = new AgentEventStream({
+    onEvent: (event) => handleSSEEvent(event),
+    onStatusChange: (connected) => { agentPresence.sseConnected = connected; },
+  });
+  sse.connect();
 }
 
 function handleSSEEvent(data: any) {
@@ -321,6 +304,7 @@ function handleSSEEvent(data: any) {
         type: 'phase',
         content: `Started working${data.issue ? ` on #${data.issue}` : ''}`,
       });
+      refreshActiveRuns();
       break;
     case 'employee_complete':
       addConversationEntry({
@@ -329,6 +313,7 @@ function handleSSEEvent(data: any) {
         type: 'phase',
         content: `Finished — ${data.turns ?? '?'} turns`,
       });
+      refreshActiveRuns();
       break;
     case 'manager_review':
       agentPresence.phase = 'manager_review';
@@ -401,19 +386,39 @@ async function refreshActiveRuns() {
       agentPresence.latestRunId = latestRun.run_id;
     }
 
-    // Fallback: if active-employees returns empty but latest run is still active,
-    // synthesize agent data from the latest run. This happens when project_id
-    // hasn't been assigned yet (run just started) or during manager phase.
-    if (activeEmployees.length === 0 && latestRun && !latestRun.finished_at &&
-        (latestRun.status === 'running' || latestRun.status === 'reviewing')) {
-      activeEmployees = [{
-        run_id: latestRun.run_id,
-        project_id: latestRun.project_id ?? 0,
-        mode: latestRun.mode ?? 'employee',
-        status: latestRun.status ?? 'running',
-        issue_number: latestRun.issue_number,
-        turns: latestRun.turns,
-      }];
+    // Fallback: if active-employees returns empty but runs are still active,
+    // try listing all running runs first (covers multi-employee cases where
+    // project_id is NULL on newly created runs), then fall back to latestRun.
+    if (activeEmployees.length === 0) {
+      try {
+        const runningRuns = await listRuns({ status: 'running', limit: 10 });
+        if (runningRuns.runs && runningRuns.runs.length > 0) {
+          activeEmployees = runningRuns.runs.map((r: Run, idx: number) => ({
+            run_id: r.run_id,
+            project_id: r.project_id ?? 0,
+            mode: r.mode ?? 'employee',
+            status: r.status ?? 'running',
+            issue_number: r.issue_number,
+            turns: r.turns,
+            employee_index: r.employee_index ?? idx,
+          }));
+        }
+      } catch {
+        // Fall through to latestRun synthesis
+      }
+
+      // Final fallback: synthesize from latestRun if still nothing
+      if (activeEmployees.length === 0 && latestRun && !latestRun.finished_at &&
+          (latestRun.status === 'running' || latestRun.status === 'reviewing')) {
+        activeEmployees = [{
+          run_id: latestRun.run_id,
+          project_id: latestRun.project_id ?? 0,
+          mode: latestRun.mode ?? 'employee',
+          status: latestRun.status ?? 'running',
+          issue_number: latestRun.issue_number,
+          turns: latestRun.turns,
+        }];
+      }
     }
 
     agentPresence.activeRuns = activeEmployees;
@@ -474,7 +479,7 @@ export function connect() {
 
 export function disconnect() {
   if (ws) { ws.disconnect(); ws = null; }
-  if (sse) { sse.close(); sse = null; }
+  if (sse) { sse.disconnect(); sse = null; }
   if (currentToolTimer) { clearTimeout(currentToolTimer); currentToolTimer = null; }
   if (sampleTimer) { clearInterval(sampleTimer); sampleTimer = null; }
   if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }

--- a/dashboard/frontend/src/lib/event-stream.ts
+++ b/dashboard/frontend/src/lib/event-stream.ts
@@ -39,6 +39,7 @@ const EVENT_TYPES = [
   'manager_review',
   'verdict_execute',
   'run_complete',
+  'run_interrupted',
   // Legacy names
   'started',
   'finished',

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -62,7 +62,7 @@ export interface RunList {
 
 export interface ActiveEmployeeData {
   run_id: string;
-  project_id: number;
+  project_id: number | null;
   mode: string;
   status: string;
   issue_number: number | null;


### PR DESCRIPTION
## Summary
- **Frontend SSE**: Replaced broken `EventSource.onmessage` with `AgentEventStream` that properly listens for named SSE events (`employee_start`, `employee_complete`, etc.). Added immediate `refreshActiveRuns()` on employee lifecycle events.
- **Backend SQL**: Removed `project_id IS NOT NULL` filter from `active-employees` endpoint that was hiding runs with unmatched projects. Made `project_id` optional in schema.
- **Coordinator/Manager**: Removed mode-based employee count restrictions — all modes now respect `max_employees_per_project` config. Analyze mode with multiple employees creates N parallel analysis tasks.

## Test plan
- [x] Trigger multi-employee run in analyze mode — all employees visible in dashboard
- [ ] Verify SSE events appear in browser DevTools Network tab
- [ ] Confirm employees disappear promptly when they complete
- [ ] Test SSE reconnection after backend restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)