### PR TITLE
feat(ui): autonomy badge on Runs + Run Detail [P2.T12]

### DIFF
--- a/dashboard/frontend/src/components/badges/AutonomyBadge.svelte
+++ b/dashboard/frontend/src/components/badges/AutonomyBadge.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { AutonomyLevel } from '../../lib/types';
+
+  let {
+    level,
+    size = 'sm',
+  }: {
+    level: AutonomyLevel | null | undefined;
+    size?: 'xs' | 'sm';
+  } = $props();
+
+  // Falsy / unknown levels render as the default 'assisted' pill so we never
+  // show a blank space on legacy rows.
+  const resolved = $derived(
+    level === 'manual' || level === 'assisted' || level === 'auto'
+      ? level
+      : 'assisted'
+  );
+
+  const styles: Record<AutonomyLevel, string> = {
+    // Manual — operator drives every decision. Neutral, slightly warm.
+    manual: 'background: rgba(160,142,122,0.10); color: #6E5D4A;',
+    // Assisted — today's de-facto baseline. Quiet, readable.
+    assisted: 'background: rgba(99,102,180,0.10); color: #5D5F94;',
+    // Auto — full autonomy. Clearly distinct green so the operator notices.
+    auto: 'background: rgba(46,125,50,0.14); color: #2E7D32;',
+  };
+
+  const padding = $derived(size === 'xs' ? '2px 8px' : '4px 10px');
+  const fontSize = $derived(size === 'xs' ? '11px' : '12px');
+</script>
+
+<span
+  class="autonomy-badge"
+  data-level={resolved}
+  title="Autonomy level: {resolved}"
+  style="
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: {padding}; border-radius: 999px;
+    font-size: {fontSize}; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    white-space: nowrap; line-height: 1;
+    {styles[resolved]}
+  "
+>
+  {resolved}
+</span>

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -13,6 +13,8 @@ export type CoordinatorTaskStatus = 'pending' | 'ready' | 'running' | 'completed
 export type BackpressureLevel = 'GREEN' | 'YELLOW' | 'RED' | 'BLACK';
 
 // --- Projects ---
