### PR TITLE
fix(ui): P1 UX touch-ups across command center + agent teams [P2.T1-T9]

### DIFF
--- a/dashboard/frontend/src/App.svelte
+++ b/dashboard/frontend/src/App.svelte
@@ -16,6 +16,7 @@
 
   // Overlays
   import Toast from './components/overlays/Toast.svelte';
+  import ShortcutsOverlay from './components/overlays/ShortcutsOverlay.svelte';
 
   // Pages
   import CommandCenter from './pages/CommandCenter.svelte';
@@ -30,6 +31,7 @@
   // --- App State ---
   let triggering = $state(false);
   let activeEmployees = $state<ActiveEmployee[]>([]);
+  let showShortcuts = $state(false);
 
   // SSE connected state from agentPresence
   let sseConnected = $derived(agentPresence.sseConnected);
@@ -73,6 +75,9 @@
   // --- Keyboard shortcuts ---
   function handleKeydown(e: KeyboardEvent) {
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement || e.target instanceof HTMLSelectElement) return;
+
+    // `?` toggles the shortcuts cheatsheet (on many keyboards `?` = Shift+/).
+    if (e.key === '?') { showShortcuts = !showShortcuts; e.preventDefault(); return; }
 
     // Number keys for navigation (matches NavRail order)
     if (e.key === '1') { navigate('/'); return; }
@@ -124,4 +129,5 @@
   </Shell>
 
   <Toast />
+  <ShortcutsOverlay show={showShortcuts} onClose={() => (showShortcuts = false)} />
 </div>

--- a/dashboard/frontend/src/components/agent-teams/TeammateCard.svelte
+++ b/dashboard/frontend/src/components/agent-teams/TeammateCard.svelte
@@ -4,7 +4,7 @@
 
   let {
     name,
-    model = 'claude-sonnet-4-6',
+    model = 'claude-opus-4-6',
     task = '',
     status = '',
     statusType = 'idle',
@@ -24,8 +24,14 @@
 
   let isActive = $derived(statusType === 'working');
   let isReviewing = $derived(statusType === 'reviewing');
-  let isBlocked = $derived(statusType === 'blocked' || statusType === 'idle');
-  let statusColor = $derived(isActive ? '#2E7D32' : isReviewing ? '#B06030' : '#8C7A66');
+  let isBlocked = $derived(statusType === 'blocked');
+  let isIdle = $derived(statusType === 'idle');
+  let statusColor = $derived(
+    isActive ? '#2E7D32' :
+    isReviewing ? '#B06030' :
+    isBlocked ? '#D06050' :
+    '#8C7A66'
+  );
 </script>
 
 <div
@@ -33,6 +39,7 @@
   class:active={isActive}
   class:plan-review={isReviewing}
   class:blocked={isBlocked}
+  class:idle={isIdle}
 >
   <!-- Header -->
   <div style="display: flex; align-items: center; gap: 12px;">
@@ -98,7 +105,8 @@
     box-shadow: 3px 3px 10px rgba(0,0,0,0.05), -3px -3px 10px rgba(255,255,255,0.45);
   }
   .tm-card.plan-review { border-color: rgba(176,96,48,0.25); }
-  .tm-card.blocked { opacity: 0.50; }
+  .tm-card.blocked { border-color: rgba(208,96,80,0.35); }
+  .tm-card.idle { opacity: 0.55; }
 
   .tm-card::before {
     content: ''; position: absolute; left: 0; top: 14px; bottom: 14px; width: 3px;
@@ -106,6 +114,7 @@
   }
   .tm-card.active::before { background: rgba(46,125,50,0.4); opacity: 1; }
   .tm-card.plan-review::before { background: rgba(176,96,48,0.4); opacity: 1; }
+  .tm-card.blocked::before { background: rgba(208,96,80,0.55); opacity: 1; }
 
   .tm-card.active { animation: card-breathe 4s ease-in-out infinite; }
   .tm-card.plan-review { animation: card-breathe-amber 4s ease-in-out infinite; }

