### PR TITLE
fix: remaining high-priority issues (sprint 2)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,12 +79,12 @@ claude-agent-station/
 │   │   │   ├── main.py             # App, lifespan, router registration
 │   │   │   ├── config.py           # pydantic-settings (STATION_ prefix)
 │   │   │   ├── database.py         # Async SQLAlchemy + migrations
-│   │   │   ├── models.py           # ORM models (9 tables)
+│   │   │   ├── models.py           # ORM models (14 tables)
 │   │   │   ├── schemas.py          # Pydantic request/response schemas
 │   │   │   ├── dependencies.py     # FastAPI dependency injection
 │   │   │   ├── middleware/
 │   │   │   │   └── auth.py         # API key authentication middleware
-│   │   │   ├── routers/            # 16 API routers
+│   │   │   ├── routers/            # 20 API routers
 │   │   │   │   ├── analytics.py    # Token usage charts, verdicts
 │   │   │   │   ├── config_router.py# Agent configuration CRUD
 │   │   │   │   ├── coordinator.py  # DAG, tasks, guidance API
@@ -148,7 +148,7 @@ claude-agent-station/
 
 ---
 
-## Database Schema (9 tables)
+## Database Schema (14 tables)
 
 | Table | Purpose | Key fields |
 |-------|---------|------------|
@@ -161,6 +161,11 @@ claude-agent-station/
 | `notifications` | Run completion alerts | type (approve/reject/pr/error) |
 | `task_queue` | Work queue with state machine | state, priority, retry_count |
 | `plan_usage_history` | Token usage tracking | plan_tier, weekly_tokens_used |
+| `agent_events` | Structured audit trail (ESAA) | workflow_id, agent_id, event_type |
+| `task_outcomes` | Adaptive scheduling learning | mode_used, model_used, success |
+| `brainstorm_sessions` | AI brainstorm conversations | project_id, persona, title |
+| `brainstorm_messages` | Brainstorm chat messages | session_id, role, content |
+| `prompt_versions` | Prompt A/B testing | prompt_name, version, content_hash |
 
 ---
 
@@ -168,10 +173,10 @@ claude-agent-station/
 
 | Layer | Mechanism |
 |-------|-----------|
-| **API authentication** | Optional API key via `STATION_API_KEY` env var. Bearer token or query parameter. Health/webhook/SSE endpoints always public. |
+| **API authentication** | Optional API key via `STATION_API_KEY` env var. Bearer token or query parameter. Health and webhook endpoints always public. SSE requires API key when configured. |
 | **Webhook authentication** | Optional shared secret via `STATION_WEBHOOK_SECRET`. X-Webhook-Token header. |
 | **Event idempotency** | In-memory deduplication with TTL (prevents replay attacks) |
-| **Path traversal** | `os.path.realpath()` + `startswith()` checks on log endpoints |
+| **Path traversal** | `os.path.realpath()` + `Path.is_relative_to()` checks on log endpoints |
 | **XSS prevention** | DOMPurify for markdown rendering, Svelte auto-escaping |
 | **CORS** | Explicit origin whitelist (no wildcard with credentials) |
 | **OAuth** | PKCE flow with TTL state parameter |

--- a/dashboard/backend/app/routers/config_router.py
+++ b/dashboard/backend/app/routers/config_router.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -87,8 +88,17 @@ async def get_config():
     return _normalize_config(config)
 
 
+class StationConfigUpdate(BaseModel):
+    models: dict[str, Any] | None = None
+    limits: dict[str, Any] | None = None
+    schedule: dict[str, Any] | None = None
+    notifications: dict[str, Any] | None = None
+    logging: dict[str, Any] | None = None
+    model_config = ConfigDict(extra="forbid")
+
+
 @router.put("")
-async def update_config(body: dict[str, Any], db: AsyncSession = Depends(get_db)):
+async def update_config(body: StationConfigUpdate, db: AsyncSession = Depends(get_db)):
     """Update the full station config (writes to JSON file + syncs DB).
 
     Accepts the full config object. Projects are synced to the DB.
@@ -101,9 +111,8 @@ async def update_config(body: dict[str, Any], db: AsyncSession = Depends(get_db)
     # Read current config to preserve any fields not sent by frontend
     current = await asyncio.to_thread(_read_config_json)
     # Merge: update only keys the frontend sends
-    for key in ("models", "limits", "schedule", "notifications", "logging"):
-        if key in body:
-            current[key] = body[key]
+    for key, value in body.model_dump(exclude_none=True).items():
+        current[key] = value
 
     # Normalize limits (migrate old -> new) before persisting
     current = _normalize_config(current)

--- a/dashboard/backend/app/routers/queue.py
+++ b/dashboard/backend/app/routers/queue.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from typing import Optional
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_db
@@ -220,32 +220,53 @@ async def claim_work(
 ):
     """Atomically claim the highest-priority pending item (work-stealing pattern).
 
