### PR TITLE
fix: restore Modal portal to escape TopNav stacking context [P0.T1]

### DIFF
--- a/dashboard/frontend/src/components/overlays/Modal.svelte
+++ b/dashboard/frontend/src/components/overlays/Modal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { portal } from '../../lib/portal';
 
   let {
     show = false,
@@ -30,6 +31,7 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
+    use:portal
     class="fixed inset-0 z-modal flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-fade-in-up"
     onclick={handleBackdrop}
   >

--- a/dashboard/frontend/src/lib/portal.ts
+++ b/dashboard/frontend/src/lib/portal.ts
@@ -1,0 +1,15 @@
+export function portal(node: HTMLElement, target: HTMLElement | string = document.body) {
+  const resolve = (t: HTMLElement | string): HTMLElement =>
+    typeof t === 'string' ? ((document.querySelector(t) as HTMLElement) ?? document.body) : t;
+  let host = resolve(target);
+  host.appendChild(node);
+  return {
+    update(newTarget: HTMLElement | string) {
+      host = resolve(newTarget);
+      host.appendChild(node);
+    },
+    destroy() {
+      if (node.parentNode) node.parentNode.removeChild(node);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Add reusable `src/lib/portal.ts` Svelte action that reparents a node to `document.body`.
- Apply `use:portal` to Modal.svelte's outer `fixed inset-0 z-modal` element so the modal escapes TopNav's `backdrop-filter: blur(24px)` stacking context.

## Why
Modals were clipped behind TopNav because `backdrop-filter` creates a new stacking context that `z-modal` cannot escape. Derived from prior work in `eae97ea` (inline portal), extracted into a reusable action.

## Test plan
- [ ] Open any modal (ProjectsPage) while scrolled down → backdrop covers full viewport, no TopNav bleed
- [ ] `npm run build` succeeds
- [ ] Part of Phase 0 stabilization plan (see `/root/.claude/plans/fluttering-meandering-clarke.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)