### PR TITLE
fix: agent-presence fallback uses status='started' [P0.T4]

### DIFF
--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -489,7 +489,7 @@ async function refreshActiveRuns() {
     // project_id is NULL on newly created runs), then fall back to latestRun.
     if (activeEmployees.length === 0) {
       try {
-        const runningRuns = await listRuns({ status: 'running', limit: 10 });
+        const runningRuns = await listRuns({ status: 'started', limit: 10 });
         if (runningRuns.runs && runningRuns.runs.length > 0) {
           activeEmployees = runningRuns.runs.map((r: Run, idx: number) => ({
             run_id: r.run_id,


### PR DESCRIPTION
## Summary
`agent-presence.svelte.ts:492` fallback now queries `listRuns({ status: 'started' })` — matching what Agent Teams writes to `Run.status`.

## Why
Fallback was always empty (queried `'running'` which the lifecycle doesn't use). Result: AgentTeamsCanvas showed the idle state during live multi-employee runs whenever `/api/active-employees` was briefly empty.

## Test plan
- [ ] Trigger a multi-employee run → teammates show up even before `/api/active-employees` populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)