### PR TITLE
feat(tray): live permission tray [P2.T10]

### DIFF
--- a/dashboard/backend/app/database.py
+++ b/dashboard/backend/app/database.py
@@ -107,6 +107,7 @@ async def init_db():
             CoordinatorTask,
             IntegrationFeature,
             Notification,
+            PermissionRequest,
             Plan,
             PlanUsageHistory,
             PromptVersion,

--- a/dashboard/backend/app/main.py
+++ b/dashboard/backend/app/main.py
@@ -27,6 +27,7 @@ from app.routers import (
     health,
     logs,
     oauth,
+    permissions,
     plan_usage,
     plans,
     projects,
@@ -186,6 +187,7 @@ app.include_router(plan_usage.router, dependencies=_auth)
 app.include_router(prompts.router, dependencies=_auth)
 app.include_router(queue.router, dependencies=_auth)
 app.include_router(agent_events.router, dependencies=_auth)
+app.include_router(permissions.router, dependencies=_auth)
 
 # GitHub webhook: has own auth via HMAC signature verification
 app.include_router(github_webhook.router)

--- a/dashboard/backend/app/models.py
+++ b/dashboard/backend/app/models.py
@@ -324,3 +324,31 @@ class PromptVersion(Base):
     success_rate = Column(Float, nullable=True)  # Calculated from task_outcomes
     sample_count = Column(Integer, default=0)
     created_at = Column(DateTime, default=_utcnow)
+
+
+class PermissionRequest(Base):
+    """Pending operator permission requests raised by the policy engine.
+
+    ADR-0001: under manual/assisted, destructive bash or edit calls can be
+    referred to the operator instead of being denied outright. The policy
+    engine writes a row here, an SSE event notifies the dashboard, the
+    operator clicks approve/deny, and the agent polls the row to unblock.
+
+    Auto-deny after 5 minutes if the operator doesn't respond — configurable
+    via STATION_PERMISSION_TRAY_TIMEOUT_SECONDS.
+    """
+    __tablename__ = "permission_requests"
+
+    id = Column(Integer, primary_key=True)
+    request_id = Column(Text, nullable=False, unique=True, index=True)
+    run_id = Column(Text, nullable=False, index=True)
+    agent_id = Column(Text, nullable=False)
+    tool_name = Column(Text, nullable=False)
+    tool_input = Column(Text, nullable=False)  # JSON
+    autonomy_level = Column(Text, nullable=False)
+    reason = Column(Text, nullable=True)  # Why the policy referred this to the operator
+    status = Column(Text, nullable=False, default="pending", index=True)
+    # pending | approved | denied | timed_out
+    resolution_note = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=_utcnow)
+    resolved_at = Column(DateTime, nullable=True)

