### PR TITLE
fix: intelligence cache reactive loop + canvas freeze

### DIFF
--- a/dashboard/backend/app/routers/config_router.py
+++ b/dashboard/backend/app/routers/config_router.py
@@ -189,20 +189,26 @@ async def get_usage():
     )
 
     usage_path = Path(settings.log_dir) / "usage-tracking.json"
-    if not usage_path.exists():
-        return {
-            "sessions_used": 0,
-            "max_usage_percent": max_usage_pct,
-            "window_start": time.time(),
-            "window_remaining_hours": 24.0,
-            "usage_percent": 0.0,
-        }
+    empty_usage = {
+        "sessions_used": 0,
+        "max_usage_percent": max_usage_pct,
+        "window_start": time.time(),
+        "window_remaining_hours": 24.0,
+        "usage_percent": 0.0,
+    }
+    if not usage_path.exists() or usage_path.stat().st_size == 0:
+        return empty_usage
 
     def _read_usage():
         with open(usage_path) as f:
-            return json.load(f)
+            content = f.read().strip()
+            if not content:
+                return None
+            return json.loads(content)
 
     data = await asyncio.to_thread(_read_usage)
+    if data is None:
+        return empty_usage
 
     sessions_used = data.get("sessions_used", 0)
     window_start = data.get("window_start", time.time())

--- a/dashboard/frontend/src/App.svelte
+++ b/dashboard/frontend/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { route, navigate, handleLinkClick } from './lib/router.svelte';
   import { getSystemStatus, getAuthStatus, getUsage, triggerRun, getGitHubOAuthStatus } from './lib/api';
   import { toastSuccess, toastError } from './lib/toast.svelte';
@@ -121,7 +122,7 @@
 
   // Intelligence cache lifecycle
   $effect(() => {
-    startIntelligenceRefresh();
+    untrack(() => startIntelligenceRefresh());
     return () => stopIntelligenceRefresh();
   });
 

--- a/dashboard/frontend/src/components/AgentWorkspace.svelte
+++ b/dashboard/frontend/src/components/AgentWorkspace.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { WorkspaceRenderer } from '../lib/workspace-renderer';
   import { agentPresence, togglePanel } from '../lib/agent-presence.svelte';
   import { navigate } from '../lib/router.svelte';
@@ -25,6 +26,10 @@
   // HUD tool cycling state
   let hudToolCycleIndex = $state(0);
   let hudToolCycleTimer: ReturnType<typeof setInterval> | null = null;
+
+  // rAF throttle for renderer updates — prevents effect storms from starving the animation loop
+  let dataRafPending = false;
+  let activityRafPending = false;
 
   // Initialize renderer
   $effect(() => {
@@ -74,43 +79,74 @@
   });
 
   // Feed agent-presence data to renderer (with employee data)
