### PR TITLE
feat(agent): auto mode audit hook [P1.T6]

### DIFF
--- a/agent/audit_hook.py
+++ b/agent/audit_hook.py
@@ -1,0 +1,152 @@
+"""Auto Mode audit hook — ADR-0001.
+
+Records every `can_use_tool` decision made by :func:`agent.auto_mode.policy_decide`
+to the ``agent_events`` table (see ``dashboard/backend/app/models.py``), so the
+operator has a per-call audit trail of what was allowed/denied at which
+autonomy level.
+
+Design:
+- ``make_audited_policy(run_id, level)`` composes the policy engine with a
+  best-effort sqlite write. The returned coroutine matches the SDK's
+  ``can_use_tool`` signature.
+- Audit writes never raise — a failure to log must not break tool execution.
+  Errors are logged at WARNING.
+- Uses raw ``sqlite3`` so the agent does not import the dashboard backend.
+- Database path comes from ``STATION_DB_PATH`` (matches ``Settings.db_path``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from claude_agent_sdk.types import (
+    PermissionResultAllow,
+    PermissionResultDeny,
+    ToolPermissionContext,
+)
+
+from agent.auto_mode import AutonomyLevel, policy_decide
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DB_PATH = "/var/lib/claude-agent-station/station.db"
+EVENT_TYPE = "auto_mode_decision"
+
+CanUseTool = Callable[
+    [str, dict[str, Any], ToolPermissionContext],
+    Awaitable[PermissionResultAllow | PermissionResultDeny],
+]
+
+
+def _db_path() -> str:
+    return os.environ.get("STATION_DB_PATH", DEFAULT_DB_PATH)
+
+
+def _summarise_input(tool_input: dict[str, Any], limit: int = 500) -> dict[str, Any]:
+    """Truncate long string values so audit rows don't store entire file bodies."""
+    out: dict[str, Any] = {}
+    for key, value in tool_input.items():
+        if isinstance(value, str) and len(value) > limit:
+            out[key] = value[:limit] + f"…[+{len(value) - limit} chars]"
+        else:
+            out[key] = value
+    return out
+
+
+def write_decision_event(
+    *,
+    run_id: str,
+    agent_id: str,
+    level: AutonomyLevel,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    decision: PermissionResultAllow | PermissionResultDeny,
+    db_path: str | None = None,
+) -> None:
+    """Append one audit row. Never raises."""
+    path = db_path or _db_path()
+    allowed = isinstance(decision, PermissionResultAllow)
+    reason = "" if allowed else getattr(decision, "message", "") or ""
+
+    payload = {
+        "level": level.value,
+        "tool_name": tool_name,
+        "tool_input": _summarise_input(tool_input),
+        "decision": "allow" if allowed else "deny",
+        "reason": reason,
+    }
+
+    try:
+        conn = sqlite3.connect(path, timeout=5.0)
+        try:
+            conn.execute(
+                """
+                INSERT INTO agent_events
+                    (workflow_id, run_id, agent_id, event_type, team_name, event_data, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id,
+                    run_id,
+                    agent_id,
+                    EVENT_TYPE,
+                    None,
+                    json.dumps(payload, default=str),
+                    datetime.now(timezone.utc).isoformat(),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        logger.warning("audit_hook: failed to write %s row: %s", EVENT_TYPE, exc)
+    except Exception as exc:  # pragma: no cover — belt and braces
+        logger.warning("audit_hook: unexpected error writing %s row: %s", EVENT_TYPE, exc)
+
+
+def make_audited_policy(
+    run_id: str,
+    level: AutonomyLevel,
+    *,
+    agent_id: str = "lead",
+    db_path: str | None = None,
+) -> CanUseTool:
+    """Return a ``can_use_tool`` callable that policy-decides then audits.
+
+    Parameters
+    ----------
+    run_id
+        The station run id (e.g. ``run-20260419T...``). Used as both
+        ``workflow_id`` and ``run_id`` on the audit row.
+    level
+        The autonomy level for this run.
+    agent_id
+        Identifier for the caller — defaults to ``"lead"``. Teammates should
+        pass e.g. ``"teammate-issue-worker"``.
+    db_path
+        Override the DB path. Tests use this; production uses ``STATION_DB_PATH``.
+    """
+
+    async def can_use_tool(
+        tool_name: str,
+        tool_input: dict[str, Any],
+        ctx: ToolPermissionContext | None,
+    ) -> PermissionResultAllow | PermissionResultDeny:
+        decision = await policy_decide(tool_name, tool_input, ctx, level)
+        write_decision_event(
+            run_id=run_id,
+            agent_id=agent_id,
+            level=level,
+            tool_name=tool_name,
+            tool_input=tool_input,
+            decision=decision,
+            db_path=db_path,
+        )
+        return decision
+
+    return can_use_tool

--- a/dashboard/backend/tests/test_audit_hook.py
+++ b/dashboard/backend/tests/test_audit_hook.py
@@ -1,0 +1,256 @@
+"""Unit tests for the Auto Mode audit hook — ADR-0001.
+
+Covers:
+- make_audited_policy composes policy_decide with a DB write per call.
+- Allow/Deny outcomes are labelled correctly in the event row.
+- Long string inputs are truncated so we don't store file bodies.
+- DB write failures don't propagate (best-effort logging).
+- Always-deny path still records an event with the deny reason.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from agent.audit_hook import (
+    EVENT_TYPE,
+    _summarise_input,
+    make_audited_policy,
+    write_decision_event,
+)
+from agent.auto_mode import AutonomyLevel
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+
+
+def _init_db(path: Path) -> None:
+    """Create a minimal agent_events table matching models.py:227."""
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE agent_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            workflow_id TEXT NOT NULL,
+            run_id TEXT,
+            agent_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            team_name TEXT,
+            event_data TEXT NOT NULL,
+            parent_event_id INTEGER,
+            created_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _fetch_events(path: Path) -> list[sqlite3.Row]:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    rows = list(conn.execute("SELECT * FROM agent_events ORDER BY event_id"))
+    conn.close()
+    return rows
+
+
+# --- write_decision_event --------------------------------------------------
+
+
+def test_write_decision_event_inserts_allow_row(tmp_path):
+    db = tmp_path / "test.db"
+    _init_db(db)
+
+    write_decision_event(
+        run_id="run-001",
+        agent_id="lead",
+        level=AutonomyLevel.ASSISTED,
+        tool_name="Read",
+        tool_input={"file_path": "/etc/hosts"},
+        decision=PermissionResultAllow(),
+        db_path=str(db),
+    )
+
+    rows = _fetch_events(db)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["workflow_id"] == "run-001"
+    assert row["run_id"] == "run-001"
+    assert row["agent_id"] == "lead"
+    assert row["event_type"] == EVENT_TYPE
+    payload = json.loads(row["event_data"])
+    assert payload["level"] == "assisted"
+    assert payload["tool_name"] == "Read"
+    assert payload["decision"] == "allow"
+    assert payload["reason"] == ""
+
+
+def test_write_decision_event_inserts_deny_row_with_reason(tmp_path):
+    db = tmp_path / "test.db"
+    _init_db(db)
+
+    deny = PermissionResultDeny(message="blocked by always-deny policy: push to main")
+    write_decision_event(
+        run_id="run-042",
+        agent_id="lead",
+        level=AutonomyLevel.AUTO,
+        tool_name="Bash",
+        tool_input={"command": "git push origin main"},
+        decision=deny,
+        db_path=str(db),
+    )
+
+    rows = _fetch_events(db)
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["event_data"])
+    assert payload["decision"] == "deny"
+    assert "push to main" in payload["reason"]
+
+
+def test_write_decision_event_is_best_effort_on_missing_table(tmp_path):
+    """If the DB exists but the table is absent, we must NOT raise."""
+    db = tmp_path / "broken.db"
+    # Create an empty DB without the agent_events table
+    sqlite3.connect(str(db)).close()
+
+    # Should log a warning internally but never raise
+    write_decision_event(
+        run_id="run-001",
+        agent_id="lead",
+        level=AutonomyLevel.MANUAL,
+        tool_name="Read",
+        tool_input={},
+        decision=PermissionResultAllow(),
+        db_path=str(db),
+    )
+
+
+# --- _summarise_input ------------------------------------------------------
+
+
+def test_summarise_input_truncates_long_strings():
+    huge = "x" * 1000
+    summary = _summarise_input({"content": huge, "path": "/tmp/x"})
+    assert len(summary["content"]) < 1000
+    assert summary["content"].startswith("x" * 500)
+    assert "+500 chars" in summary["content"]
+    assert summary["path"] == "/tmp/x"
+
+
+def test_summarise_input_preserves_non_string_values():
+    summary = _summarise_input({"count": 42, "flag": True, "items": [1, 2, 3]})
+    assert summary == {"count": 42, "flag": True, "items": [1, 2, 3]}
+
+
+# --- make_audited_policy ---------------------------------------------------
+
+
+async def test_audited_policy_allows_read_and_records_event(tmp_path):
+    db = tmp_path / "test.db"
+    _init_db(db)
+
+    can_use_tool = make_audited_policy(
+        run_id="run-777",
+        level=AutonomyLevel.ASSISTED,
+        db_path=str(db),
+    )
+    result = await can_use_tool("Read", {"file_path": "/etc/hosts"}, None)
+
+    assert isinstance(result, PermissionResultAllow)
+    rows = _fetch_events(db)
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["event_data"])
+    assert payload["decision"] == "allow"
+    assert payload["level"] == "assisted"
+    assert payload["tool_name"] == "Read"
+
+
+async def test_audited_policy_denies_destructive_bash_at_manual(tmp_path):
+    db = tmp_path / "test.db"
+    _init_db(db)
+
+    can_use_tool = make_audited_policy(
+        run_id="run-manual",
+        level=AutonomyLevel.MANUAL,
+        db_path=str(db),
+    )
+    result = await can_use_tool("Bash", {"command": "rm -rf node_modules"}, None)
+
+    assert isinstance(result, PermissionResultDeny)
+    rows = _fetch_events(db)
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["event_data"])
+    assert payload["decision"] == "deny"
+    assert payload["level"] == "manual"
+
+
+async def test_audited_policy_denies_push_to_main_even_at_auto(tmp_path):
+    """ALWAYS_DENY beats autonomy level; audit still records the decision."""
+    db = tmp_path / "test.db"
+    _init_db(db)
+
+    can_use_tool = make_audited_policy(
+        run_id="run-auto",
+        level=AutonomyLevel.AUTO,
+        db_path=str(db),
+    )
+    result = await can_use_tool("Bash", {"command": "git push origin main"}, None)
+
+    assert isinstance(result, PermissionResultDeny)
+    rows = _fetch_events(db)
+    assert len(rows) == 1
+    payload = json.loads(rows[0]["event_data"])
+    assert payload["decision"] == "deny"
+    assert "push to main" in payload["reason"]
+
+
+async def test_audited_policy_writes_one_row_per_call(tmp_path):
+    db = tmp_path / "test.db"
+    _init_db(db)
+
+    can_use_tool = make_audited_policy(
+        run_id="run-seq",
+        level=AutonomyLevel.AUTO,
+        db_path=str(db),
+    )
+    await can_use_tool("Read", {"file_path": "/a"}, None)
+    await can_use_tool("Bash", {"command": "ls"}, None)
+    await can_use_tool("Edit", {"file_path": "/a", "content": "x"}, None)
+
+    rows = _fetch_events(db)
+    assert len(rows) == 3
+    tools = [json.loads(r["event_data"])["tool_name"] for r in rows]
+    assert tools == ["Read", "Bash", "Edit"]
+
+
+async def test_audited_policy_tags_agent_id(tmp_path):
+    db = tmp_path / "test.db"
+    _init_db(db)
+
+    can_use_tool = make_audited_policy(
+        run_id="run-team",
+        level=AutonomyLevel.ASSISTED,
+        agent_id="teammate-issue-worker",
+        db_path=str(db),
+    )
+    await can_use_tool("Read", {"file_path": "/a"}, None)
+
+    rows = _fetch_events(db)
+    assert rows[0]["agent_id"] == "teammate-issue-worker"
+
+
+async def test_audited_policy_does_not_raise_when_db_missing(tmp_path):
+    """Audit is best-effort; a broken DB must not break tool execution."""
+    db = tmp_path / "does-not-exist.db"
+    # Intentionally do not initialise the schema
+
+    can_use_tool = make_audited_policy(
+        run_id="run-nop",
+        level=AutonomyLevel.ASSISTED,
+        db_path=str(db),
+    )
+    # Must still return a valid PermissionResult
+    result = await can_use_tool("Read", {"file_path": "/a"}, None)
+    assert isinstance(result, PermissionResultAllow)


