### PR TITLE
fix: align frontend timer field with backend next_trigger [P0.T3]

### DIFF
--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -332,7 +332,7 @@ export interface TokenUsage {
 // --- System ---
 export interface SystemStatus {
   service: { active: boolean; status: string };
-  timer: { active: boolean; next: string | null };
+  timer: { active: boolean; next_trigger: string | null };
   resources: { memory_mb: number; load_avg: number[]; disk_free_gb: number; uptime_seconds: number };
 }
 

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -41,8 +41,8 @@
     if ((queueStats?.by_state?.review ?? 0) > 0) {
       return `${queueStats!.by_state.review} item${queueStats!.by_state.review > 1 ? 's' : ''} need review`;
     }
-    if (systemStatus?.timer?.next) {
-      return `Next run ${timeAgo(systemStatus.timer.next)}`;
+    if (systemStatus?.timer?.next_trigger) {
+      return `Next run ${timeAgo(systemStatus.timer.next_trigger)}`;
     }
     return 'All systems nominal';
   });

--- a/dashboard/frontend/src/pages/SettingsPage.svelte
+++ b/dashboard/frontend/src/pages/SettingsPage.svelte
@@ -169,7 +169,7 @@
         <div class="flex items-center justify-between text-sm">
           <div>
             <div class="text-primary">Timer</div>
-            <div class="text-xs text-tertiary">Next: {systemStatus.timer.next ?? 'N/A'}</div>
+            <div class="text-xs text-tertiary">Next: {systemStatus.timer.next_trigger ?? 'N/A'}</div>
           </div>
           <span class="w-2 h-2 rounded-full {systemStatus.timer.active ? 'bg-status-active' : 'bg-status-inactive'}"></span>
         </div>


### PR DESCRIPTION
## Summary
Rename `timer.next` → `timer.next_trigger` at three call sites (CommandCenter greeting, SettingsPage system tab, `lib/types.ts` `SystemStatus`).

## Why
Backend `routers/system.py:39` emits `timer.next_trigger`; frontend was reading the wrong key and always showed "N/A" / no greeting "Next run …" line.

## Test plan
- [ ] CommandCenter greeting shows `Next run in Xm` when service is armed
- [ ] Settings → System tab timer row shows a real ISO timestamp, not `N/A`

🤖 Generated with [Claude Code](https://claude.com/claude-code)