### PR TITLE
feat(agent): auto mode policy engine [P1.T4]

### DIFF
--- a/agent/auto_mode.py
+++ b/agent/auto_mode.py
@@ -1,0 +1,174 @@
+"""Auto Mode policy engine — ADR-0001.
+
+Decides whether a tool invocation is allowed at a given autonomy level.
+Wired into the Claude Agent SDK's `can_use_tool` callback. See
+`docs/adr/0001-autonomy-levels.md` for the policy matrix.
+
+Design goals:
+- Pure function where possible — easy to unit test.
+- Default-deny on unknown tools.
+- Always-deny list cannot be overridden by level=auto.
+- Never raise — the SDK expects a PermissionResult, not an exception.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import Enum
+from typing import Any
+
+from claude_agent_sdk.types import (
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
+
+PermissionResult = PermissionResultAllow | PermissionResultDeny
+
+
+class AutonomyLevel(str, Enum):
+    MANUAL = "manual"
+    ASSISTED = "assisted"
+    AUTO = "auto"
+
+
+def _coerce_level(value: str | None) -> AutonomyLevel:
+    """Tolerate None / unknown strings — default to ASSISTED."""
+    if not value:
+        return AutonomyLevel.ASSISTED
+    try:
+        return AutonomyLevel(value.lower())
+    except ValueError:
+        return AutonomyLevel.ASSISTED
+
+
+# --- Always-deny list ------------------------------------------------------
+# Patterns here are rejected at every level, including Auto. Added to catch
+# destructive side-effects that should never happen from an autonomous run.
+
+ALWAYS_DENY: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"git\s+push\s+(?:\S+\s+)*(?:HEAD:)?\bmain\b"), "push to main"),
+    (re.compile(r"git\s+push\s+--force"), "force push"),
+    (re.compile(r"git\s+push\s+-f\b"), "force push (-f)"),
+    (re.compile(r"\brm\s+-rf\s+/(\s|$)"), "rm -rf /"),
+    (re.compile(r"\bDROP\s+(TABLE|DATABASE)\b", re.IGNORECASE), "drop table/database"),
+    (re.compile(r"systemctl\s+(restart|stop|disable)\s+claude-"), "control claude service"),
+    (
+        re.compile(r"\b(AWS_SECRET|ANTHROPIC_API_KEY|GITHUB_TOKEN|STATION_WEBHOOK_SECRET)\s*="),
+        "secret exfiltration",
+    ),
+    (re.compile(r"(?:^|\W)sudo\s+rm\b"), "sudo rm"),
+    (re.compile(r"mkfs\."), "filesystem format"),
+    (re.compile(r":\(\)\s*\{"), "fork bomb"),
+]
+
+
+# --- Destructive Bash ------------------------------------------------------
+# Denied at manual/assisted, allowed at auto (still subject to ALWAYS_DENY).
+
+DESTRUCTIVE_BASH: list[re.Pattern[str]] = [
+    re.compile(r"\brm\s+-rf\b"),
+    re.compile(r"\brm\s+-fr\b"),
+    re.compile(r"\bchmod\s+-R\s+777\b"),
+    re.compile(r"\bgit\s+reset\s+--hard\b"),
+    re.compile(r"\bgit\s+clean\s+-fd?x?\b"),
+    re.compile(r"\bgit\s+branch\s+-D\b"),
+    re.compile(r"(?:^|[\s;&|])sudo\b"),
+    re.compile(r"\bdd\s+if="),
+]
+
+
+READ_ONLY_TOOLS = frozenset({"Read", "Glob", "Grep", "NotebookRead"})
+EDIT_TOOLS = frozenset({"Write", "Edit", "NotebookEdit"})
+BASH_TOOL = "Bash"
+AGENT_TOOL = "Agent"
+# Subagent spawn variants used by the SDK.
+SUBAGENT_TOOLS = frozenset({"Agent", "Task", "SubagentStart"})
+
+
+def _input_to_text(tool_input: dict[str, Any]) -> str:
+    """Flatten a tool input dict to a searchable string for deny-list regex."""
+    parts: list[str] = []
+    for value in tool_input.values():
+        if isinstance(value, str):
+            parts.append(value)
+        elif isinstance(value, (int, float, bool)):
+            parts.append(str(value))
+    return " ".join(parts)
+
+
+async def policy_decide(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    ctx: ToolPermissionContext | None,
+    level: AutonomyLevel,
+) -> PermissionResult:
+    """Decide whether `tool_name(tool_input)` is allowed at `level`.
+
+    Parameters
+    ----------
+    tool_name
+        The SDK tool name, e.g. "Bash", "Read", "Edit".
+    tool_input
+        The tool's argument dict (e.g. ``{"command": "ls -la"}``).
+    ctx
+        The SDK-provided ``ToolPermissionContext``. Unused today but required
+        by the SDK callback signature; kept so hooks can evolve without a
+        call-site change.
+    level
+        The autonomy level for the calling run.
+    """
+    del ctx  # Reserved for future per-call context checks.
+
+    as_text = _input_to_text(tool_input)
+
+    # 1. Always-deny list — catches push-to-main etc. regardless of level.
+    for pattern, reason in ALWAYS_DENY:
+        if pattern.search(as_text):
+            return PermissionResultDeny(
+                message=f"blocked by always-deny policy: {reason}",
+                interrupt=False,
+            )
+
+    # 2. Read-only tools — safe at all levels.
+    if tool_name in READ_ONLY_TOOLS:
+        return PermissionResultAllow()
+
+    # 3. Subagent spawn — lead may always fan out to teammates.
+    if tool_name in SUBAGENT_TOOLS:
+        return PermissionResultAllow()
+
+    # 4. Edit tools — manual defers, assisted+ allows.
+    if tool_name in EDIT_TOOLS:
+        if level is AutonomyLevel.MANUAL:
+            return PermissionResultDeny(
+                message="edits require human approval at manual level",
+            )
+        return PermissionResultAllow()
+
+    # 5. Bash — split on destructive patterns.
+    if tool_name == BASH_TOOL:
+        cmd = tool_input.get("command") or ""
+        if not isinstance(cmd, str):
+            return PermissionResultDeny(
+                message=f"Bash input 'command' must be a string, got {type(cmd).__name__}",
+            )
+        is_destructive = any(pat.search(cmd) for pat in DESTRUCTIVE_BASH)
+        if is_destructive:
+            if level is AutonomyLevel.AUTO:
+                return PermissionResultAllow()
+            # Manual/assisted: defer via a deny. The Phase 2 permission tray
+            # will convert this into a tray prompt. Until then, deny is the
+            # safe default.
+            snippet = cmd[:80].replace("\n", " ")
+            return PermissionResultDeny(
+                message=(
+                    f"destructive bash denied at {level.value}: {snippet}"
+                ),
+            )
+        return PermissionResultAllow()
+
+    # 6. Unknown tool — conservative deny.
+    return PermissionResultDeny(
+        message=f"unknown tool {tool_name!r}; denied by default policy",
+    )

--- a/dashboard/backend/tests/test_auto_mode.py
+++ b/dashboard/backend/tests/test_auto_mode.py
@@ -1,0 +1,163 @@
+"""Unit tests for the Auto Mode policy engine — ADR-0001.
+
+Covers the policy matrix from docs/adr/0001-autonomy-levels.md:
+- Read-only tools always allow.
+- Edit tools: deny at manual, allow at assisted/auto.
+- Bash destructive patterns: deny at manual/assisted, allow at auto.
+- ALWAYS_DENY patterns: deny at every level, including auto.
+- Unknown tools: deny at every level.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.auto_mode import AutonomyLevel, _coerce_level, policy_decide
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+
+
+def _is_allow(result) -> bool:
+    return isinstance(result, PermissionResultAllow)
+
+
+def _is_deny(result) -> bool:
+    return isinstance(result, PermissionResultDeny)
+
+
+# --- Read-only tools -------------------------------------------------------
+
+
+@pytest.mark.parametrize("level", list(AutonomyLevel))
+@pytest.mark.parametrize("tool", ["Read", "Glob", "Grep", "NotebookRead"])
+async def test_read_only_always_allowed(level, tool):
+    result = await policy_decide(tool, {"file_path": "/etc/hosts"}, None, level)
+    assert _is_allow(result)
+
+
+# --- Edit tools ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool", ["Write", "Edit", "NotebookEdit"])
+async def test_edit_denied_at_manual(tool):
+    result = await policy_decide(tool, {"file_path": "/tmp/x.txt"}, None, AutonomyLevel.MANUAL)
+    assert _is_deny(result)
+
+
+@pytest.mark.parametrize("level", [AutonomyLevel.ASSISTED, AutonomyLevel.AUTO])
+@pytest.mark.parametrize("tool", ["Write", "Edit", "NotebookEdit"])
+async def test_edit_allowed_at_assisted_and_auto(level, tool):
+    result = await policy_decide(tool, {"file_path": "/tmp/x.txt"}, None, level)
+    assert _is_allow(result)
+
+
+# --- Bash ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("level", list(AutonomyLevel))
+async def test_safe_bash_allowed_at_all_levels(level):
+    for cmd in ["ls -la", "cat README.md", "git status", "git log --oneline", "pwd"]:
+        result = await policy_decide("Bash", {"command": cmd}, None, level)
+        assert _is_allow(result), f"{level.value}: expected allow for {cmd!r}, got {result}"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        "rm -rf node_modules",
+        "git reset --hard HEAD~3",
+        "git branch -D old-feature",
+        "git clean -fd",
+        "chmod -R 777 ./public",
+        "sudo apt install git",
+        "dd if=/dev/zero of=/tmp/x",
+    ],
+)
+async def test_destructive_bash_denied_at_manual_and_assisted(cmd):
+    for level in (AutonomyLevel.MANUAL, AutonomyLevel.ASSISTED):
+        result = await policy_decide("Bash", {"command": cmd}, None, level)
+        assert _is_deny(result), f"{level.value}: expected deny for {cmd!r}, got {result}"
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    ["rm -rf node_modules", "git reset --hard HEAD~3", "chmod -R 777 ./public"],
+)
+async def test_destructive_bash_allowed_at_auto(cmd):
+    result = await policy_decide("Bash", {"command": cmd}, None, AutonomyLevel.AUTO)
+    assert _is_allow(result)
+
+
+# --- Always-deny list ------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "cmd,reason_fragment",
+    [
+        ("git push origin main", "push to main"),
+        ("git push -u origin HEAD:main", "push to main"),
+        ("git push --force origin feature/x", "force push"),
+        ("git push -f origin feature/x", "force push"),
+        ("rm -rf /", "rm -rf /"),
+        ("DROP TABLE projects", "drop table"),
+        ("drop database station", "drop table"),
+        ("systemctl restart claude-station-dashboard.service", "claude service"),
+        ("systemctl stop claude-agent.service", "claude service"),
+        ("echo GITHUB_TOKEN=xyz", "secret exfiltration"),
+        ("export ANTHROPIC_API_KEY=xyz", "secret exfiltration"),
+        ("sudo rm /etc/hosts", "sudo rm"),
+        ("mkfs.ext4 /dev/sda1", "filesystem format"),
+        (":(){ :|:& };:", "fork bomb"),
+    ],
+)
+@pytest.mark.parametrize("level", list(AutonomyLevel))
+async def test_always_deny_blocks_every_level(cmd, reason_fragment, level):
+    """Auto does NOT override ALWAYS_DENY."""
+    result = await policy_decide("Bash", {"command": cmd}, None, level)
+    assert _is_deny(result)
+    assert reason_fragment in result.message
+
+
+# --- Subagent / Agent tool -------------------------------------------------
+
+
+@pytest.mark.parametrize("level", list(AutonomyLevel))
+async def test_subagent_spawn_allowed(level):
+    for tool in ["Agent", "Task", "SubagentStart"]:
+        result = await policy_decide(tool, {"prompt": "do work"}, None, level)
+        assert _is_allow(result)
+
+
+# --- Unknown tools ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("level", list(AutonomyLevel))
+async def test_unknown_tool_denied(level):
+    result = await policy_decide("Mystery", {"foo": "bar"}, None, level)
+    assert _is_deny(result)
+    assert "Mystery" in result.message
+    assert "default policy" in result.message
+
+
+# --- Type coercion / edge cases -------------------------------------------
+
+
+def test_coerce_level_handles_none_and_invalid():
+    assert _coerce_level(None) is AutonomyLevel.ASSISTED
+    assert _coerce_level("") is AutonomyLevel.ASSISTED
+    assert _coerce_level("UNKNOWN") is AutonomyLevel.ASSISTED
+    assert _coerce_level("auto") is AutonomyLevel.AUTO
+    assert _coerce_level("MANUAL") is AutonomyLevel.MANUAL
+
+
+async def test_bash_without_command_key_is_denied():
+    """Defensive: if SDK hands us weird input, we don't crash."""
+    result = await policy_decide("Bash", {"something_else": "noop"}, None, AutonomyLevel.AUTO)
+    # Empty command string is not destructive and not in always-deny → allow.
+    # But non-string command should be denied.
+    assert _is_allow(result)  # empty string -> safe
+
+
+async def test_bash_with_non_string_command_denied():
+    result = await policy_decide("Bash", {"command": 42}, None, AutonomyLevel.AUTO)
+    assert _is_deny(result)
+    assert "must be a string" in result.message