+export type AutonomyLevel = 'manual' | 'assisted' | 'auto';
+
 export interface Project {
   id: number;
   repo: string;
@@ -23,6 +25,8 @@ export interface Project {
   custom_instructions: string | null;
   setup_script: string | null;
   security_review_enabled: boolean;
+  autonomy_level: AutonomyLevel;
+  max_budget_usd: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -65,6 +69,8 @@ export interface Run {
   concurrent_group_id: string | null;
   team_name: string | null;
   team_members: string | null;
+  autonomy_level: AutonomyLevel | null;
+  max_budget_usd: number | null;
 }
 
 export interface RunList {

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -5,6 +5,7 @@
   import type { RunFullContext, DiffResult, CoordinatorMessage } from '../lib/types';
   import { navigate } from '../lib/router.svelte';
   import LogViewer from '../components/data-display/LogViewer.svelte';
+  import AutonomyBadge from '../components/badges/AutonomyBadge.svelte';
 
   let { runId }: { runId: string } = $props();
 
@@ -91,13 +92,20 @@
     <!-- ===== HEADER ===== -->
     <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
       <div>
-        <div class="flex items-center gap-3 mb-2">
+        <div class="flex items-center gap-3 mb-2 flex-wrap">
           <span class="status-dot {run.status === 'started' ? 'running' : run.verdict === 'REJECT' ? 'error' : run.verdict ? 'online' : 'offline'}"></span>
           <h1 class="font-heading text-xl">{run.run_id?.slice(0, 20)}</h1>
           {#if run.verdict}
             <span class="badge {getVerdictBadge(run.verdict)}">{run.verdict}</span>
           {:else if run.status === 'started'}
             <span class="badge badge-running">LIVE</span>
+          {/if}
+          <AutonomyBadge level={run.autonomy_level} />
+          {#if run.max_budget_usd != null}
+            <span
+              class="text-xs font-mono text-tertiary"
+              title="Per-run budget cap"
+            >&le; ${run.max_budget_usd.toFixed(2)}</span>
           {/if}
         </div>
         <div class="flex items-center gap-4 text-xs text-tertiary font-mono">

--- a/dashboard/frontend/src/pages/RunsPage.svelte
+++ b/dashboard/frontend/src/pages/RunsPage.svelte
@@ -5,6 +5,7 @@
   import type { Run } from '../lib/types';
   import SkeletonLoader from '../components/data-display/SkeletonLoader.svelte';
   import EmptyState from '../components/data-display/EmptyState.svelte';
+  import AutonomyBadge from '../components/badges/AutonomyBadge.svelte';
 
   let runs = $state<Run[]>([]);
   let total = $state(0);
@@ -115,6 +116,7 @@
           <th class="text-left p-3">Issue</th>
           <th class="text-left p-3">Mode</th>
           <th class="text-left p-3">Model</th>
+          <th class="text-left p-3">Autonomy</th>
           <th class="text-left p-3">Verdict</th>
           <th class="text-right p-3">Tokens</th>
           <th class="text-right p-3">Duration</th>
@@ -125,7 +127,7 @@
         {#if loading}
           {#each Array(5) as _}
             <tr style="border-bottom: 1px solid rgba(240,220,200,0.10);">
-              {#each Array(9) as __}<td class="p-3"><div class="skeleton h-4 w-full"></div></td>{/each}
+              {#each Array(10) as __}<td class="p-3"><div class="skeleton h-4 w-full"></div></td>{/each}
             </tr>
           {/each}
         {:else}
@@ -146,6 +148,7 @@
               </td>
               <td class="p-3">{#if run.mode}<span class="badge {getModeBadge(run.mode)}">{run.mode}</span>{:else}<span class="text-xs text-ghost">-</span>{/if}</td>
               <td class="p-3"><span class="text-xs font-mono text-tertiary">{run.model?.split('-').pop() ?? '-'}</span></td>
+              <td class="p-3"><AutonomyBadge level={run.autonomy_level} size="xs" /></td>
               <td class="p-3">
                 {#if run.verdict}<span class="badge {getVerdictBadge(run.verdict)}">{run.verdict}</span>
                 {:else if run.status === 'started'}<span class="badge badge-running">LIVE</span>
@@ -158,7 +161,7 @@
           {/each}
         {/if}
         {#if !loading && runs.length === 0}
-          <tr><td colspan="9">
+          <tr><td colspan="10">
             <EmptyState title="No runs found" description="Try adjusting your filters" icon="▷" />
           </td></tr>
         {/if}


### PR DESCRIPTION
## Summary
Surfaces ADR-0001 autonomy levels in the dashboard so the operator can see at a glance which runs ran under which policy.

- **New component** \`components/badges/AutonomyBadge.svelte\` with three visually distinct pills:
  - \`manual\` — warm-grey (operator drives every decision)
  - \`assisted\` — indigo (today's de-facto baseline)
  - \`auto\` — green (full autonomy)
  - \`xs\` / \`sm\` size variants, defaults to \`assisted\` for legacy rows.
- **RunsPage**: new Autonomy column between Model and Verdict (xs badge, colspan bumped).
- **RunDetail**: sm badge next to the verdict + a "≤ \$X.XX" budget cap hint whenever \`max_budget_usd\` is set.
- **Types**: new \`AutonomyLevel\` union and matching fields on \`Project\` / \`Run\` mirroring the backend schema from #230.

## Test plan
- [x] \`npm run build\` clean (only pre-existing a11y warnings on unrelated files)
- [x] Falsy / unknown autonomy levels fall back to 'assisted' so historical rows don't render blank
- [ ] Manual check post-merge: Runs table row with \`autonomy_level=auto\` shows the green pill; Run Detail shows pill + budget caption

Part of the Auto Mode rollout plan at \`/root/.claude/plans/fluttering-meandering-clarke.md\`.