### PR TITLE
feat: expose tokens_total + started_at on ActiveEmployeeOut [P0.T6]

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -97,6 +97,8 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
             concurrent_group_id=r.concurrent_group_id,
             model=r.model,
             branch=r.branch,
+            tokens_total=r.tokens_total,
+            started_at=r.started_at,
         )
         for r in runs
     ]
@@ -126,6 +128,7 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
                 proj = proj_result.scalar_one_or_none()
                 project_id = proj.id if proj else 0
 
+            parent_run = employees[0] if employees else None
             employees.append(ActiveEmployeeOut(
                 run_id=ct.run_id,
                 project_id=project_id,
@@ -137,6 +140,8 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
                 concurrent_group_id=ct.run_id,
                 model=None,
                 branch=ct.branch,
+                tokens_total=parent_run.tokens_total if parent_run else None,
+                started_at=ct.started_at or (parent_run.started_at if parent_run else None),
             ))
 
     return employees

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -98,6 +98,8 @@ class ActiveEmployeeOut(BaseModel):
     concurrent_group_id: str | None = None
     model: str | None = None
     branch: str | None = None
+    tokens_total: int | None = None
+    started_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -85,6 +85,7 @@ async def sample_runs(setup_db):
                 project_id=project.id,
                 status="running",
                 issue_number=3,
+                tokens_total=15000,
                 started_at=now,
                 employee_index=1,
                 concurrent_group_id="group-A",
@@ -232,6 +233,10 @@ async def test_get_active_employees(client, sample_runs):
     assert data[0]["run_id"] == "run-003"
     assert data[0]["status"] == "running"
     assert data[0]["issue_number"] == 3
+    # tokens_total and started_at surface on the schema so the AgentTeams canvas
+    # can render real duration and token counts on the Lead card.
+    assert data[0]["tokens_total"] == 15000
+    assert data[0]["started_at"] is not None
 
 
 @pytest.mark.asyncio

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -83,6 +83,8 @@ export interface ActiveEmployee {
   concurrent_group_id: string | null;
   model: string | null;
   branch: string | null;
+  tokens_total?: number | null;
+  started_at?: string | null;
 }
 
 export interface TeammateStatus {


### PR DESCRIPTION
## Summary
- Extend `ActiveEmployeeOut` Pydantic schema with `tokens_total: int | None` and `started_at: datetime | None`.
- Thread the values through both the direct `Run` construction and the `CoordinatorTask` fallback in `routers/runs.py`.
- Add matching optional fields on the frontend `ActiveEmployee` interface.
- Extend `test_get_active_employees` to assert the new fields surface.

## Why
`AgentTeamsCanvas.svelte:140,169` already reads `e.tokens_total` and `employees[0]?.started_at` for the Lead card's token count and duration — neither ever surfaced, so the card showed 0 tokens and `—` duration during live runs.

## Migration
None. Both columns already exist on `Run` (models.py:54, 57).

## Test plan
- [ ] `pytest dashboard/backend/tests/test_runs.py::test_get_active_employees` passes
- [ ] Trigger a run → Agent Teams canvas Lead card shows non-zero tokens and running duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)