### PR TITLE
fix: critical security hardening (sprint 1)

### DIFF
--- a/agent/coordinator/skill_loader.py
+++ b/agent/coordinator/skill_loader.py
@@ -25,6 +25,9 @@ def load_skills(skill_names: list[str]) -> str:
 
     sections: list[str] = []
     for name in skill_names:
+        if not name.replace("-", "").replace("_", "").isalnum():
+            logger.warning("Invalid skill name, skipping: %s", name)
+            continue
         skill_file = SKILLS_DIR / f"{name}.md"
         if not skill_file.is_file():
             logger.warning("Skill file not found, skipping: %s", skill_file)

--- a/agent/scripts/circuit-breaker.sh
+++ b/agent/scripts/circuit-breaker.sh
@@ -25,31 +25,26 @@ fi
 # Function to get failure count for agent
 get_failure_count() {
     local agent="$1"
-    local count=$(grep "\"$agent\":" "$CIRCUIT_FILE" 2>/dev/null | grep -oE '[0-9]+' | tail -1)
+    local count
+    count=$(jq -r --arg a "$agent" '.[$a] // 0' "$CIRCUIT_FILE" 2>/dev/null)
     echo "${count:-0}"
 }
 
 # Function to increment failure count
 increment_failure() {
     local agent="$1"
-    local current=$(get_failure_count "$agent")
+    local current
+    current=$(get_failure_count "$agent")
     local new_count=$((current + 1))
-
-    # Update or add entry
-    if grep -q "\"$agent\":" "$CIRCUIT_FILE"; then
-        sed -i.bak "s/\"$agent\": [0-9]*/\"$agent\": $new_count/" "$CIRCUIT_FILE"
-    else
-        # Add new entry
-        sed -i.bak "s/}/  \"$agent\": $new_count\n}/" "$CIRCUIT_FILE"
-    fi
+    local tmp="${CIRCUIT_FILE}.tmp"
+    jq --arg a "$agent" --argjson n "$new_count" '.[$a] = $n' "$CIRCUIT_FILE" > "$tmp" && mv "$tmp" "$CIRCUIT_FILE"
 }
 
 # Function to reset circuit
 reset_circuit() {
     local agent="$1"
-    if grep -q "\"$agent\":" "$CIRCUIT_FILE"; then
-        sed -i.bak "s/\"$agent\": [0-9]*/\"$agent\": 0/" "$CIRCUIT_FILE"
-    fi
+    local tmp="${CIRCUIT_FILE}.tmp"
+    jq --arg a "$agent" '.[$a] = 0' "$CIRCUIT_FILE" > "$tmp" && mv "$tmp" "$CIRCUIT_FILE"
 }
 
 # Function to check if circuit is open

--- a/dashboard/backend/app/config.py
+++ b/dashboard/backend/app/config.py
@@ -48,6 +48,10 @@ class Settings(BaseSettings):
     # Optional redirect URI for GitHub OAuth callback
     github_oauth_redirect_uri: str = ""
 
