### PR TITLE
fix: inline review content to prevent manager re-reading (#140)

### DIFF
--- a/agent/coordinator/scheduler.py
+++ b/agent/coordinator/scheduler.py
@@ -105,11 +105,15 @@ Write your plan verdict to: {verdict_file}
 
     # Run manager for plan review
     manager_model = "claude-sonnet-4-6"
+    # Inline review content directly to avoid wasting turns re-reading the file
     manager_prompt = (
-        f"Review the employee's implementation plan in: {review_file}\n\n"
+        f"Review the employee's implementation plan below.\n\n"
         f"Write your plan verdict to: {verdict_file}\n\n"
         "Use APPROVE_PLAN if the plan is solid, REVISE_PLAN with specific feedback "
-        "if it needs changes, or REJECT_PLAN if the plan is fundamentally flawed."
+        "if it needs changes, or REJECT_PLAN if the plan is fundamentally flawed.\n\n"
+        "--- BEGIN PLAN REVIEW PACKAGE ---\n"
+        f"{review_content}\n"
+        "--- END PLAN REVIEW PACKAGE ---"
     )
 
     stream_file = str(

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -1398,11 +1398,19 @@ run_manager_plan_review() {
     local manager_fallback="claude-haiku-4-5-20251001"
     [ "$model" = "claude-haiku-4-5-20251001" ] && manager_fallback="claude-sonnet-4-6"
 
-    local manager_prompt="Review the employee's implementation plan in: $review_file
+    # Inline review content directly to avoid wasting turns re-reading the file
+    local review_content
+    review_content=$(cat "$review_file")
+
+    local manager_prompt="Review the employee's implementation plan below.
 
 Write your plan verdict to: $verdict_file
 
-Use APPROVE_PLAN if the plan is solid, REVISE_PLAN with specific feedback if it needs changes, or REJECT_PLAN if fundamentally flawed."
+Use APPROVE_PLAN if the plan is solid, REVISE_PLAN with specific feedback if it needs changes, or REJECT_PLAN if fundamentally flawed.
+
+--- BEGIN PLAN REVIEW PACKAGE ---
+$review_content
+--- END PLAN REVIEW PACKAGE ---"
 
     local stream_file="$LOG_DIR/run-${RUN_ID}-plan-review-${name}.stream.jsonl"
     local stderr_file="$LOG_DIR/run-${RUN_ID}-plan-review-${name}.stderr.log"
@@ -1672,11 +1680,17 @@ run_manager_review() {
     cmd+=(--system-prompt-file "$(resolve_prompt manager)")
     # No --allowedTools: full VM access, prompt-enforced guardrails
 
-    local manager_prompt="Review the employee work in this file: $review_package
+    # Inline review content directly to avoid wasting turns re-reading the file
+    local review_content
+    review_content=$(cat "$review_package")
 
-Write your verdicts to: $verdicts_file
+    local manager_prompt="Review the employee work below and write your verdicts to: $verdicts_file
 
-Read the review package file first, then evaluate each project's work against the criteria in your system prompt. Be strict on completeness — never approve partial implementations."
+Evaluate each project's work against the criteria in your system prompt. Be strict on completeness — never approve partial implementations.
+
+--- BEGIN REVIEW PACKAGE ---
+$review_content
+--- END REVIEW PACKAGE ---"
 
     log_info "Manager command: ${cmd[*]} '<prompt>'" >&2
 


### PR DESCRIPTION
## Summary
- Inlines review package content directly into manager prompts at all 3 locations where file paths were being passed, eliminating wasted turns where the manager had to re-read the file
- **`run_manager_review()`** (line ~1675): Reads `$review_package` into a variable and embeds it in the prompt
- **`run_manager_plan_review()`** (line ~1401): Reads `$review_file` into a variable and embeds it in the prompt
- **`scheduler.py` `_run_manager_plan_review()`** (line ~108): Uses the already-constructed `review_content` variable directly instead of referencing the file path

## Test plan
- [ ] Run a full cycle with plan review enabled — verify manager no longer uses Read tool to open the review file
- [ ] Run a multi-project review — verify the review package content appears inline in the manager prompt
- [ ] Check manager stream logs for reduced turn count compared to previous runs
- [ ] Verify verdict files are still written correctly (no regression)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)