### PR TITLE
fix: make TeammateCard state reactive via $derived [P0.T5]

### DIFF
--- a/dashboard/frontend/src/components/agent-teams/TeammateCard.svelte
+++ b/dashboard/frontend/src/components/agent-teams/TeammateCard.svelte
@@ -22,10 +22,10 @@
     connections?: { direction: 'in' | 'out' | 'both'; target: string; type: 'peer' | 'lead' }[];
   } = $props();
 
-  const isActive = statusType === 'working';
-  const isReviewing = statusType === 'reviewing';
-  const isBlocked = statusType === 'blocked' || statusType === 'idle';
-  const statusColor = isActive ? '#2E7D32' : isReviewing ? '#B06030' : '#8C7A66';
+  let isActive = $derived(statusType === 'working');
+  let isReviewing = $derived(statusType === 'reviewing');
+  let isBlocked = $derived(statusType === 'blocked' || statusType === 'idle');
+  let statusColor = $derived(isActive ? '#2E7D32' : isReviewing ? '#B06030' : '#8C7A66');
 </script>
 
 <div


### PR DESCRIPTION
## Summary
Rewrite `isActive`, `isReviewing`, `isBlocked`, `statusColor` in `TeammateCard.svelte:25-28` as `\$derived` instead of plain `const`.

## Why
In Svelte 5 runes mode, plain `const` values are evaluated once at component creation and do not track prop changes. `statusType` flipping from `idle` → `working` → `reviewing` therefore left the classes frozen on initial values. Svelte's `state_referenced_locally` build warning disappears.

## Notes
- Preserves existing behavior (idle still rolls into isBlocked). That semantic split is P2.T3.

## Test plan
- [ ] Trigger a run → watch a teammate transition idle → working → completed and confirm class changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)