+    # Secret for verifying GitHub webhook HMAC-SHA256 signatures.
+    # Set via STATION_GITHUB_WEBHOOK_SECRET env var.
+    github_webhook_secret: str | None = None
+
     # CORS allowed origins for cross-origin requests (e.g. frontend dev server)
     # Override with STATION_ALLOWED_ORIGINS as a JSON list or comma-separated string
     allowed_origins: list[str] = [

--- a/dashboard/backend/app/main.py
+++ b/dashboard/backend/app/main.py
@@ -154,7 +154,6 @@ _auth = [Depends(verify_api_key)]
 app.include_router(analytics.router, dependencies=_auth)
 app.include_router(projects.router, dependencies=_auth)
 app.include_router(runs.router, dependencies=_auth)
-app.include_router(logs.ws_router)  # WS route: handles auth internally (HTTPBearer incompatible with WS)
 app.include_router(logs.router, dependencies=_auth)
 app.include_router(config_router.router, dependencies=_auth)
 app.include_router(system.router, dependencies=_auth)

--- a/dashboard/backend/app/routers/github_webhook.py
+++ b/dashboard/backend/app/routers/github_webhook.py
@@ -100,7 +100,7 @@ async def handle_github_webhook(
     body = await request.body()
 
     # Verify signature if webhook secret is configured
-    webhook_secret = getattr(settings, "github_webhook_secret", "")
+    webhook_secret = settings.github_webhook_secret or ""
     if webhook_secret and not _verify_signature(body, x_hub_signature_256, webhook_secret):
         raise HTTPException(403, "Invalid webhook signature")
 

--- a/dashboard/backend/app/routers/logs.py
+++ b/dashboard/backend/app/routers/logs.py
@@ -7,6 +7,7 @@ import contextlib
 import json
 import os
 import secrets
+from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
@@ -46,7 +47,7 @@ async def stream_logs(
     if file:
         filepath = os.path.realpath(file)
         log_dir_real = os.path.realpath(settings.log_dir)
-        if not filepath.startswith(log_dir_real):
+        if not Path(filepath).is_relative_to(log_dir_real):
             await websocket.send_json({"error": "Path outside log directory"})
             await websocket.close()
             return

--- a/dashboard/backend/app/routers/oauth.py
+++ b/dashboard/backend/app/routers/oauth.py
@@ -34,6 +34,7 @@ CREDS_PATH = Path(settings.credentials_path)
 # In-memory store for pending PKCE flows: {state: (code_verifier, expires_at)}
 _pending: dict[str, tuple[str, float]] = {}
 STATE_TTL_SECONDS = 600  # 10 minutes
+MAX_PENDING = 100
 
 
 def _cleanup_expired_states() -> None:
@@ -89,6 +90,8 @@ def _write_credentials(path: Path, data: dict) -> None:
 async def start_oauth():
     """Generate PKCE challenge and return authorization URL."""
     _cleanup_expired_states()
+    if len(_pending) >= MAX_PENDING:
+        raise HTTPException(status_code=429, detail="Too many pending OAuth flows. Try again later.")
     state = secrets.token_urlsafe(32)
     code_verifier, code_challenge = _generate_pkce()
     _pending[state] = (code_verifier, time.time() + STATE_TTL_SECONDS)
@@ -135,6 +138,7 @@ def _clean_code(raw: str) -> str:
 @router.post("/callback", response_model=OAuthCallbackResponse)
 async def oauth_callback(req: OAuthCallbackRequest):
     """Exchange authorization code for tokens and write credentials."""
+    _cleanup_expired_states()
     entry = _pending.pop(req.state, None)
     if not entry:
         raise HTTPException(status_code=400, detail="Invalid or expired state parameter")


### PR DESCRIPTION
## Summary
- **C-1**: Remove duplicate `ws_router` mount in `main.py` (line 157 was a duplicate of line 150)
- **C-2**: Add `github_webhook_secret` field to `Settings` model, replace fragile `getattr` with direct attribute access
- **C-3**: Rewrite `circuit-breaker.sh` JSON manipulation from `grep`/`sed` to `jq` — eliminates regex injection via agent names and `.bak` file litter
- **H-1**: Fix path traversal bypass in log streamer — `startswith()` → `Path.is_relative_to()` to prevent sibling directory access
- **H-9**: Cap OAuth pending states at 100 with HTTP 429; clean expired states on callback entry too
- **NEW-1**: Validate skill names are alphanumeric (with hyphens/underscores) before constructing file paths

## Test plan
- [x] All 497 backend tests pass
- [x] Circuit breaker verified: fail×3 → OPEN → reset → valid JSON output
- [ ] Start dashboard, verify WebSocket log streaming works
- [ ] Set `STATION_GITHUB_WEBHOOK_SECRET=test` and send unsigned webhook → expect 403
- [ ] Verify skill loader rejects `../../etc/passwd` as skill name

🤖 Generated with [Claude Code](https://claude.com/claude-code)