--- a/dashboard/backend/app/routers/permissions.py
+++ b/dashboard/backend/app/routers/permissions.py
@@ -1,0 +1,205 @@
+"""Permission tray endpoints (ADR-0001, P2.T10).
+
+The policy engine writes rows into `permission_requests`; the dashboard
+lists pending rows, shows an approve/deny UI, and resolves the request.
+A 5-minute timer auto-denies rows the operator ignores.
+
+Row lifecycle:
+    pending --(approve)--> approved
+    pending --(deny)----> denied
+    pending --(timeout)-> timed_out
+    <terminal> is immutable
+
+The agent process polls its own row via `GET /api/runs/{run_id}/permissions/{request_id}`
+and only proceeds once the row leaves 'pending'. That polling path lives
+in the agent; this router owns the operator side.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies import get_db
+from app.models import PermissionRequest
+from app.schemas import PermissionDecisionIn, PermissionRequestOut
+from app.services import event_bus
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/permissions", tags=["permissions"])
+
+
+def _timeout_seconds() -> int:
+    raw = os.environ.get("STATION_PERMISSION_TRAY_TIMEOUT_SECONDS", "300")
+    try:
+        return max(30, int(raw))
+    except ValueError:
+        return 300
+
+
+async def _timeout_expired_rows(db: AsyncSession) -> list[PermissionRequest]:
+    """Flip any pending rows older than the timeout to timed_out."""
+    horizon = datetime.now(timezone.utc) - timedelta(seconds=_timeout_seconds())
+    stmt = select(PermissionRequest).where(
+        PermissionRequest.status == "pending",
+        PermissionRequest.created_at <= horizon,
+    )
+    result = await db.execute(stmt)
+    expired = list(result.scalars().all())
+    if not expired:
+        return []
+    now = datetime.now(timezone.utc)
+    for row in expired:
+        row.status = "timed_out"
+        row.resolved_at = now
+        row.resolution_note = (
+            f"auto-denied after {_timeout_seconds()}s without operator response"
+        )
+    await db.commit()
+    for row in expired:
+        await event_bus.publish({
+            "type": "permission_resolved",
+            "data": {
+                "request_id": row.request_id,
+                "status": row.status,
+                "run_id": row.run_id,
+                "note": row.resolution_note,
+            },
+        })
+    return expired
+
+
+@router.get("", response_model=list[PermissionRequestOut])
+async def list_permission_requests(
+    status: str | None = None,
+    run_id: str | None = None,
+    limit: int = 50,
+    db: AsyncSession = Depends(get_db),
+):
+    """List permission requests. Default status=pending, oldest first."""
+    await _timeout_expired_rows(db)
+
+    stmt = select(PermissionRequest)
+    effective_status = status or "pending"
+    if effective_status != "all":
+        stmt = stmt.where(PermissionRequest.status == effective_status)
+    if run_id:
+        stmt = stmt.where(PermissionRequest.run_id == run_id)
+    stmt = stmt.order_by(PermissionRequest.created_at.asc()).limit(limit)
+
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+@router.get("/{request_id}", response_model=PermissionRequestOut)
+async def get_permission_request(
+    request_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    await _timeout_expired_rows(db)
+    result = await db.execute(
+        select(PermissionRequest).where(PermissionRequest.request_id == request_id)
+    )
+    row = result.scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="permission request not found")
+    return row
+
+
+@router.post("/{request_id}", response_model=PermissionRequestOut)
+async def resolve_permission_request(
+    request_id: str,
+    payload: PermissionDecisionIn,
+    db: AsyncSession = Depends(get_db),
+):
+    """Operator resolves a pending request. Idempotent in terminal states:
+    calls against already-resolved rows return 409 rather than silently
+    overwriting — we don't want to flip an expired auto-deny to approve."""
+    # Run a timeout sweep first so the operator can't act on a row that has
+    # already expired on the server side.
+    await _timeout_expired_rows(db)
+
+    result = await db.execute(
+        select(PermissionRequest).where(PermissionRequest.request_id == request_id)
+    )
+    row = result.scalar_one_or_none()
+    if not row:
+        raise HTTPException(status_code=404, detail="permission request not found")
+
+    if row.status != "pending":
+        raise HTTPException(
+            status_code=409,
+            detail=f"request already resolved (status={row.status})",
+        )
+
+    row.status = "approved" if payload.decision == "approve" else "denied"
+    row.resolution_note = payload.note
+    row.resolved_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(row)
+
+    await event_bus.publish({
+        "type": "permission_resolved",
+        "data": {
+            "request_id": row.request_id,
+            "status": row.status,
+            "run_id": row.run_id,
+            "note": row.resolution_note,
+        },
+    })
+    logger.info(
+        "permission %s resolved: %s (run=%s, tool=%s)",
+        row.request_id, row.status, row.run_id, row.tool_name,
+    )
+    return row
+
+
+async def create_permission_request(
+    db: AsyncSession,
+    *,
+    request_id: str,
+    run_id: str,
+    agent_id: str,
+    tool_name: str,
+    tool_input: dict,
+    autonomy_level: str,
+    reason: str | None = None,
+) -> PermissionRequest:
+    """Helper used by the policy engine to raise a new request.
+
+    Also publishes a `permission_request` SSE event so the dashboard can
+    pop the tray without polling.
+    """
+    row = PermissionRequest(
+        request_id=request_id,
+        run_id=run_id,
+        agent_id=agent_id,
+        tool_name=tool_name,
+        tool_input=json.dumps(tool_input, default=str),
+        autonomy_level=autonomy_level,
+        reason=reason,
+        status="pending",
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    await event_bus.publish({
+        "type": "permission_request",
+        "data": {
+            "request_id": row.request_id,
+            "run_id": row.run_id,
+            "agent_id": row.agent_id,
+            "tool_name": row.tool_name,
+            "tool_input": tool_input,
+            "autonomy_level": row.autonomy_level,
+            "reason": row.reason,
+        },
+    })
+    return row

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -617,3 +617,49 @@ class EffortPrediction(BaseModel):
     predicted_tokens: float | None = None
     confidence: float | None = None
     sample_count: int = 0
+
+
+# --- Permission Tray (ADR-0001, P2.T10) ---
+
+class PermissionRequestOut(BaseModel):
+    """Payload for a pending operator permission prompt."""
+    id: int
+    request_id: str
+    run_id: str
+    agent_id: str
+    tool_name: str
+    tool_input: dict[str, Any]
+    autonomy_level: str
+    reason: str | None = None
+    status: str
+    resolution_note: str | None = None
+    created_at: datetime | None = None
+    resolved_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("tool_input", mode="before")
+    @classmethod
+    def _parse_json_input(cls, v: Any) -> Any:
+        """tool_input is stored as a JSON string; unwrap for the API."""
+        if isinstance(v, str):
+            import json as _json
+            try:
+                return _json.loads(v)
+            except Exception:
+                return {"raw": v}
+        return v or {}
+
+
+class PermissionDecisionIn(BaseModel):
+    """Operator response to a pending permission request."""
+    decision: str  # 'approve' or 'deny'
+    note: str | None = None
+
+    @field_validator("decision")
+    @classmethod
+    def _validate_decision(cls, v: str) -> str:
+        v = (v or "").strip().lower()
+        if v not in ("approve", "deny"):
+            raise ValueError("decision must be 'approve' or 'deny'")
+        return v

--- a/dashboard/backend/tests/test_permissions.py
+++ b/dashboard/backend/tests/test_permissions.py
@@ -1,0 +1,217 @@
+"""Tests for the permission-tray endpoints — ADR-0001, P2.T10."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import Base, async_session, engine
+from app.main import app
+from app.models import PermissionRequest
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _seed_pending(
+    request_id: str = "req-1",
+    *,
+    run_id: str = "run-100",
+    created_at: datetime | None = None,
+    status: str = "pending",
+) -> PermissionRequest:
+    async with async_session() as session:
+        row = PermissionRequest(
+            request_id=request_id,
+            run_id=run_id,
+            agent_id="lead",
+            tool_name="Bash",
+            tool_input=json.dumps({"command": "rm -rf node_modules"}),
+            autonomy_level="assisted",
+            reason="destructive bash",
+            status=status,
+        )
+        if created_at is not None:
+            row.created_at = created_at
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        return row
+
+
+# --- GET list ---
+
+@pytest.mark.asyncio
+async def test_list_returns_empty_when_no_requests(client):
+    resp = await client.get("/api/permissions")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.asyncio
+async def test_list_returns_pending_only_by_default(client, setup_db):
+    await _seed_pending("req-pending", status="pending")
+    await _seed_pending("req-done", status="approved")
+
+    resp = await client.get("/api/permissions")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert [r["request_id"] for r in rows] == ["req-pending"]
+    assert rows[0]["tool_input"] == {"command": "rm -rf node_modules"}
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_run_id(client, setup_db):
+    await _seed_pending("req-a", run_id="run-A")
+    await _seed_pending("req-b", run_id="run-B")
+
+    resp = await client.get("/api/permissions?run_id=run-B")
+    assert resp.status_code == 200
+    assert [r["request_id"] for r in resp.json()] == ["req-b"]
+
+
+@pytest.mark.asyncio
+async def test_list_status_all_returns_everything(client, setup_db):
+    await _seed_pending("req-pending", status="pending")
+    await _seed_pending("req-done", status="approved")
+
+    resp = await client.get("/api/permissions?status=all")
+    assert resp.status_code == 200
+    assert {r["request_id"] for r in resp.json()} == {"req-pending", "req-done"}
+
+
+# --- GET single ---
+
+@pytest.mark.asyncio
+async def test_get_single_request(client, setup_db):
+    await _seed_pending("req-1")
+    resp = await client.get("/api/permissions/req-1")
+    assert resp.status_code == 200
+    assert resp.json()["request_id"] == "req-1"
+
+
+@pytest.mark.asyncio
+async def test_get_single_request_404(client):
+    resp = await client.get("/api/permissions/missing")
+    assert resp.status_code == 404
+
+
+# --- POST resolve ---
+
+@pytest.mark.asyncio
+async def test_approve_transitions_status(client, setup_db):
+    await _seed_pending("req-1")
+    resp = await client.post("/api/permissions/req-1", json={
+        "decision": "approve",
+        "note": "operator sign-off",
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "approved"
+    assert body["resolution_note"] == "operator sign-off"
+    assert body["resolved_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_deny_transitions_status(client, setup_db):
+    await _seed_pending("req-1")
+    resp = await client.post("/api/permissions/req-1", json={"decision": "deny"})
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "denied"
+
+
+@pytest.mark.asyncio
+async def test_resolve_twice_returns_409(client, setup_db):
+    await _seed_pending("req-1")
+    first = await client.post("/api/permissions/req-1", json={"decision": "approve"})
+    assert first.status_code == 200
+
+    # Second call is blocked — terminal state is immutable.
+    second = await client.post("/api/permissions/req-1", json={"decision": "deny"})
+    assert second.status_code == 409
+    assert "already resolved" in second.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_missing_returns_404(client):
+    resp = await client.post("/api/permissions/missing", json={"decision": "approve"})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_decision_must_be_approve_or_deny(client, setup_db):
+    await _seed_pending("req-1")
+    resp = await client.post("/api/permissions/req-1", json={"decision": "maybe"})
+    assert resp.status_code == 422
+
+
+# --- Timeout / auto-deny ---
+
+@pytest.mark.asyncio
+async def test_stale_pending_request_auto_times_out(client, setup_db, monkeypatch):
+    """Rows older than the timeout are flipped to timed_out on read."""
+    # Keep the timeout small for the test.
+    monkeypatch.setenv("STATION_PERMISSION_TRAY_TIMEOUT_SECONDS", "60")
+    long_ago = datetime.now(timezone.utc) - timedelta(seconds=120)
+    await _seed_pending("req-stale", created_at=long_ago)
+
+    # A plain list call triggers the sweep.
+    resp = await client.get("/api/permissions?status=all")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["status"] == "timed_out"
+    assert "auto-denied" in (rows[0]["resolution_note"] or "")
+
+
+@pytest.mark.asyncio
+async def test_cannot_resolve_after_timeout(client, setup_db, monkeypatch):
+    """Once a row has timed out, approve/deny returns 409 so the operator
+    can't retroactively allow a call the agent already moved past."""
+    monkeypatch.setenv("STATION_PERMISSION_TRAY_TIMEOUT_SECONDS", "60")
+    long_ago = datetime.now(timezone.utc) - timedelta(seconds=120)
+    await _seed_pending("req-stale", created_at=long_ago)
+
+    resp = await client.post("/api/permissions/req-stale", json={"decision": "approve"})
+    assert resp.status_code == 409
+    assert "timed_out" in resp.json()["detail"]
+
+
+# --- Helper (agent side) ---
+
+@pytest.mark.asyncio
+async def test_create_permission_request_helper(setup_db):
+    from app.routers.permissions import create_permission_request
+
+    async with async_session() as session:
+        row = await create_permission_request(
+            session,
+            request_id="req-agent",
+            run_id="run-A",
+            agent_id="teammate-issue-worker",
+            tool_name="Bash",
+            tool_input={"command": "git reset --hard HEAD~1"},
+            autonomy_level="manual",
+            reason="destructive at manual",
+        )
+    assert row.status == "pending"
+    # Stored as JSON string; schema decodes on the way out.
+    assert json.loads(row.tool_input) == {"command": "git reset --hard HEAD~1"}

--- a/dashboard/frontend/src/App.svelte
+++ b/dashboard/frontend/src/App.svelte
@@ -17,6 +17,7 @@
   // Overlays
   import Toast from './components/overlays/Toast.svelte';
   import ShortcutsOverlay from './components/overlays/ShortcutsOverlay.svelte';
+  import PermissionTray from './components/layout/PermissionTray.svelte';
 
   // Pages
   import CommandCenter from './pages/CommandCenter.svelte';
@@ -130,4 +131,5 @@
 
   <Toast />
   <ShortcutsOverlay show={showShortcuts} onClose={() => (showShortcuts = false)} />
+  <PermissionTray />
 </div>

--- a/dashboard/frontend/src/components/layout/PermissionTray.svelte
+++ b/dashboard/frontend/src/components/layout/PermissionTray.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { portal } from '../../lib/portal';
+  import { approve, deny, loadPending, permissionTray } from '../../lib/permission-tray.svelte';
+  import { addToast } from '../../lib/toast.svelte';
+  import AutonomyBadge from '../badges/AutonomyBadge.svelte';
+  import type { PermissionRequest } from '../../lib/api';
+  import type { AutonomyLevel } from '../../lib/types';
+
+  let expanded = $state(false);
+  let resolvingId = $state<string | null>(null);
+
+  // Hydrate once on mount — after that SSE keeps the list fresh.
+  $effect(() => {
+    loadPending();
+  });
+
+  let pending = $derived(permissionTray.pending);
+  let count = $derived(pending.length);
+
+  // Auto-expand whenever a new request arrives so the operator notices.
+  let previousCount = 0;
+  $effect(() => {
+    if (pending.length > previousCount) {
+      expanded = true;
+    }
+    previousCount = pending.length;
+  });
+
+  async function handleApprove(req: PermissionRequest) {
+    resolvingId = req.request_id;
+    try {
+      await approve(req.request_id);
+      addToast('success', `Approved ${req.tool_name}`);
+    } catch (e: any) {
+      addToast('error', e?.message ?? 'Approve failed');
+    } finally {
+      resolvingId = null;
+    }
+  }
+
+  async function handleDeny(req: PermissionRequest) {
+    resolvingId = req.request_id;
+    try {
+      await deny(req.request_id);
+      addToast('success', `Denied ${req.tool_name}`);
+    } catch (e: any) {
+      addToast('error', e?.message ?? 'Deny failed');
+    } finally {
+      resolvingId = null;
+    }
+  }
+
+  function summary(input: Record<string, unknown>): string {
+    // Bash → command; Edit/Write → file_path; everything else → first value.
+    if (typeof input.command === 'string') return input.command;
+    if (typeof input.file_path === 'string') return input.file_path;
+    for (const v of Object.values(input)) {
+      if (typeof v === 'string') return v;
+    }
+    try {
+      return JSON.stringify(input).slice(0, 120);
+    } catch {
+      return '';
+    }
+  }
+</script>
+
+{#if count > 0}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    use:portal
+    class="fixed bottom-4 right-4 z-tray max-w-md w-full shadow-2xl"
+    role="region"
+    aria-label="Pending permissions"
+  >
+    <div class="glass rounded-xl border border-border overflow-hidden">
+      <button
+        class="w-full flex items-center justify-between px-4 py-2 border-b border-border text-sm font-semibold text-primary"
+        onclick={() => (expanded = !expanded)}
+      >
+        <span>
+          {count} pending permission{count === 1 ? '' : 's'}
+        </span>
+        <span class="text-tertiary text-xs">{expanded ? '▼' : '▲'}</span>
+      </button>
+
+      {#if expanded}
+        <ul class="max-h-80 overflow-y-auto divide-y divide-border">
+          {#each pending as req (req.request_id)}
+            <li class="p-3 space-y-2 text-xs">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="badge badge-pending">{req.tool_name}</span>
+                <AutonomyBadge level={req.autonomy_level as AutonomyLevel} size="xs" />
+                <span class="font-mono text-tertiary truncate">{req.run_id}</span>
+              </div>
+              {#if req.reason}
+                <div class="text-secondary">{req.reason}</div>
+              {/if}
+              <div class="font-mono text-[11px] text-primary bg-surface-1 rounded-md px-2 py-1 break-all">
+                {summary(req.tool_input)}
+              </div>
+              <div class="flex items-center gap-2">
+                <button
+                  class="btn btn-primary btn-sm flex-1"
+                  disabled={resolvingId === req.request_id}
+                  onclick={() => handleApprove(req)}
+                >
+                  Approve
+                </button>
+                <button
+                  class="btn btn-secondary btn-sm flex-1"
+                  disabled={resolvingId === req.request_id}
+                  onclick={() => handleDeny(req)}
+                >
+                  Deny
+                </button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
+  </div>
+{/if}
+
+<style>
+  :global(.z-tray) { z-index: 60; }
+</style>

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -10,6 +10,7 @@ import type { ParsedLogEvent } from './log-parser';
 import { getActiveEmployees, getLatestRun, listPlans, listRuns, getStoredApiKey } from './api';
 import type { ActiveEmployee, Run } from './types';
 import { AgentEventStream } from './event-stream';
+import { handleStreamEvent as permissionTrayHandleEvent } from './permission-tray.svelte';
 
 // --- Agent Identity ---
 
@@ -327,7 +328,11 @@ function handleWsMessage(data: string) {
 
 function connectSSE() {
   sse = new AgentEventStream({
-    onEvent: (event) => handleSSEEvent(event),
+    onEvent: (event) => {
+      handleSSEEvent(event);
+      // Forward permission tray events to the tray store (ADR-0001 / P2.T10).
+      permissionTrayHandleEvent(event);
+    },
     onStatusChange: (state) => { agentPresence.sseConnected = state === 'connected'; },
   });
   sse.connect();

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -137,6 +137,42 @@ export const updateProject = (id: number, data: Partial<Project>) =>
 export const deleteProject = (id: number) =>
   requestWithToast<void>(`/api/projects/${id}`, { method: 'DELETE' });
 
+// --- Permissions (ADR-0001 tray) ---
+
+export interface PermissionRequest {
+  id: number;
+  request_id: string;
+  run_id: string;
+  agent_id: string;
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  autonomy_level: string;
+  reason: string | null;
+  status: 'pending' | 'approved' | 'denied' | 'timed_out';
+  resolution_note: string | null;
+  created_at: string | null;
+  resolved_at: string | null;
+}
+
+export const listPermissionRequests = (params?: { status?: string; run_id?: string; limit?: number }) => {
+  const q = new URLSearchParams();
+  if (params?.status) q.set('status', params.status);
+  if (params?.run_id) q.set('run_id', params.run_id);
+  if (params?.limit != null) q.set('limit', String(params.limit));
+  const qs = q.toString();
+  return request<PermissionRequest[]>(`/api/permissions${qs ? '?' + qs : ''}`);
+};
+
+export const resolvePermissionRequest = (
+  requestId: string,
+  decision: 'approve' | 'deny',
+  note?: string,
+) =>
+  request<PermissionRequest>(`/api/permissions/${encodeURIComponent(requestId)}`, {
+    method: 'POST',
+    body: JSON.stringify({ decision, note }),
+  });
+
 // --- Runs ---
 
 export const listRuns = (params?: {

--- a/dashboard/frontend/src/lib/event-stream.ts
+++ b/dashboard/frontend/src/lib/event-stream.ts
@@ -119,6 +119,7 @@ export class AgentEventStream {
       'queue_pending', 'queue_claimed', 'queue_assigned', 'queue_in_progress',
       'queue_review', 'queue_approved', 'queue_rejected', 'queue_completed', 'queue_failed',
       'intelligence_decision', 'notification',
+      'permission_request', 'permission_resolved',
     ];
 
     for (const eventType of knownTypes) {

--- a/dashboard/frontend/src/lib/permission-tray.svelte.ts
+++ b/dashboard/frontend/src/lib/permission-tray.svelte.ts
@@ -1,0 +1,99 @@
+/**
+ * Permission Tray store — ADR-0001, P2.T10.
+ *
+ * Lifecycle:
+ *  - On app boot, call `loadPending()` once to hydrate the queue.
+ *  - The central SSE stream in `agent-presence` forwards `permission_request`
+ *    and `permission_resolved` events here via `handleStreamEvent`.
+ *  - UI components read `permissionTray.pending` and call `approve`/`deny`
+ *    to act on a request.
+ */
+
+import type { PermissionRequest } from './api';
+import { listPermissionRequests, resolvePermissionRequest } from './api';
+
+interface TrayState {
+  pending: PermissionRequest[];
+  loading: boolean;
+  error: string | null;
+}
+
+export const permissionTray = $state<TrayState>({
+  pending: [],
+  loading: false,
+  error: null,
+});
+
+export async function loadPending(): Promise<void> {
+  permissionTray.loading = true;
+  try {
+    const rows = await listPermissionRequests({ status: 'pending', limit: 50 });
+    permissionTray.pending = rows;
+    permissionTray.error = null;
+  } catch (e: any) {
+    permissionTray.error = e?.message ?? 'failed to load permissions';
+  } finally {
+    permissionTray.loading = false;
+  }
+}
+
+function upsertPending(req: PermissionRequest): void {
+  const idx = permissionTray.pending.findIndex(r => r.request_id === req.request_id);
+  if (idx >= 0) {
+    permissionTray.pending[idx] = req;
+  } else {
+    // Newest at the bottom — operator works through the queue top-down.
+    permissionTray.pending.push(req);
+  }
+}
+
+function removePending(requestId: string): void {
+  const idx = permissionTray.pending.findIndex(r => r.request_id === requestId);
+  if (idx >= 0) permissionTray.pending.splice(idx, 1);
+}
+
+/** Process a single SSE event. Called by agent-presence for every tick. */
+export function handleStreamEvent(event: Record<string, unknown>): void {
+  const type = event.type as string | undefined;
+  if (type === 'permission_request') {
+    const data = (event.data ?? event) as Partial<PermissionRequest>;
+    if (data.request_id) {
+      // Synthesize a minimal PermissionRequest row from the event payload.
+      const row: PermissionRequest = {
+        id: 0,
+        request_id: String(data.request_id),
+        run_id: String(data.run_id ?? ''),
+        agent_id: String(data.agent_id ?? ''),
+        tool_name: String(data.tool_name ?? ''),
+        tool_input: (data.tool_input as Record<string, unknown>) ?? {},
+        autonomy_level: String(data.autonomy_level ?? 'assisted'),
+        reason: (data.reason ?? null) as string | null,
+        status: 'pending',
+        resolution_note: null,
+        created_at: null,
+        resolved_at: null,
+      };
+      upsertPending(row);
+    }
+    return;
+  }
+  if (type === 'permission_resolved') {
+    const data = (event.data ?? event) as { request_id?: string };
+    if (data.request_id) removePending(String(data.request_id));
+    return;
+  }
+}
+
+export async function approve(requestId: string, note?: string): Promise<void> {
+  await resolvePermissionRequest(requestId, 'approve', note);
+  removePending(requestId);
+}
+
+export async function deny(requestId: string, note?: string): Promise<void> {
+  await resolvePermissionRequest(requestId, 'deny', note);
+  removePending(requestId);
+}
+
+export function pendingCount(): number {
+  return permissionTray.pending.length;
+}


### PR DESCRIPTION
## Summary
The operator-in-the-loop escape hatch for ADR-0001 manual / assisted runs. A destructive call the policy engine wants to refer to the human now lands in a \`permission_requests\` row; the dashboard surfaces a floating bottom-right tray; the operator approves or denies; the decision flips the row AND publishes an SSE event so the agent unblocks.

## Backend (\`/api/permissions\`)
- New \`PermissionRequest\` model — unique \`request_id\`, status lifecycle \`pending → approved | denied | timed_out\`, JSON \`tool_input\`, \`reason\`, \`resolution_note\`, \`resolved_at\`. No migration step — \`Base.metadata.create_all\` creates it on next boot.
- **GET \`/api/permissions\`** — list pending (or \`?status=all|approved|denied\`), optional \`run_id\` filter.
- **GET \`/api/permissions/{request_id}\`** — single row; 404 if missing.
- **POST \`/api/permissions/{request_id}\`** — body \`{ decision: 'approve'|'deny', note?: string }\`. 422 on bad decision, 409 on terminal (no retroactive flips).
- Every read runs a sweep that flips rows older than \`STATION_PERMISSION_TRAY_TIMEOUT_SECONDS\` (default 300s, floor 30s) to \`timed_out\` and emits a resolution SSE.
- Helper \`create_permission_request(...)\` for the agent side — inserts the row AND publishes a \`permission_request\` SSE.

## Frontend
- \`event-stream.ts\` registers \`permission_request\` + \`permission_resolved\` as well-known SSE types.
- \`permission-tray.svelte.ts\` — pending-array store, \`loadPending()\` hydrator, \`approve\` / \`deny\` helpers, and an SSE event handler that upserts/removes rows in place.
- \`agent-presence.svelte.ts\` forwards every SSE event through the tray store — single connection.
- \`components/layout/PermissionTray.svelte\` — floating bottom-right card, auto-expands on arrival, shows tool name + autonomy badge + input summary + reason. Approve/deny buttons disable while resolving. Renders nothing when empty.
- \`api.ts\` exposes \`listPermissionRequests\` + \`resolvePermissionRequest\` + the \`PermissionRequest\` TypeScript shape.
- Mounted at the bottom of \`App.svelte\` via the \`portal\` action to escape the shell's stacking context.

## Depends on
Standalone this PR — does not depend on any other open PR.

## What this does NOT do (yet)
Wire \`agent/auto_mode.py\` to actually call \`create_permission_request\` on destructive bash / edits at manual / assisted. Today the policy engine still deny-returns those calls. Switching it to a referral write is a follow-up — the infra lands here first so we can flip it behind a single flag.

## Test plan
- [x] \`pytest dashboard/backend/tests/test_permissions.py -q\` → **14 passed in 6.10s**
  - list empty / filter by status / filter by run_id
  - get single / 404
  - approve / deny transitions / resolve twice → 409 / missing → 404 / bad decision → 422
  - stale pending auto-times-out / resolve after timeout → 409
  - agent-side helper round-trip
- [x] Full backend suite: **568 passed, 53 skipped**
- [x] \`npm run build\` clean (only pre-existing a11y warnings on unrelated files)
- [ ] Manual post-merge: POST a pending row via Python, see it appear in the tray, approve it → row flips and tray clears.

Part of the Auto Mode rollout plan at \`/root/.claude/plans/fluttering-meandering-clarke.md\`.