### PR TITLE
fix: resolve 422 error when saving intelligence settings

### DIFF
--- a/dashboard/backend/app/routers/config_router.py
+++ b/dashboard/backend/app/routers/config_router.py
@@ -91,9 +91,10 @@ async def get_config():
 class StationConfigUpdate(BaseModel):
     models: dict[str, Any] | None = None
     limits: dict[str, Any] | None = None
-    schedule: dict[str, Any] | None = None
+    schedule: str | None = None
     notifications: dict[str, Any] | None = None
     logging: dict[str, Any] | None = None
+    intelligence: dict[str, Any] | None = None
     model_config = ConfigDict(extra="forbid")
 
 

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -45,7 +45,10 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
       let message: string;
       try {
         const parsed = JSON.parse(body);
-        message = parsed.detail || body;
+        const detail = parsed.detail;
+        message = Array.isArray(detail)
+          ? detail.map((e: any) => e.msg ?? JSON.stringify(e)).join('; ')
+          : (detail || body);
       } catch { message = body; }
       throw new Error(`${res.status}: ${message}`);
     }


### PR DESCRIPTION
## Summary
- **Add `intelligence` field** to `StationConfigUpdate` Pydantic model — fixes the 422 rejection when saving intelligence settings
- **Fix `schedule` type** from `dict` to `str` — prevents a masked 422 when saving schedule values
- **Humanize 422 error messages** — Pydantic's array `detail` is now joined into readable text instead of `[object Object],[object Object]`

## Test plan
- [x] All 497 backend tests pass
- [x] Frontend builds cleanly
- [x] Intelligence settings save and persist correctly (verified via API)
- [ ] Schedule value saves without error
- [ ] Malformed request shows human-readable error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)