+  // Throttled to once per animation frame — during active runs, agentPresence
+  // $state changes dozens of times/sec (tool calls, thinking, intensity samples).
+  // Without throttling, each change re-runs this effect synchronously,
+  // starving requestAnimationFrame and freezing the canvas.
   $effect(() => {
-    renderer?.setData({
-      agents: agentPresence.agents.map(a => ({
-        id: a.name,
-        role: a.role,
-        name: a.name,
-        color: a.color,
-        isActive: a.status === 'active' || a.status === 'thinking',
-        isThinking: a.status === 'thinking',
-        currentAction: a.currentAction,
-        turnCount: agentPresence.turnCount,
-        tokenCount: agentPresence.tokensBurned,
-        employees: agentPresence.activeRuns
-          .filter(r => r.mode !== 'manager' && r.mode !== 'analyst')
-          .map((r, i) => ({
-            index: i,
-            runId: r.run_id,
-            status: r.status === 'running' ? 'working' as const : 'waiting' as const,
-            tool: null,
-            issueNumber: r.issue_number,
-            inWorktree: false, // TODO: populate from backend when available
-            tokensUsed: 0,
-            turnsUsed: r.turns ?? 0,
+    // Read all reactive deps to establish tracking
+    const agents = agentPresence.agents;
+    const activeRuns = agentPresence.activeRuns;
+    const phase = agentPresence.phase;
+    const turnCount = agentPresence.turnCount;
+    const tokensBurned = agentPresence.tokensBurned;
+    const activityIntensity = agentPresence.activityIntensity;
+    const svcActive = systemStatus?.service.active ?? false;
+    const usagePct = usage?.usage_percent ?? 0;
+    // Deep-read agent properties so Svelte tracks them
+    const agentSnapshot = agents.map(a => ({ name: a.name, role: a.role, color: a.color, status: a.status, currentAction: a.currentAction }));
+    const runSnapshot = activeRuns.map(r => ({ run_id: r.run_id, mode: r.mode, status: r.status, issue_number: r.issue_number, turns: r.turns }));
+
+    if (dataRafPending) return;
+    dataRafPending = true;
+    requestAnimationFrame(() => {
+      dataRafPending = false;
+      untrack(() => {
+        renderer?.setData({
+          agents: agentSnapshot.map(a => ({
+            id: a.name,
+            role: a.role,
+            name: a.name,
+            color: a.color,
+            isActive: a.status === 'active' || a.status === 'thinking',
+            isThinking: a.status === 'thinking',
+            currentAction: a.currentAction,
+            turnCount,
+            tokenCount: tokensBurned,
+            employees: runSnapshot
+              .filter(r => r.mode !== 'manager' && r.mode !== 'analyst')
+              .map((r, i) => ({
+                index: i,
+                runId: r.run_id,
+                status: r.status === 'running' ? 'working' as const : 'waiting' as const,
+                tool: null,
+                issueNumber: r.issue_number,
+                inWorktree: false,
+                tokensUsed: 0,
+                turnsUsed: r.turns ?? 0,
+              })),
           })),
-      })),
-      phase: agentPresence.phase,
-      serviceActive: systemStatus?.service.active ?? false,
-      usagePercent: usage?.usage_percent ?? 0,
-      activityIntensity: agentPresence.activityIntensity,
+          phase,
+          serviceActive: svcActive,
+          usagePercent: usagePct,
+          activityIntensity,
+        });
+      });
     });
   });
 
   $effect(() => {
-    renderer?.setActivity({
-      intensity: agentPresence.activityIntensity,
-      currentTool: agentPresence.currentTool?.summary ?? null,
-      activeAgent: agentPresence.agents.find(a => a.status === 'active')?.name ?? null,
+    const intensity = agentPresence.activityIntensity;
+    const toolSummary = agentPresence.currentTool?.summary ?? null;
+    const activeAgent = agentPresence.agents.find(a => a.status === 'active')?.name ?? null;
+
+    if (activityRafPending) return;
+    activityRafPending = true;
+    requestAnimationFrame(() => {
+      activityRafPending = false;
+      untrack(() => {
+        renderer?.setActivity({ intensity, currentTool: toolSummary, activeAgent });
+      });
     });
   });
 

--- a/dashboard/frontend/src/components/IntelligencePanel.svelte
+++ b/dashboard/frontend/src/components/IntelligencePanel.svelte
@@ -1,34 +1,29 @@
 <script lang="ts">
-  import { getIntelligenceInsights, getIntelligenceDecisions, getBackpressure } from '../lib/api';
-  import type { IntelligenceInsights, IntelligenceDecision, BackpressureStatus } from '../lib/types';
+  import { getIntelligenceDecisions } from '../lib/api';
+  import { intelligenceCache } from '../lib/intelligence-cache.svelte';
+  import type { IntelligenceDecision } from '../lib/types';
   import GlassCard from './GlassCard.svelte';
   import EscalationTimeline from './EscalationTimeline.svelte';
   import ConfidenceCalibration from './ConfidenceCalibration.svelte';
 
-  let insights = $state<IntelligenceInsights | null>(null);
+  let insights = $derived(intelligenceCache.insights);
+  let pressure = $derived(intelligenceCache.backpressure);
   let decisions = $state<IntelligenceDecision[]>([]);
-  let pressure = $state<BackpressureStatus | null>(null);
   let expanded = $state(false);
   let loading = $state(false);
 
-  async function loadData() {
+  async function loadDecisions() {
     loading = true;
     try {
-      const [insightsRes, decisionsRes, pressureRes] = await Promise.allSettled([
-        getIntelligenceInsights(),
-        getIntelligenceDecisions({ limit: 10 }),
-        getBackpressure(),
-      ]);
-      if (insightsRes.status === 'fulfilled') insights = insightsRes.value;
-      if (decisionsRes.status === 'fulfilled') decisions = decisionsRes.value;
-      if (pressureRes.status === 'fulfilled') pressure = pressureRes.value;
+      const res = await getIntelligenceDecisions({ limit: 10 });
+      decisions = res;
     } catch { /* silent */ }
     finally { loading = false; }
   }
 
   function toggle() {
     expanded = !expanded;
-    if (expanded && !insights) loadData();
+    if (expanded) loadDecisions();
   }
 
   function pressureColor(level: string): string {
@@ -60,8 +55,8 @@
 
   $effect(() => {
     if (expanded) {
-      loadData();
-      const interval = setInterval(loadData, 30000);
+      loadDecisions();
+      const interval = setInterval(loadDecisions, 30000);
       return () => clearInterval(interval);
     }
   });

--- a/dashboard/frontend/src/lib/intelligence-cache.svelte.ts
+++ b/dashboard/frontend/src/lib/intelligence-cache.svelte.ts
@@ -48,7 +48,7 @@ export async function refreshIntelligence() {
 
 export function startIntelligenceRefresh() {
   if (refreshTimer) return;
-  refreshIntelligence();
+  setTimeout(refreshIntelligence, 0);
   refreshTimer = setInterval(refreshIntelligence, REFRESH_INTERVAL);
 }
 

--- a/dashboard/frontend/src/lib/workspace-renderer.ts
+++ b/dashboard/frontend/src/lib/workspace-renderer.ts
@@ -860,8 +860,12 @@ export class WorkspaceRenderer {
     if (!this.running) return;
     const dt = Math.min(now - this.lastTime, 50);
     this.lastTime = now;
-    this.update(dt);
-    this.draw();
+    try {
+      this.update(dt);
+      this.draw();
+    } catch {
+      // Swallow draw/update errors to keep the animation loop alive
+    }
     this.rafId = requestAnimationFrame(this.tick);
   };
 


### PR DESCRIPTION
## Summary

- **Intelligence cache infinite loop**: Svelte 5 `$effect` tracked `$state` reads inside `refreshIntelligence()`, creating a reactive cycle firing thousands of requests/sec. Fixed with `untrack()` + `setTimeout` deferral.
- **Usage endpoint 500**: Empty `usage-tracking.json` (0 bytes after midnight truncation) crashed `json.load()`. Now returns sensible defaults.
- **Mission Cortex canvas freeze**: During active runs with 8 employees, `agentPresence` `$state` changes dozens of times/sec. Each change synchronously re-ran `setData`/`setActivity` effects, starving `requestAnimationFrame`. Fixed with rAF-throttled effect batching + try-catch in `tick()`.
- **Duplicate polling eliminated**: `IntelligencePanel` now reads from `intelligenceCache` instead of making its own insight/pressure requests.

## Test plan

- [ ] Hard-refresh dashboard, confirm Network tab shows ~1 pair of intelligence/pressure requests every 5 min (not thousands/sec)
- [ ] Navigate to Pulse page, confirm Mission Cortex canvas animates smoothly
- [ ] Trigger or wait for an active run — confirm canvas stays animated with 8 employees
- [ ] Expand Intelligence Panel — confirm it shows cached data, only fetches decisions independently
- [ ] Confirm `/api/config/usage` returns 200 (not 500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)