### PR TITLE
feat(ui): per-project autonomy toggle [P2.T11]

### DIFF
--- a/dashboard/backend/tests/test_projects.py
+++ b/dashboard/backend/tests/test_projects.py
@@ -173,6 +173,32 @@ async def test_update_project_not_found(client):
     assert resp.status_code == 404
 
 
+@pytest.mark.asyncio
+@patch("app.routers.projects.sync_db_to_config", new_callable=AsyncMock)
+async def test_update_project_autonomy_level_and_budget(mock_sync, client, sample_project):
+    """PUT accepts autonomy_level + max_budget_usd per ADR-0001."""
+    resp = await client.put(f"/api/projects/{sample_project.id}", json={
+        "autonomy_level": "auto",
+        "max_budget_usd": 5.50,
+    })
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["autonomy_level"] == "auto"
+    assert data["max_budget_usd"] == 5.50
+    # Unchanged fields should remain
+    assert data["repo"] == "owner/test-repo"
+
+
+@pytest.mark.asyncio
+async def test_project_defaults_to_assisted(client, sample_project):
+    """Fresh projects default to autonomy_level='assisted' per migration."""
+    resp = await client.get(f"/api/projects/{sample_project.id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["autonomy_level"] == "assisted"
+    assert data["max_budget_usd"] is None
+
+
 # --- Delete project ---
 
 @pytest.mark.asyncio

--- a/dashboard/frontend/src/components/badges/AutonomyBadge.svelte
+++ b/dashboard/frontend/src/components/badges/AutonomyBadge.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+  import type { AutonomyLevel } from '../../lib/types';
+
+  let {
+    level,
+    size = 'sm',
+  }: {
+    level: AutonomyLevel | null | undefined;
+    size?: 'xs' | 'sm';
+  } = $props();
+
+  // Falsy / unknown levels render as the default 'assisted' pill so we never
+  // show a blank space on legacy rows.
+  const resolved = $derived(
+    level === 'manual' || level === 'assisted' || level === 'auto'
+      ? level
+      : 'assisted'
+  );
+
+  const styles: Record<AutonomyLevel, string> = {
+    // Manual — operator drives every decision. Neutral, slightly warm.
+    manual: 'background: rgba(160,142,122,0.10); color: #6E5D4A;',
+    // Assisted — today's de-facto baseline. Quiet, readable.
+    assisted: 'background: rgba(99,102,180,0.10); color: #5D5F94;',
+    // Auto — full autonomy. Clearly distinct green so the operator notices.
+    auto: 'background: rgba(46,125,50,0.14); color: #2E7D32;',
+  };
+
+  const padding = $derived(size === 'xs' ? '2px 8px' : '4px 10px');
+  const fontSize = $derived(size === 'xs' ? '11px' : '12px');
+</script>
+
+<span
+  class="autonomy-badge"
+  data-level={resolved}
+  title="Autonomy level: {resolved}"
+  style="
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: {padding}; border-radius: 999px;
+    font-size: {fontSize}; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.05em;
+    white-space: nowrap; line-height: 1;
+    {styles[resolved]}
+  "
+>
+  {resolved}
+</span>

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -13,6 +13,8 @@ export type CoordinatorTaskStatus = 'pending' | 'ready' | 'running' | 'completed
 export type BackpressureLevel = 'GREEN' | 'YELLOW' | 'RED' | 'BLACK';
 
 // --- Projects ---
+export type AutonomyLevel = 'manual' | 'assisted' | 'auto';
+
 export interface Project {
   id: number;
   repo: string;
@@ -23,6 +25,8 @@ export interface Project {
   custom_instructions: string | null;
   setup_script: string | null;
   security_review_enabled: boolean;
+  autonomy_level: AutonomyLevel;
+  max_budget_usd: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -65,6 +69,8 @@ export interface Run {
   concurrent_group_id: string | null;
   team_name: string | null;
   team_members: string | null;
+  autonomy_level: AutonomyLevel | null;
+  max_budget_usd: number | null;
 }
 
 export interface RunList {

--- a/dashboard/frontend/src/pages/ProjectsPage.svelte
+++ b/dashboard/frontend/src/pages/ProjectsPage.svelte
@@ -2,10 +2,11 @@
   import { listProjects, createProject, deleteProject, updateProject } from '../lib/api';
   import { navigate } from '../lib/router.svelte';
   import { toastSuccess, toastError } from '../lib/toast.svelte';
-  import type { Project, AgentMode } from '../lib/types';
+  import type { Project, AgentMode, AutonomyLevel } from '../lib/types';
   import Modal from '../components/overlays/Modal.svelte';
   import EmptyState from '../components/data-display/EmptyState.svelte';
   import SkeletonLoader from '../components/data-display/SkeletonLoader.svelte';
+  import AutonomyBadge from '../components/badges/AutonomyBadge.svelte';
 
   let projects = $state<Project[]>([]);
   let loading = $state(true);
@@ -37,6 +38,19 @@
       await updateProject(p.id, { enabled: !p.enabled });
       p.enabled = !p.enabled;
     } catch (e: any) { toastError(e.message); }
+  }
+
+  async function setAutonomy(p: Project, next: AutonomyLevel) {
+    if (p.autonomy_level === next) return;
+    const prev = p.autonomy_level;
+    p.autonomy_level = next;   // optimistic
+    try {
+      await updateProject(p.id, { autonomy_level: next });
+      toastSuccess(`Autonomy: ${prev} \u2192 ${next}`);
+    } catch (e: any) {
+      p.autonomy_level = prev; // rollback
+      toastError(e.message ?? 'Failed to update autonomy');
+    }
   }
 
   function getStatusBorder(p: Project): string {
@@ -101,6 +115,28 @@
             <span class="text-[10px] font-mono text-tertiary">Priority: {project.priority}</span>
             <span class="text-[10px] font-mono text-tertiary">Branch: {project.branch}</span>
           </div>
+
+          <!-- Autonomy selector (ADR-0001) -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_static_element_interactions -->
+          <div
+            class="mt-3 flex items-center gap-2"
+            onclick={(e) => e.stopPropagation()}
+          >
+            <span class="text-[10px] font-mono uppercase tracking-widest text-tertiary">Autonomy</span>
+            <AutonomyBadge level={project.autonomy_level} size="xs" />
+            <select
+              class="input text-xs py-1 px-2 ml-auto"
+              style="width: auto; min-width: 90px;"
+              value={project.autonomy_level ?? 'assisted'}
+              onchange={(e) => setAutonomy(project, (e.currentTarget as HTMLSelectElement).value as AutonomyLevel)}
+            >
+              <option value="manual">manual</option>
+              <option value="assisted">assisted</option>
+              <option value="auto">auto</option>
+            </select>
+          </div>
+
           {#if !project.enabled}
             <div class="mt-2">
               <span class="badge badge-failed">Disabled</span>

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -5,6 +5,7 @@
   import type { RunFullContext, DiffResult, CoordinatorMessage } from '../lib/types';
   import { navigate } from '../lib/router.svelte';
   import LogViewer from '../components/data-display/LogViewer.svelte';
+  import AutonomyBadge from '../components/badges/AutonomyBadge.svelte';
 
   let { runId }: { runId: string } = $props();
 
@@ -91,13 +92,20 @@
     <!-- ===== HEADER ===== -->
     <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
       <div>
-        <div class="flex items-center gap-3 mb-2">
+        <div class="flex items-center gap-3 mb-2 flex-wrap">
           <span class="status-dot {run.status === 'started' ? 'running' : run.verdict === 'REJECT' ? 'error' : run.verdict ? 'online' : 'offline'}"></span>
           <h1 class="font-heading text-xl">{run.run_id?.slice(0, 20)}</h1>
           {#if run.verdict}
             <span class="badge {getVerdictBadge(run.verdict)}">{run.verdict}</span>
           {:else if run.status === 'started'}
             <span class="badge badge-running">LIVE</span>
+          {/if}
+          <AutonomyBadge level={run.autonomy_level} />
+          {#if run.max_budget_usd != null}
+            <span
+              class="text-xs font-mono text-tertiary"
+              title="Per-run budget cap"
+            >&le; ${run.max_budget_usd.toFixed(2)}</span>
           {/if}
         </div>
         <div class="flex items-center gap-4 text-xs text-tertiary font-mono">

--- a/dashboard/frontend/src/pages/RunsPage.svelte
+++ b/dashboard/frontend/src/pages/RunsPage.svelte
@@ -5,6 +5,7 @@
   import type { Run } from '../lib/types';
   import SkeletonLoader from '../components/data-display/SkeletonLoader.svelte';
   import EmptyState from '../components/data-display/EmptyState.svelte';
+  import AutonomyBadge from '../components/badges/AutonomyBadge.svelte';
 
   let runs = $state<Run[]>([]);
   let total = $state(0);
@@ -115,6 +116,7 @@
           <th class="text-left p-3">Issue</th>
           <th class="text-left p-3">Mode</th>
           <th class="text-left p-3">Model</th>
+          <th class="text-left p-3">Autonomy</th>
           <th class="text-left p-3">Verdict</th>
           <th class="text-right p-3">Tokens</th>
           <th class="text-right p-3">Duration</th>
@@ -125,7 +127,7 @@
         {#if loading}
           {#each Array(5) as _}
             <tr style="border-bottom: 1px solid rgba(240,220,200,0.10);">
-              {#each Array(9) as __}<td class="p-3"><div class="skeleton h-4 w-full"></div></td>{/each}
+              {#each Array(10) as __}<td class="p-3"><div class="skeleton h-4 w-full"></div></td>{/each}
             </tr>
           {/each}
         {:else}
@@ -146,6 +148,7 @@
               </td>
               <td class="p-3">{#if run.mode}<span class="badge {getModeBadge(run.mode)}">{run.mode}</span>{:else}<span class="text-xs text-ghost">-</span>{/if}</td>
               <td class="p-3"><span class="text-xs font-mono text-tertiary">{run.model?.split('-').pop() ?? '-'}</span></td>
+              <td class="p-3"><AutonomyBadge level={run.autonomy_level} size="xs" /></td>
               <td class="p-3">
                 {#if run.verdict}<span class="badge {getVerdictBadge(run.verdict)}">{run.verdict}</span>
                 {:else if run.status === 'started'}<span class="badge badge-running">LIVE</span>
@@ -158,7 +161,7 @@
           {/each}
         {/if}
         {#if !loading && runs.length === 0}
-          <tr><td colspan="9">
+          <tr><td colspan="10">
             <EmptyState title="No runs found" description="Try adjusting your filters" icon="▷" />
           </td></tr>
         {/if}


### PR DESCRIPTION
## Summary
Adds an inline autonomy-level control to every project card on ProjectsPage so the operator can flip \`manual | assisted | auto\` without leaving the list.

- **UI**: badge + dropdown next to Mode/Priority/Branch. Click on the control does not navigate to the project detail (\`e.stopPropagation\`).
- **Optimistic**: value flips instantly; rollback + error toast if \`PUT /api/projects/{id}\` fails.
- **Success toast** shows the transition (\`assisted → auto\`).

**Backend needed no changes** — \`PUT /api/projects/{id}\` and \`ProjectUpdate\` already accept \`autonomy_level\` + \`max_budget_usd\` (from PR #230). Two new tests pin that behaviour.

## Depends on
- #236 — autonomy badge component + types (stacked on this branch)

## Test plan
- [x] \`pytest dashboard/backend/tests/test_projects.py -q\` → **15 passed in 5.99s** (13 old + 2 new: autonomy PUT + default=assisted)
- [x] \`npm run build\` clean
- [ ] Manual: flip a project to 'auto' → toast appears, reload → dropdown reflects new value → Runs table shows the green autonomy pill

## Descoped from this PR
The plan also calls for a **TopNav popover for per-run autonomy override**. That only becomes useful once there's UI to trigger a run with a specific level, which ties into P2.T10 (permission tray) and a Phase 3 run-trigger modal. Filing as a separate task so this PR stays small.

Part of the Auto Mode rollout plan at \`/root/.claude/plans/fluttering-meandering-clarke.md\`.