### PR TITLE
chore(deps): pin claude-agent-sdk==0.1.50 [P1.T1]

### DIFF
--- a/dashboard/backend/requirements.txt
+++ b/dashboard/backend/requirements.txt
@@ -9,5 +9,6 @@ eval-type-backport>=0.2.0;python_version<"3.10"
 pydantic-settings>=2.0
 httpx>=0.27.0
 anthropic>=0.42.0
+claude-agent-sdk==0.1.50
 scipy>=1.11.0
 numpy>=1.24.0


### PR DESCRIPTION
## Summary
Pin \`claude-agent-sdk==0.1.50\` in \`dashboard/backend/requirements.txt\`. The SDK was installed in the project venv but never declared.

## Why
Phase 1 Auto Mode wiring depends on stable SDK surface: \`permission_mode\`, \`can_use_tool\`, \`hooks\`, \`max_budget_usd\`. All verified present at 0.1.50.

## Test plan
- [ ] \`python3 -m venv /tmp/cas-check && /tmp/cas-check/bin/pip install -r dashboard/backend/requirements.txt && /tmp/cas-check/bin/python -c 'import claude_agent_sdk; print(claude_agent_sdk.__version__)'\` → \`0.1.50\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)