--- a/dashboard/frontend/src/components/overlays/ShortcutsOverlay.svelte
+++ b/dashboard/frontend/src/components/overlays/ShortcutsOverlay.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { portal } from '../../lib/portal';
+
+  let {
+    show = false,
+    onClose,
+  }: {
+    show: boolean;
+    onClose: () => void;
+  } = $props();
+
+  const shortcuts: { key: string; label: string }[] = [
+    { key: '1', label: 'Command Center' },
+    { key: '2', label: 'Runs' },
+    { key: '3', label: 'Queue' },
+    { key: '4', label: 'Projects' },
+    { key: '5', label: 'Agent Teams' },
+    { key: '6', label: 'Settings' },
+    { key: '?', label: 'Toggle this overlay' },
+    { key: 'Esc', label: 'Close overlays & modals' },
+  ];
+
+  function handleBackdrop(e: MouseEvent) {
+    if (e.target === e.currentTarget) onClose();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === 'Escape') onClose();
+  }
+</script>
+
+<svelte:window onkeydown={show ? handleKeydown : undefined} />
+
+{#if show}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    use:portal
+    class="fixed inset-0 z-modal flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm animate-fade-in-up"
+    onclick={handleBackdrop}
+  >
+    <div
+      class="glass rounded-xl max-w-md w-full shadow-2xl"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
+      <div class="flex items-center justify-between px-5 py-3 border-b border-border">
+        <h2 class="text-sm font-semibold text-primary">Keyboard shortcuts</h2>
+        <button
+          onclick={onClose}
+          class="text-tertiary hover:text-primary transition-colors text-lg leading-none"
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+      <ul class="p-4 flex flex-col gap-2">
+        {#each shortcuts as s}
+          <li class="flex items-center justify-between gap-4 px-2 py-1.5">
+            <span class="text-sm text-primary">{s.label}</span>
+            <kbd
+              class="inline-flex items-center px-2 py-0.5 rounded-md border border-border bg-surface text-xs font-mono text-secondary"
+            >{s.key}</kbd>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  </div>
+{/if}

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -211,7 +211,13 @@ function deriveAgents(runs: ActiveEmployee[]): AgentIdentity[] {
       name: agentName,
       color: getAgentColor(agentName.toLowerCase()),
       employeeIndex: idx,
-      status: run.status === 'running' ? 'active' : 'idle',
+      status: (
+        run.status === 'running' ||
+        run.status === 'started' ||
+        run.status === 'reviewing' ||
+        run.status === 'plan_reviewing' ||
+        run.status === 'employee_done'
+      ) ? 'active' : 'idle',
       currentAction: null,
     });
   }

--- a/dashboard/frontend/src/lib/router.svelte.ts
+++ b/dashboard/frontend/src/lib/router.svelte.ts
@@ -4,8 +4,6 @@
 
 export type Page =
   | 'command-center'
-  | 'theater'
-  | 'team-comms'
   | 'agent-teams'
   | 'runs'
   | 'run-detail'
@@ -20,7 +18,11 @@ export interface Route {
   param: string | null;
 }
 
