### PR TITLE
fix: update prompt test counts after security-reviewer addition

### DIFF
--- a/dashboard/backend/tests/test_prompt_contracts.py
+++ b/dashboard/backend/tests/test_prompt_contracts.py
@@ -146,12 +146,12 @@ class TestPromptRouterSync:
         router_count = len(PROMPT_ROLES)
 
         # This assertion documents the gap. Update both sides when fixed.
-        assert actual_files_count == 7, (
-            f"Expected 7 prompt files on disk, found {actual_files_count}"
+        assert actual_files_count == 8, (
+            f"Expected 8 prompt files on disk, found {actual_files_count}"
         )
-        assert router_count == 5, (
+        assert router_count == 6, (
             f"PROMPT_ROLES currently has {router_count} entries. "
-            f"Expected 5 (reviewer and triager not yet added to router)."
+            f"Expected 6 (triager not yet added to router)."
         )
 
 


### PR DESCRIPTION
## Summary
- Updates `test_router_roles_count` assertion from 7→8 files and 5→6 router roles
- The security-reviewer prompt added in PR #162 increased both counts

## Test plan
- [x] `python -m pytest tests/test_prompt_contracts.py -v` — all 36 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)