+    Uses an atomic UPDATE-WHERE to prevent race conditions when multiple
+    employees try to claim simultaneously.  SQLite serializes writes, so
+    the second claimer sees rowcount == 0 and gets 204.
+
     Returns the claimed item, or 204 No Content if nothing is available.
     """
-    q = (
-        select(QueueItem)
+    # Subquery: find the best pending item's ID
+    sub = (
+        select(QueueItem.id)
         .where(QueueItem.state == "pending")
-        .order_by(QueueItem.priority.desc(), QueueItem.created_at.asc())
-        .limit(1)
     )
     if project_repo:
-        q = q.where(QueueItem.project_repo == project_repo)
+        sub = sub.where(QueueItem.project_repo == project_repo)
     if mode:
-        q = q.where(QueueItem.mode == mode)
-
-    result = await db.execute(q)
-    item = result.scalar_one_or_none()
-    if not item:
-        return Response(status_code=204)
+        sub = sub.where(QueueItem.mode == mode)
+    sub = sub.order_by(QueueItem.priority.desc(), QueueItem.created_at.asc()).limit(1)
+    best = sub.scalar_subquery()
 
     now = _utcnow()
-    item.state = "claimed"
-    item.assigned_to = employee_index
-    item.run_id = run_id
-    item.assigned_at = now
-    item.updated_at = now
+    stmt = (
+        update(QueueItem)
+        .where(QueueItem.id == best, QueueItem.state == "pending")
+        .values(
+            state="claimed",
+            assigned_to=employee_index,
+            run_id=run_id,
+            assigned_at=now,
+            updated_at=now,
+        )
+    )
+    result = await db.execute(stmt)
+    if result.rowcount == 0:
+        return Response(status_code=204)
+
     await db.commit()
-    await db.refresh(item)
+
+    # Fetch the claimed item for the response
+    fetch = await db.execute(
+        select(QueueItem).where(
+            QueueItem.assigned_to == employee_index,
+            QueueItem.run_id == run_id,
+            QueueItem.state == "claimed",
+        ).order_by(QueueItem.updated_at.desc()).limit(1)
+    )
+    item = fetch.scalar_one_or_none()
+    if not item:
+        return Response(status_code=204)
 
     await event_bus_publish({
         "type": "queue_claimed",

--- a/dashboard/backend/app/services/adapters/telegram.py
+++ b/dashboard/backend/app/services/adapters/telegram.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 from typing import Any
 
 from app.services.adapters.base import NotificationAdapter, STATUS_EMOJI
@@ -33,19 +34,19 @@ class TelegramAdapter(NotificationAdapter):
     ) -> dict[str, Any]:
         emoji = STATUS_EMOJI.get(event_type, "\u2139\uFE0F")
 
-        lines = [f"<b>{emoji} {event_type} \u2014 {project}</b>"]
+        lines = [f"<b>{emoji} {html.escape(event_type)} \u2014 {html.escape(project)}</b>"]
 
         if issue_number is not None:
             issue_text = f"#{issue_number}"
             if issue_title:
-                issue_text += f" {issue_title}"
+                issue_text += f" {html.escape(issue_title)}"
             lines.append(f"<b>Issue:</b> {issue_text}")
 
         if tokens_total is not None:
             lines.append(f"<b>Tokens:</b> {tokens_total:,}")
 
         if summary:
-            lines.append(f"\n{summary[:1000]}")
+            lines.append(f"\n{html.escape(summary[:1000])}")
 
         if dashboard_url and run_id:
             lines.append(f'\n<a href="{dashboard_url}/runs/{run_id}">View in Dashboard</a>')

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -54,6 +54,7 @@ export interface Run {
   employee_report: string | null;
   verdict_detail: string | null;
   log_file: string | null;
+  trace_id: string | null;
   employee_index: number | null;
   concurrent_group_id: string | null;
 }


### PR DESCRIPTION
## Summary
- **H-2**: Replace SELECT-then-UPDATE with atomic `UPDATE ... WHERE state='pending'` in queue claim endpoint — prevents race condition when multiple employees claim simultaneously
- **H-7**: Add `StationConfigUpdate` Pydantic model with `extra="forbid"` for config PUT — rejects unknown keys with 422
- **H-10**: Add missing `trace_id: string | null` to frontend `Run` type
- **NEW-2**: HTML-escape `event_type`, `project`, `issue_title`, and `summary` in Telegram adapter to prevent HTML injection
- **Doc**: Update ARCHITECTURE.md — table count (9→14), router count (16→20), security descriptions

## Test plan
- [x] All 497 backend tests pass
- [x] Frontend builds successfully
- [ ] PUT `/api/config` with unknown key → expect 422
- [ ] Verify queue claim works with concurrent employees
- [ ] Telegram notification with `<script>` in project name renders safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)