### PR DESCRIPTION
## Summary
- Adds `agent/audit_hook.py` — audit layer that composes with the policy engine from #231 so every `can_use_tool` call leaves an `agent_events` row with `event_type='auto_mode_decision'`.
- Exposes two entry points:
  - `write_decision_event(...)` for one-off writes (tests + future dashboard surfaces).
  - `make_audited_policy(run_id, level, agent_id)` returning a `can_use_tool` callable — the thing P1.T5 will pass to `ClaudeAgentOptions`.
- 11 parametrized tests in `dashboard/backend/tests/test_audit_hook.py`.

## Design notes
- **Best-effort logging.** sqlite3 errors are caught and logged at WARNING — an audit failure must not break tool execution. Tests cover the missing-DB and missing-table paths.
- **Raw sqlite3.** The agent process does not import the dashboard backend; DB path comes from `STATION_DB_PATH` (matches `Settings.db_path`).
- **Input truncation.** String values over 500 chars are capped so audit rows never swallow a whole file body (Write/Edit arguments could be huge).
- **Reuses the existing table.** No migration — `agent_events` (models.py:227-239) has the right shape.
- `agent_id` defaults to `"lead"` so the Sonnet-4.6 coordinator is correctly labelled; teammates pass e.g. `"teammate-issue-worker"`.

## Depends on
- #231 (P1.T4 — policy engine) — imports `policy_decide` and `AutonomyLevel`.

## Test plan
- [x] `PYTHONPATH=… /usr/bin/python3.12 -m pytest dashboard/backend/tests/test_audit_hook.py -q` → **11 passed in 1.70s**
- [ ] P1.T5 will exercise this end-to-end by wiring it into `ClaudeAgentOptions(can_use_tool=make_audited_policy(...))` in `agent/station_orchestrator.py`.
- [ ] P1.T7 will validate decision-row counts grow 1:1 with tool calls on a throwaway-repo run.

Part of the Auto Mode rollout plan at `/root/.claude/plans/fluttering-meandering-clarke.md`.