### PR TITLE
fix: System Health reads correct backend memory/uptime fields [P0.T2]

### DIFF
--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -333,7 +333,16 @@ export interface TokenUsage {
 export interface SystemStatus {
   service: { active: boolean; status: string };
   timer: { active: boolean; next: string | null };
-  resources: { memory_mb: number; load_avg: number[]; disk_free_gb: number; uptime_seconds: number };
+  resources: {
+    memory_total_mb?: number;
+    memory_available_mb?: number;
+    memory_used_mb?: number;
+    load_avg?: number[];
+    disk_total_gb?: number;
+    disk_free_gb?: number;
+    disk_used_gb?: number;
+    uptime_seconds?: number;
+  };
 }
 
 export interface AuthStatus {

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -3,6 +3,21 @@
   import { navigate } from '../lib/router.svelte';
   import { agentPresence } from '../lib/agent-presence.svelte';
   import { formatTokens, formatDuration, timeAgo, formatPercent } from '../lib/format';
+
+  function formatUptime(seconds: number | null | undefined): string {
+    if (seconds == null) return '—';
+    const d = Math.floor(seconds / 86400);
+    const h = Math.floor((seconds % 86400) / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    if (d > 0) return `${d}d ${h}h`;
+    if (h > 0) return `${h}h ${m}m`;
+    return `${m}m`;
+  }
+
+  function formatMemoryMB(usedMb: number | null | undefined, totalMb: number | null | undefined): string {
+    if (usedMb == null || totalMb == null) return '—';
+    return `${(usedMb / 1024).toFixed(1)} / ${(totalMb / 1024).toFixed(1)} GB`;
+  }
   import type { Run, QueueStats, TokenUsage, SystemStatus, AnalyticsResponse, BackpressureStatus, ActiveEmployee, QueueItem } from '../lib/types';
   import VaporCard from '../components/vapor/VaporCard.svelte';
   import VaporBadge from '../components/vapor/VaporBadge.svelte';
@@ -281,11 +296,11 @@
           </div>
           <div style="display: flex; justify-content: space-between; align-items: center;">
             <span style="font-size: 14px; color: #3D2A1A;">Memory</span>
-            <span style="font-size: 13px; color: #8C7A66;">{systemStatus?.resources?.memory ?? '—'}</span>
+            <span style="font-size: 13px; color: #8C7A66;">{formatMemoryMB(systemStatus?.resources?.memory_used_mb, systemStatus?.resources?.memory_total_mb)}</span>
           </div>
           <div style="display: flex; justify-content: space-between; align-items: center;">
             <span style="font-size: 14px; color: #3D2A1A;">Uptime</span>
-            <span style="font-size: 13px; color: #8C7A66;">{systemStatus?.resources?.uptime ?? '—'}</span>
+            <span style="font-size: 13px; color: #8C7A66;">{formatUptime(systemStatus?.resources?.uptime_seconds)}</span>
           </div>
         </div>
       </VaporCard>


### PR DESCRIPTION
## Summary
- CommandCenter System Health panel now reads `memory_used_mb`/`memory_total_mb`/`uptime_seconds` — the actual backend fields from `services/systemd.py:86+`.
- Add `formatUptime()` and `formatMemoryMB()` helpers.
- Align the `SystemStatus` type in `lib/types.ts` with the real backend shape.

## Why
Panel always showed `—` because the frontend read `systemStatus.resources.memory` / `.uptime` — fields the backend never emits.

## Test plan
- [ ] Memory row shows `X.X / Y.Y GB`, not `—`
- [ ] Uptime shows `Xd Yh` or `Xh Ym`, not `—`
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)