### PR TITLE
feat(agent): auto-draft PR under autonomy=auto [P2.T13]

### DIFF
--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -232,6 +232,65 @@ queue_fail_item() {
     queue_api PUT "/api/queue/$qid" "{\"state\":\"failed\",\"error_message\":\"$error_msg\"}" >/dev/null 2>&1
 }
 
+# --- Autonomy gate (ADR-0001) ---------------------------------------------
+# Fetches the per-project autonomy level from the dashboard API. Runs fall
+# back to 'assisted' when the project isn't registered or the API is
+# unreachable. Keeps us from auto-opening a PR against an unknown project.
+get_project_autonomy() {
+    local project="$1"
+    local all_projects
+    all_projects=$(queue_api GET "/api/projects")
+    if [ -z "$all_projects" ]; then
+        echo "assisted"
+        return 0
+    fi
+    python3 - "$project" "$all_projects" 2>/dev/null <<'PY' || echo "assisted"
+import json, sys
+target, payload = sys.argv[1], sys.argv[2]
+try:
+    for p in json.loads(payload):
+        if p.get("repo") == target:
+            level = p.get("autonomy_level") or "assisted"
+            print(level)
+            sys.exit(0)
+except Exception:
+    pass
+print("assisted")
+PY
+}
+
+# Per-project rate limit for auto-draft PRs. Writes the timestamp of the
+# most recent draft-PR attempt to a lock file; returns 0 (allow) if > 1h
+# since the last write, 1 (deny) otherwise.
+AUTO_DRAFT_RATE_LIMIT_DIR="${AUTO_DRAFT_RATE_LIMIT_DIR:-/var/lib/claude-agent-station/auto-draft}"
+AUTO_DRAFT_RATE_LIMIT_SECONDS="${AUTO_DRAFT_RATE_LIMIT_SECONDS:-3600}"
+
+auto_draft_rate_limit_allowed() {
+    local project="$1"
+    local slug
+    slug=$(echo "$project" | tr '/' '_' | tr -cd 'A-Za-z0-9_.-')
+    mkdir -p "$AUTO_DRAFT_RATE_LIMIT_DIR" 2>/dev/null || true
+    local lock="$AUTO_DRAFT_RATE_LIMIT_DIR/$slug.lock"
+    if [ ! -f "$lock" ]; then
+        return 0
+    fi
+    local last_epoch now_epoch
+    last_epoch=$(cat "$lock" 2>/dev/null || echo 0)
+    now_epoch=$(date +%s)
+    if [ $((now_epoch - last_epoch)) -ge "$AUTO_DRAFT_RATE_LIMIT_SECONDS" ]; then
+        return 0
+    fi
+    return 1
+}
+
+auto_draft_rate_limit_record() {
+    local project="$1"
+    local slug
+    slug=$(echo "$project" | tr '/' '_' | tr -cd 'A-Za-z0-9_.-')
+    mkdir -p "$AUTO_DRAFT_RATE_LIMIT_DIR" 2>/dev/null || true
+    date +%s > "$AUTO_DRAFT_RATE_LIMIT_DIR/$slug.lock" 2>/dev/null || true
+}
+
 usage() {
     cat << 'EOF'
 Manager/Employee Autonomous Agent Orchestrator
@@ -1853,25 +1912,65 @@ Run: $RUN_ID" 2>/dev/null || true
                     if [ "$push_ok" = true ]; then
                         log_ok "Pushed $branch"
 
-                        # Create PR and merge via GitHub API (works with protected branches)
-                        local pr_url
-                        pr_url=$(gh pr create --repo "$project" --base "$base_branch" --head "$branch" \
-                            --title "autonomous: $(git log -1 --format=%s)" \
-                            --body "Approved by autonomous manager.
+                        # ADR-0001: under 'auto' autonomy, open a DRAFT PR and
+                        # skip the auto-merge attempt. Under manual/assisted,
+                        # fall through to the existing open-PR-then-try-merge
+                        # path (branch protection on main rejects the merge
+                        # anyway; this just preserves existing logging).
+                        local project_autonomy
+                        project_autonomy=$(get_project_autonomy "$project")
+                        local autonomy_auto=false
+                        if [ "$project_autonomy" = "auto" ]; then
+                            autonomy_auto=true
+                        fi
+
+                        if [ "$autonomy_auto" = true ]; then
+                            if auto_draft_rate_limit_allowed "$project"; then
+                                log_info "Auto-draft PR (autonomy=auto, rate limit OK)"
+                                local pr_url
+                                pr_url=$(gh pr create --repo "$project" --base "$base_branch" --head "$branch" \
+                                    --draft \
+                                    --title "autonomous (draft): $(git log -1 --format=%s)" \
+                                    --body "Draft PR auto-opened under \`autonomy=auto\`.
+
+Run: $RUN_ID
+
+**Human review required before merge.** This PR stays as a draft — mark it ready for review when satisfied.
+
+---
+Rate limit: max 1 auto-draft PR per project per hour. Regenerated at $(date -u +%Y-%m-%dT%H:%M:%SZ)." 2>&1) || true
+
+                                if [ -n "$pr_url" ]; then
+                                    log_ok "Draft PR created: $pr_url"
+                                    auto_draft_rate_limit_record "$project"
+                                    webhook_event "auto_draft_pr_opened" "\"project\":\"$project\",\"branch\":\"$branch\",\"pr_url\":\"$pr_url\"" >&2
+                                else
+                                    log_error "Auto-draft PR creation failed for $branch"
+                                fi
+                            else
+                                log_warn "Auto-draft PR skipped (rate limit: 1/hour/project); branch $branch pushed for manual review"
+                            fi
+                        else
+                            # Create PR and merge via GitHub API (works with protected branches)
+                            local pr_url
+                            pr_url=$(gh pr create --repo "$project" --base "$base_branch" --head "$branch" \
+                                --title "autonomous: $(git log -1 --format=%s)" \
+                                --body "Approved by autonomous manager.
 
 Run: $RUN_ID" 2>&1) || true
 
-                        if [ -n "$pr_url" ]; then
-                            log_info "PR created: $pr_url"
-                            # Merge the PR
-                            if gh pr merge "$pr_url" --merge --delete-branch 2>&1 | while IFS= read -r line; do log_info "  $line"; done; then
-                                push_merge_ok=true
-                                log_ok "PR merged to $base_branch"
+                            if [ -n "$pr_url" ]; then
+                                log_info "PR created: $pr_url"
+                                # Merge the PR
+                                if gh pr merge "$pr_url" --merge --delete-branch 2>&1 | while IFS= read -r line; do log_info "  $line"; done; then
+                                    push_merge_ok=true
+                                    log_ok "PR merged to $base_branch"
+                                else
+                                    log_error "PR merge failed — left open for manual review: $pr_url"
+                                fi
                             else
-                                log_error "PR merge failed — left open for manual review: $pr_url"
+                                log_error "PR creation failed for $branch"
                             fi
-                        else
-                            log_error "PR creation failed for $branch"
                         fi
                     else
                         log_error "Push failed for $branch after 2 attempts"
@@ -2659,4 +2758,7 @@ print(json.dumps(result))
     _RUN_COMPLETE_SENT=1
 }
 
-main "$@"
+# Only run main when executed directly; allow `source` for helper testing.
+if [ "${BASH_SOURCE[0]}" = "${0}" ] || [ -z "${BASH_SOURCE[0]-}" ]; then
+    main "$@"
+fi

--- a/dashboard/backend/tests/test_run_manager_helpers.py
+++ b/dashboard/backend/tests/test_run_manager_helpers.py
@@ -1,0 +1,152 @@
+"""Tests for shell helpers in agent/scripts/run-manager.sh — ADR-0001.
+
+We don't want to mock the whole shell pipeline, but the auto-draft rate
+limit is pure state + timestamp logic that's worth pinning. We source the
+script in a subshell with a throwaway rate-limit directory.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RUN_MANAGER = REPO_ROOT / "agent" / "scripts" / "run-manager.sh"
+
+
+def _run_helper(snippet: str, *, env_overrides: dict[str, str] | None = None) -> tuple[int, str, str]:
+    """Source run-manager.sh and run a bash snippet against the helpers.
+
+    We short-circuit the script's main flow by setting a sentinel that causes
+    the top-level argument parser to no-op; in practice we just source the
+    file and then exec our snippet. The script defines functions at top level
+    but also runs main logic — we wrap the call in `( ... )` so side effects
+    like `set -e` don't kill the test host.
+    """
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+
+    # Use `bash -c`: source the script with sourcing short-circuited to just
+    # pick up function definitions by setting CLAUDE_AGENT_STATION_SOURCE_ONLY.
+    # The script doesn't honour such a flag today, so we instead inline the
+    # helper functions by copying them with `declare -f` after sourcing.
+    # Simpler: source, then run the snippet; if the source side-effects try
+    # to run main, they'll hit missing args and exit. We guard with ||true.
+    cmd = f"source '{RUN_MANAGER}' 2>/dev/null || true; {snippet}"
+    result = subprocess.run(
+        ["bash", "-c", cmd], env=env, capture_output=True, text=True, timeout=10,
+    )
+    return result.returncode, result.stdout.strip(), result.stderr.strip()
+
+
+def test_rate_limit_allows_first_call(tmp_path):
+    """With no lockfile, auto_draft_rate_limit_allowed returns 0 (allow)."""
+    rc, _, _ = _run_helper(
+        'auto_draft_rate_limit_allowed "owner/repo"; echo $?',
+        env_overrides={
+            "AUTO_DRAFT_RATE_LIMIT_DIR": str(tmp_path),
+            "AUTO_DRAFT_RATE_LIMIT_SECONDS": "3600",
+        },
+    )
+    # We ran the helper then echoed $?; capture its stdout.
+    result = subprocess.run(
+        [
+            "bash", "-c",
+            f"source '{RUN_MANAGER}' 2>/dev/null || true; "
+            f'if auto_draft_rate_limit_allowed "owner/repo"; then echo YES; else echo NO; fi',
+        ],
+        env={
+            **os.environ,
+            "AUTO_DRAFT_RATE_LIMIT_DIR": str(tmp_path),
+            "AUTO_DRAFT_RATE_LIMIT_SECONDS": "3600",
+        },
+        capture_output=True, text=True, timeout=10,
+    )
+    assert "YES" in result.stdout
+
+
+def test_rate_limit_blocks_within_window(tmp_path):
+    """After recording a hit, a second call within the window is denied."""
+    env = {
+        **os.environ,
+        "AUTO_DRAFT_RATE_LIMIT_DIR": str(tmp_path),
+        "AUTO_DRAFT_RATE_LIMIT_SECONDS": "3600",
+    }
+    # Record a hit.
+    rec = subprocess.run(
+        [
+            "bash", "-c",
+            f"source '{RUN_MANAGER}' 2>/dev/null || true; "
+            f'auto_draft_rate_limit_record "owner/repo"',
+        ],
+        env=env, capture_output=True, text=True, timeout=10,
+    )
+    assert rec.returncode == 0
+
+    # Lockfile should exist and be ~now.
+    locks = list(tmp_path.glob("*.lock"))
+    assert len(locks) == 1
+    saved_epoch = int(locks[0].read_text().strip())
+    assert abs(saved_epoch - int(time.time())) < 5
+
+    # Second call is denied.
+    check = subprocess.run(
+        [
+            "bash", "-c",
+            f"source '{RUN_MANAGER}' 2>/dev/null || true; "
+            f'if auto_draft_rate_limit_allowed "owner/repo"; then echo YES; else echo NO; fi',
+        ],
+        env=env, capture_output=True, text=True, timeout=10,
+    )
+    assert "NO" in check.stdout
+
+
+def test_rate_limit_releases_after_window(tmp_path):
+    """A stale lockfile older than the window allows a new hit."""
+    slug = "owner_repo"
+    lock = tmp_path / f"{slug}.lock"
+    lock.write_text(str(int(time.time()) - 3700))  # 1h 1m 40s ago
+
+    env = {
+        **os.environ,
+        "AUTO_DRAFT_RATE_LIMIT_DIR": str(tmp_path),
+        "AUTO_DRAFT_RATE_LIMIT_SECONDS": "3600",
+    }
+    result = subprocess.run(
+        [
+            "bash", "-c",
+            f"source '{RUN_MANAGER}' 2>/dev/null || true; "
+            f'if auto_draft_rate_limit_allowed "owner/repo"; then echo YES; else echo NO; fi',
+        ],
+        env=env, capture_output=True, text=True, timeout=10,
+    )
+    assert "YES" in result.stdout
+
+
+def test_rate_limit_slug_sanitises_repo_name(tmp_path):
+    """Slug strips path separators so 'owner/repo' doesn't create subdirs."""
+    env = {
+        **os.environ,
+        "AUTO_DRAFT_RATE_LIMIT_DIR": str(tmp_path),
+        "AUTO_DRAFT_RATE_LIMIT_SECONDS": "3600",
+    }
+    subprocess.run(
+        [
+            "bash", "-c",
+            f"source '{RUN_MANAGER}' 2>/dev/null || true; "
+            f'auto_draft_rate_limit_record "owner/repo"',
+        ],
+        env=env, check=True, timeout=10, capture_output=True,
+    )
+    # Should produce exactly one lockfile at top level, no subdirs.
+    subdirs = [p for p in tmp_path.iterdir() if p.is_dir()]
+    locks = list(tmp_path.glob("*.lock"))
+    assert subdirs == []
+    assert len(locks) == 1
+    assert "owner_repo" in locks[0].name


### PR DESCRIPTION
## Summary
Adds the ADR-0001 auto-draft-PR path to \`agent/scripts/run-manager.sh\`. When the manager returns \`APPROVE\`:

- **\`autonomy=auto\`** → open as \`--draft\`, skip the auto-merge attempt, rate-limited 1/hour/project.
- **\`autonomy=manual|assisted\`** → fall through to the existing path (open PR, try merge which branch-protection blocks — unchanged behaviour).

Why \`--draft\` (not immediate merge) under auto: ADR-0001 mandates "merge to main stays 100% manual" — the operator still marks the PR ready and merges. Auto just opens the PR without waiting for a manager verdict-to-review ceremony.

## Wiring
- New helper \`get_project_autonomy "owner/repo"\` → queries \`GET /api/projects\`, falls back to \`'assisted'\` on any failure.
- Rate limit via lockfile under \`\$AUTO_DRAFT_RATE_LIMIT_DIR\` (default \`/var/lib/claude-agent-station/auto-draft\`); window \`\$AUTO_DRAFT_RATE_LIMIT_SECONDS\` (default 3600s).
- Emits a \`auto_draft_pr_opened\` webhook so the dashboard can surface the draft PR.
- Guards the script's \`main "\$@"\` tail with a \`BASH_SOURCE\` check so helpers can be sourced in isolation for testing (brought the helper test suite down from 52s → 1.3s).

## Why project-only gate (not project+run)
The plan calls for "both project AND run = auto". Run-level autonomy override UI doesn't exist yet (deferred from P2.T11), so for now this PR gates on project autonomy only — which is the operator-controlled setting that already has a UI. A second gate on \`run.autonomy_level\` is a one-line change to \`run-manager.sh\` once we add an override path.

## Test plan
- [x] \`pytest dashboard/backend/tests/test_run_manager_helpers.py -q\` → **4 passed in 1.33s**
  - \`test_rate_limit_allows_first_call\` — no lockfile → allow
  - \`test_rate_limit_blocks_within_window\` — record then re-check → deny
  - \`test_rate_limit_releases_after_window\` — stale lockfile → allow
  - \`test_rate_limit_slug_sanitises_repo_name\` — \`owner/repo\` doesn't create subdirs
- [x] \`bash -n agent/scripts/run-manager.sh\` clean
- [x] Full backend suite: **556 passed, 53 skipped**
- [ ] Post-merge: trigger an autonomous run against a project with \`autonomy_level=auto\` → verify draft PR opens, second run within the hour is rate-limited, \`/api/webhook/event\` log shows \`auto_draft_pr_opened\`.

Part of the Auto Mode rollout plan at \`/root/.claude/plans/fluttering-meandering-clarke.md\`.