### PR TITLE
test(e2e): stabilize pages.spec.ts with data-testid + real assertions [P0.T7]

### DIFF
--- a/dashboard/frontend/e2e/pages.spec.ts
+++ b/dashboard/frontend/e2e/pages.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+test('Dashboard page loads', async ({ page }) => {
+  await page.goto('/');
+  const root = page.locator('[data-testid="command-center"]');
+  await expect(root).toBeVisible({ timeout: 5000 });
+  await page.screenshot({ path: 'screenshots/01-dashboard.png', fullPage: true });
+});
+
+test('Agents page (idle state)', async ({ page }) => {
+  await page.goto('/agents');
+  // /agents redirects to /agent-teams. Idle copy is the off-duty heading.
+  const heading = page.getByRole('heading', { name: /off-duty|team/i });
+  await expect(heading).toBeVisible({ timeout: 5000 });
+  await page.screenshot({ path: 'screenshots/02-agents-idle.png', fullPage: true });
+});
+
+test('Runs page loads', async ({ page }) => {
+  await page.goto('/runs');
+  await expect(page.locator('.animate-fade-in').first()).toBeVisible({ timeout: 5000 });
+  await page.screenshot({ path: 'screenshots/03-runs.png', fullPage: true });
+});
+
+test('Queue page loads', async ({ page }) => {
+  await page.goto('/queue');
+  await expect(page.locator('.animate-fade-in-up, .animate-fade-in').first()).toBeVisible({ timeout: 5000 });
+  await page.screenshot({ path: 'screenshots/04-queue.png', fullPage: true });
+});
+
+test('Settings page loads', async ({ page }) => {
+  await page.goto('/settings');
+  // Settings exposes tabs — assert at least one tab button is visible.
+  const tab = page.getByRole('button', { name: /general|models|services|auth|prompts/i }).first();
+  await expect(tab).toBeVisible({ timeout: 5000 });
+  await page.screenshot({ path: 'screenshots/05-settings.png', fullPage: true });
+});

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -134,7 +134,7 @@
   }
 </script>
 
-<div style="animation: greeting-in 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;">
+<div data-testid="command-center" style="animation: greeting-in 0.8s cubic-bezier(0.16, 1, 0.3, 1) both;">
 
   {#if loading}
     <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 28px;">


### PR DESCRIPTION
## Summary
- Add `data-testid="command-center"` to the CommandCenter root div.
- Rewrite `e2e/pages.spec.ts`: the Dashboard test keys off the new testid; the other four tests replace `waitForTimeout(2000)` with semantic `expect(locator).toBeVisible()` assertions.

## Why
The Dashboard test waited for `.animate-fade-in`, which CommandCenter never sets — the page uses an inline `greeting-in` animation instead. Result: test would pass on screenshot-only but never validate anything. Five tests now assert real UI invariants.

## Test plan
- [ ] `cd dashboard/frontend && npx playwright test pages.spec.ts` — all 5 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)