### PR DESCRIPTION
## Summary
- Adds `agent/auto_mode.py` — table-driven `policy_decide(tool, input, ctx, level)` callback for the Claude Agent SDK, implementing the three-level autonomy matrix from ADR-0001.
- Adds 85 parametrized unit tests covering the full policy matrix in `dashboard/backend/tests/test_auto_mode.py`.
- Read-only tools always allowed; subagent spawns always allowed; edits require assisted+; destructive bash requires auto; ALWAYS_DENY (push-to-main, force-push, rm -rf /, DROP TABLE, claude service control, secret-exfil env sets, sudo rm, mkfs, fork bomb) blocks at every level including auto.
- Pure function, default-deny on unknowns, never raises — returns `PermissionResultAllow` / `PermissionResultDeny` as the SDK expects.

## Design notes
- The `ctx: ToolPermissionContext | None` parameter is reserved — it's required by the SDK callback signature and kept so hooks can evolve without a call-site change (will be used in P1.T6 for the audit-hook correlation id).
- Always-deny scans the flattened string of all tool-input values, so `Write({content: "AWS_SECRET=…"})` is caught the same as a bash env-set.
- Non-string Bash `command` → deny with explicit type error (defensive; SDK normally sends a string).

## Test plan
- [x] `PYTHONPATH=venv/lib/python3.12/site-packages /usr/bin/python3.12 -m pytest dashboard/backend/tests/test_auto_mode.py -q` → **85 passed in 1.89s**
- [ ] P1.T5 will wire this into `ClaudeAgentOptions(can_use_tool=…)` in `agent/station_orchestrator.py`
- [ ] P1.T6 will compose with the audit hook to log every decision to `agent_events`

Part of the Auto Mode rollout plan tracked in `/root/.claude/plans/fluttering-meandering-clarke.md`.