-/** Map legacy routes to new equivalents */
+/** Map legacy routes to new equivalents.
+ *
+ * `/theater`, `/team-comms`, `/observatory`, `/workspace` are historic names
+ * for the Agent Teams canvas — they are kept here so old bookmarks still
+ * resolve, but they no longer appear in the Page enum. */
 const REDIRECTS: Record<string, string> = {
   '/ops': '/',
   '/command': '/',
@@ -33,8 +35,10 @@ const REDIRECTS: Record<string, string> = {
   '/config': '/settings',
   '/prompts': '/settings',
   '/system': '/settings',
-  '/observatory': '/theater',
-  '/workspace': '/theater',
+  '/observatory': '/agent-teams',
+  '/workspace': '/agent-teams',
+  '/theater': '/agent-teams',
+  '/team-comms': '/agent-teams',
 };
 
 function parsePath(): Route {
@@ -76,7 +80,9 @@ function parsePath(): Route {
     return { page: rParts[0] as Page, param: null };
   }
 
-  // Standard routes
+  // Standard routes. `theater` / `team-comms` are kept here solely so a bare
+  // URL hit renders the Agent Teams canvas without a redirect flash; the Page
+  // enum no longer contains those names.
   const routeMap: Record<string, Page> = {
     theater: 'agent-teams',
     agents: 'agent-teams',
@@ -159,8 +165,7 @@ export function handleLinkClick(e: MouseEvent): void {
 export function getPageTitle(page: Page): string {
   const titles: Record<Page, string> = {
     'command-center': 'Command Center',
-    'theater': 'Workspace',
-    'team-comms': 'Team Comms',
+    'agent-teams': 'Agent Teams',
     'runs': 'Runs',
     'run-detail': 'Run Detail',
     'queue': 'Queue Board',

--- a/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
+++ b/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
@@ -54,9 +54,10 @@
     }
   }
 
-  // Map tasks to teammate card data
+  // Map tasks to teammate card data — render every teammate, not just the
+  // first five; hiding the tail misrepresents team size.
   let teammateData = $derived.by(() => {
-    return tasks.slice(0, 5).map(t => {
+    return tasks.map(t => {
       const statusType: 'working' | 'reviewing' | 'idle' | 'blocked' =
         t.status === 'running' ? 'working' :
         t.status === 'pending' || t.status === 'ready' ? 'idle' :
@@ -85,7 +86,10 @@
 
       return {
         name: t.claimed_by ?? `Task ${t.id?.split('-').pop()?.slice(0, 4) ?? '?'}`,
-        model: 'claude-sonnet-4-6',
+        // Teammates run as Opus per CLAUDE.md; the lead (Sonnet) is the
+        // TeamLeadCard above. If a real model name arrives on the task it
+        // will override this default.
+        model: (t as { model?: string | null }).model ?? 'claude-opus-4-6',
         task: t.title ?? 'Untitled task',
         status: t.status === 'running' ? (t.result_summary || 'Working...') :
                 t.status === 'completed' ? 'Completed' :

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { listRuns, getQueueStats, getTokenUsage, getSystemStatus, getAnalytics, getBackpressure, getActiveEmployees, listQueue } from '../lib/api';
+  import { listRuns, getQueueStats, getTokenUsage, getPlanUsage, getSystemStatus, getAnalytics, getBackpressure, getActiveEmployees, listQueue } from '../lib/api';
   import { navigate } from '../lib/router.svelte';
   import { agentPresence } from '../lib/agent-presence.svelte';
   import { formatTokens, formatDuration, timeAgo, formatPercent } from '../lib/format';
@@ -18,7 +18,7 @@
     if (usedMb == null || totalMb == null) return '—';
     return `${(usedMb / 1024).toFixed(1)} / ${(totalMb / 1024).toFixed(1)} GB`;
   }
-  import type { Run, QueueStats, TokenUsage, SystemStatus, AnalyticsResponse, BackpressureStatus, ActiveEmployee, QueueItem } from '../lib/types';
+  import type { Run, QueueStats, TokenUsage, PlanUsage, SystemStatus, AnalyticsResponse, BackpressureStatus, ActiveEmployee, QueueItem } from '../lib/types';
   import VaporCard from '../components/vapor/VaporCard.svelte';
   import VaporBadge from '../components/vapor/VaporBadge.svelte';
   import SkeletonLoader from '../components/data-display/SkeletonLoader.svelte';
@@ -37,6 +37,7 @@
   let queueStats = $state<QueueStats | null>(null);
   let queueItems = $state<QueueItem[]>([]);
   let tokenUsage = $state<TokenUsage | null>(null);
+  let planUsage = $state<PlanUsage | null>(null);
   let systemStatus = $state<SystemStatus | null>(null);
   let analyticsData = $state<AnalyticsResponse | null>(null);
   let backpressure = $state<BackpressureStatus | null>(null);
@@ -89,11 +90,12 @@
 
   // Fetch data
   async function loadData() {
-    const [runsRes, empRes, qRes, tRes, sRes, aRes, bRes, qiRes] = await Promise.allSettled([
+    const [runsRes, empRes, qRes, tRes, pRes, sRes, aRes, bRes, qiRes] = await Promise.allSettled([
       listRuns({ limit: 15 }),
       getActiveEmployees(),
       getQueueStats(),
       getTokenUsage(),
+      getPlanUsage(),
       getSystemStatus(),
       getAnalytics({ days: 7 }),
       getBackpressure(),
@@ -103,6 +105,7 @@
     if (empRes.status === 'fulfilled') activeEmployees = empRes.value;
     if (qRes.status === 'fulfilled') queueStats = qRes.value;
     if (tRes.status === 'fulfilled') tokenUsage = tRes.value;
+    if (pRes.status === 'fulfilled') planUsage = pRes.value;
     if (sRes.status === 'fulfilled') systemStatus = sRes.value;
     if (aRes.status === 'fulfilled') analyticsData = aRes.value;
     if (bRes.status === 'fulfilled') backpressure = bRes.value;
@@ -208,7 +211,13 @@
           </div>
         </div>
         <div style="font-size: 48px; font-weight: 800; letter-spacing: -0.05em; margin-top: 10px; line-height: 1; color: #3D2A1A;">{formatTokens(tokenUsage?.daily?.tokens_total ?? null)}</div>
-        <div style="font-size: 13px; color: #8C7A66; margin-top: 8px;">{formatPercent(tokenUsage?.max_usage_percent ?? 0)} of budget</div>
+        <div style="font-size: 13px; color: #8C7A66; margin-top: 8px;">
+          {#if planUsage?.weekly_tokens_percent != null}
+            {formatPercent(planUsage.weekly_tokens_percent)} of weekly plan
+          {:else}
+            this week
+          {/if}
+        </div>
       </VaporCard>
 
       <VaporCard stagger={0.26}>
@@ -292,7 +301,13 @@
           </div>
           <div style="display: flex; justify-content: space-between; align-items: center;">
             <span style="font-size: 14px; color: #3D2A1A;">Backpressure</span>
-            <span style="font-size: 13px; color: {backpressure?.level === 'GREEN' ? '#2E7D32' : backpressure?.level === 'YELLOW' ? '#B06030' : '#D06050'}; font-weight: 600;">{backpressure?.level ?? '—'}</span>
+            <span style="font-size: 13px; color: {
+              backpressure?.level === 'GREEN' ? '#2E7D32' :
+              backpressure?.level === 'YELLOW' ? '#B06030' :
+              backpressure?.level === 'RED' ? '#D06050' :
+              backpressure?.level === 'BLACK' ? '#111111' :
+              '#8C7A66'
+            }; font-weight: 600;">{backpressure?.level ?? '—'}</span>
           </div>
           <div style="display: flex; justify-content: space-between; align-items: center;">
             <span style="font-size: 14px; color: #3D2A1A;">Memory</span>

--- a/dashboard/frontend/src/pages/RunsPage.svelte
+++ b/dashboard/frontend/src/pages/RunsPage.svelte
@@ -50,7 +50,14 @@
   }
 
   function getStatusDot(run: Run): string {
-    if (run.status === 'started') return 'running';
+    // Any active sub-state of a live run should render green, not offline.
+    if (
+      run.status === 'started' ||
+      run.status === 'running' ||
+      run.status === 'reviewing' ||
+      run.status === 'plan_reviewing' ||
+      run.status === 'employee_done'
+    ) return 'running';
     if (run.verdict === 'APPROVE' || run.verdict === 'PR') return 'online';
     if (run.verdict === 'REJECT') return 'error';
     return 'offline';


### PR DESCRIPTION
## Summary
Nine small UX fixes grouped into one PR — the plan explicitly calls them out as the tier-2 visual regressions that escaped Phase 0.

### Fixes
| | Task | File | Why |
|---|---|---|---|
| T1 | Tokens card shows real % | \`CommandCenter.svelte\` | \`max_usage_percent\` is the BUDGET CEILING (e.g. 80%) not actual utilisation — now reads \`planUsage.weekly_tokens_percent\` from \`getPlanUsage()\` |
| T2 | Backpressure BLACK branch | \`CommandCenter.svelte\` | Throttled state fell back to the RED colour; now BLACK renders \`#111111\` with RED and unknown both separated |
| T3 | Split idle vs blocked | \`TeammateCard.svelte\` | Both states were conflated into 50%-opacity ghost; blocked now gets a red accent rail + coloured status text |
| T4 | \`getStatusDot\` covers active sub-states | \`RunsPage.svelte\` | Anything past \`started\` (reviewing, plan_reviewing, employee_done) rendered as offline grey |
| T5 | Agent presence treats sub-states as active | \`agent-presence.svelte.ts\` | Same regression — only \`status === 'running'\` counted as active |
| T6 | Model label de-hardcoded | \`TeammateCard.svelte\`, \`AgentTeamsCanvas.svelte\` | Teammates run Opus per CLAUDE.md; default flipped + canvas reads \`task.model\` when available |
| T7 | \`?\` shortcut overlay | new \`ShortcutsOverlay.svelte\` + \`App.svelte\` | Discoverability — shows the 1-6 nav keys + Esc |
| T8 | Drop \`theater\` / \`team-comms\` from Page enum | \`router.svelte.ts\` | Legacy names; URLs still redirect via \`REDIRECTS\` + \`routeMap\` so bookmarks keep working |
| T9 | Canvas shows all teammates | \`AgentTeamsCanvas.svelte\` | \`tasks.slice(0, 5)\` silently hid the tail once team size > 5 |

### Why grouped
Each diff is 1-15 lines and touches an independent file. Stacking these behind separate PRs would be all review ceremony with no safety benefit.

## Test plan
- [x] \`npm run build\` → clean (only pre-existing a11y warnings on unrelated files).
- [x] Backend suite untouched.
- [ ] First CI run will exercise the Playwright suite.
- [ ] Manual visual pass once CI (#234) is in: hit \`?\` on any page → overlay appears; tokens card shows a plan %, not 80%; /theater URL still routes to /agent-teams.

Part of the Auto Mode rollout plan at \`/root/.claude/plans/fluttering-meandering-clarke.md\`.