### PR TITLE
feat(agent): wire policy engine to live permission tray [deferred P2]

### DIFF
--- a/agent/audit_hook.py
+++ b/agent/audit_hook.py
@@ -137,7 +137,10 @@ def make_audited_policy(
         tool_input: dict[str, Any],
         ctx: ToolPermissionContext | None,
     ) -> PermissionResultAllow | PermissionResultDeny:
-        decision = await policy_decide(tool_name, tool_input, ctx, level)
+        decision = await policy_decide(
+            tool_name, tool_input, ctx, level,
+            run_id=run_id, agent_id=agent_id,
+        )
         write_decision_event(
             run_id=run_id,
             agent_id=agent_id,

--- a/agent/auto_mode.py
+++ b/agent/auto_mode.py
@@ -102,6 +102,9 @@ async def policy_decide(
     tool_input: dict[str, Any],
     ctx: ToolPermissionContext | None,
     level: AutonomyLevel,
+    *,
+    run_id: str | None = None,
+    agent_id: str = "lead",
 ) -> PermissionResult:
     """Decide whether `tool_name(tool_input)` is allowed at `level`.
 
@@ -117,12 +120,16 @@ async def policy_decide(
         call-site change.
     level
         The autonomy level for the calling run.
+    run_id, agent_id
+        Used when ``STATION_TRAY_REFERRAL=1`` to tag a tray referral row.
+        Without these, referral falls back to deny-return.
     """
     del ctx  # Reserved for future per-call context checks.
 
     as_text = _input_to_text(tool_input)
 
     # 1. Always-deny list — catches push-to-main etc. regardless of level.
+    #    These are never referred; the agent must never do them.
     for pattern, reason in ALWAYS_DENY:
         if pattern.search(as_text):
             return PermissionResultDeny(
@@ -138,11 +145,16 @@ async def policy_decide(
     if tool_name in SUBAGENT_TOOLS:
         return PermissionResultAllow()
 
-    # 4. Edit tools — manual defers, assisted+ allows.
+    # 4. Edit tools — manual refers / defers, assisted+ allows.
     if tool_name in EDIT_TOOLS:
         if level is AutonomyLevel.MANUAL:
-            return PermissionResultDeny(
-                message="edits require human approval at manual level",
+            return await _defer_or_deny(
+                level=level,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                run_id=run_id,
+                agent_id=agent_id,
+                reason="edits require human approval at manual level",
             )
         return PermissionResultAllow()
 
@@ -157,14 +169,14 @@ async def policy_decide(
         if is_destructive:
             if level is AutonomyLevel.AUTO:
                 return PermissionResultAllow()
-            # Manual/assisted: defer via a deny. The Phase 2 permission tray
-            # will convert this into a tray prompt. Until then, deny is the
-            # safe default.
             snippet = cmd[:80].replace("\n", " ")
-            return PermissionResultDeny(
-                message=(
-                    f"destructive bash denied at {level.value}: {snippet}"
-                ),
+            return await _defer_or_deny(
+                level=level,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                run_id=run_id,
+                agent_id=agent_id,
+                reason=f"destructive bash at {level.value}: {snippet}",
             )
         return PermissionResultAllow()
 
@@ -172,3 +184,35 @@ async def policy_decide(
     return PermissionResultDeny(
         message=f"unknown tool {tool_name!r}; denied by default policy",
     )
+
+
+async def _defer_or_deny(
+    *,
+    level: AutonomyLevel,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    run_id: str | None,
+    agent_id: str,
+    reason: str,
+) -> PermissionResult:
+    """Route a policy-deferred call either to the tray (if enabled + run_id
+    available) or to a straight deny. Import is lazy so tests can exercise
+    the policy matrix without importing the urllib-touching referral module.
+    """
+    if run_id:
+        try:
+            from agent.tray_referral import referral_enabled, refer_to_operator
+        except Exception:
+            referral_enabled = lambda: False  # noqa: E731
+            refer_to_operator = None  # type: ignore[assignment]
+
+        if referral_enabled() and refer_to_operator is not None:
+            return await refer_to_operator(
+                run_id=run_id,
+                agent_id=agent_id,
+                level=level,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                reason=reason,
+            )
+    return PermissionResultDeny(message=reason)

--- a/agent/tray_referral.py
+++ b/agent/tray_referral.py
@@ -1,0 +1,235 @@
+"""Tray referral helper — ADR-0001 (deferred Phase 2 wiring).
+
+When ``STATION_TRAY_REFERRAL=1`` is set, destructive bash calls at manual /
+assisted and edits at manual are referred to the operator instead of being
+deny-returned. We POST to ``/api/permissions`` (which inserts a row and fires
+the ``permission_request`` SSE) and then poll sqlite for the row's status.
+
+Returns ``PermissionResultAllow`` on approve; ``PermissionResultDeny`` on
+deny, timeout, or any error — deny is always the safe fallback.
+
+Design notes:
+- The backend does timeout sweeping on read; we also enforce a local wall
+  clock so a disconnected backend can't hang the agent forever.
+- sqlite polling is cheaper than HTTP polling and avoids the auth dance.
+- Never raises — the SDK expects a PermissionResult.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import time
+import urllib.error
+import urllib.request
+import uuid
+from typing import Any
+
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+
+from agent.audit_hook import _db_path
+from agent.auto_mode import AutonomyLevel
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BACKEND_URL = "http://127.0.0.1:8420"
+DEFAULT_TIMEOUT_SECONDS = 300  # matches backend STATION_PERMISSION_TRAY_TIMEOUT_SECONDS default
+POLL_INTERVAL_SECONDS = 1.0
+REFERRAL_EVENT_TYPE = "auto_mode_referral"
+
+
+def referral_enabled() -> bool:
+    """Gate for the tray-referral path. Default OFF for safe rollout."""
+    raw = os.environ.get("STATION_TRAY_REFERRAL", "0").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _backend_url() -> str:
+    return os.environ.get("STATION_BACKEND_URL", DEFAULT_BACKEND_URL).rstrip("/")
+
+
+def _timeout_seconds() -> int:
+    raw = os.environ.get("STATION_PERMISSION_TRAY_TIMEOUT_SECONDS", str(DEFAULT_TIMEOUT_SECONDS))
+    try:
+        return max(30, int(raw))
+    except ValueError:
+        return DEFAULT_TIMEOUT_SECONDS
+
+
+def _auth_headers() -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    key = os.environ.get("STATION_API_KEY", "").strip()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    return headers
+
+
+def _post_request(payload: dict[str, Any]) -> bool:
+    """POST /api/permissions — returns True on 2xx, False otherwise."""
+    url = f"{_backend_url()}/api/permissions"
+    body = json.dumps(payload).encode()
+    req = urllib.request.Request(url, data=body, headers=_auth_headers(), method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return 200 <= resp.status < 300
+    except urllib.error.HTTPError as exc:
+        # 201 Created raises as HTTPError in some stdlib paths; treat 2xx as OK.
+        if 200 <= exc.code < 300:
+            return True
+        logger.warning("tray_referral: POST failed http=%s body=%s", exc.code, exc.read()[:200])
+        return False
+    except Exception as exc:
+        logger.warning("tray_referral: POST failed: %s", exc)
+        return False
+
+
+def _read_status(request_id: str, db_path: str | None = None) -> tuple[str | None, str | None]:
+    """Return (status, resolution_note) for the row, or (None, None) if missing."""
+    path = db_path or _db_path()
+    try:
+        conn = sqlite3.connect(path, timeout=5.0)
+        try:
+            cur = conn.execute(
+                "SELECT status, resolution_note FROM permission_requests WHERE request_id = ?",
+                (request_id,),
+            )
+            row = cur.fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        logger.warning("tray_referral: status read failed: %s", exc)
+        return None, None
+    if not row:
+        return None, None
+    return row[0], row[1]
+
+
+def _write_referral_audit(
+    *,
+    run_id: str,
+    agent_id: str,
+    level: AutonomyLevel,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    request_id: str,
+    final_status: str,
+    reason: str | None,
+    db_path: str | None = None,
+) -> None:
+    """One row per referral, event_type='auto_mode_referral'. Never raises."""
+    path = db_path or _db_path()
+    payload = {
+        "level": level.value,
+        "tool_name": tool_name,
+        "tool_input": _summarise_input(tool_input),
+        "request_id": request_id,
+        "final_status": final_status,
+        "reason": reason,
+    }
+    try:
+        conn = sqlite3.connect(path, timeout=5.0)
+        try:
+            conn.execute(
+                """
+                INSERT INTO agent_events
+                    (workflow_id, run_id, agent_id, event_type, team_name, event_data, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+                """,
+                (
+                    run_id,
+                    run_id,
+                    agent_id,
+                    REFERRAL_EVENT_TYPE,
+                    None,
+                    json.dumps(payload, default=str),
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        logger.warning("tray_referral: audit write failed: %s", exc)
+
+
+def _summarise_input(tool_input: dict[str, Any], limit: int = 500) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for key, value in tool_input.items():
+        if isinstance(value, str) and len(value) > limit:
+            out[key] = value[:limit] + f"…[+{len(value) - limit} chars]"
+        else:
+            out[key] = value
+    return out
+
+
+async def refer_to_operator(
+    *,
+    run_id: str,
+    agent_id: str,
+    level: AutonomyLevel,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    reason: str,
+    db_path: str | None = None,
+    timeout_seconds: int | None = None,
+    poll_interval_seconds: float = POLL_INTERVAL_SECONDS,
+) -> PermissionResultAllow | PermissionResultDeny:
+    """Raise a tray request and block until resolved.
+
+    Safe fallback: any failure to post or poll returns a deny so the agent
+    never silently proceeds on an unreachable backend.
+    """
+    request_id = f"tray-{uuid.uuid4().hex[:16]}"
+
+    posted = _post_request({
+        "request_id": request_id,
+        "run_id": run_id,
+        "agent_id": agent_id,
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+        "autonomy_level": level.value,
+        "reason": reason,
+    })
+    if not posted:
+        _write_referral_audit(
+            run_id=run_id, agent_id=agent_id, level=level,
+            tool_name=tool_name, tool_input=tool_input,
+            request_id=request_id, final_status="post_failed", reason=reason,
+            db_path=db_path,
+        )
+        return PermissionResultDeny(
+            message=f"tray referral unreachable; defaulting to deny at {level.value}",
+        )
+
+    deadline = time.monotonic() + (timeout_seconds or _timeout_seconds())
+    final_status: str = "timed_out"
+    note: str | None = None
+    while time.monotonic() < deadline:
+        status, resolution_note = _read_status(request_id, db_path=db_path)
+        if status and status != "pending":
+            final_status = status
+            note = resolution_note
+            break
+        # Yield to the loop so operator updates can flow in.
+        await asyncio.sleep(poll_interval_seconds)
+
+    _write_referral_audit(
+        run_id=run_id, agent_id=agent_id, level=level,
+        tool_name=tool_name, tool_input=tool_input,
+        request_id=request_id, final_status=final_status, reason=reason,
+        db_path=db_path,
+    )
+
+    if final_status == "approved":
+        return PermissionResultAllow()
+    if final_status == "denied":
+        return PermissionResultDeny(
+            message=f"operator denied tray request {request_id}"
+            + (f": {note}" if note else ""),
+        )
+    # timed_out, unknown, etc.
+    return PermissionResultDeny(
+        message=f"tray request {request_id} final_status={final_status}",
+    )

--- a/dashboard/backend/app/routers/permissions.py
+++ b/dashboard/backend/app/routers/permissions.py
@@ -28,7 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_db
 from app.models import PermissionRequest
-from app.schemas import PermissionDecisionIn, PermissionRequestOut
+from app.schemas import PermissionCreateIn, PermissionDecisionIn, PermissionRequestOut
 from app.services import event_bus
 
 logger = logging.getLogger(__name__)
@@ -74,6 +74,33 @@ async def _timeout_expired_rows(db: AsyncSession) -> list[PermissionRequest]:
             },
         })
     return expired
+
+
+@router.post("", response_model=PermissionRequestOut, status_code=201)
+async def create_permission_request_endpoint(
+    payload: PermissionCreateIn,
+    db: AsyncSession = Depends(get_db),
+):
+    """Agent-facing: raise a new tray request. Idempotent on request_id — a
+    second POST with an existing id returns the current row so the agent can
+    safely retry after a transient network blip."""
+    existing = await db.execute(
+        select(PermissionRequest).where(PermissionRequest.request_id == payload.request_id)
+    )
+    row = existing.scalar_one_or_none()
+    if row is not None:
+        return row
+
+    return await create_permission_request(
+        db,
+        request_id=payload.request_id,
+        run_id=payload.run_id,
+        agent_id=payload.agent_id,
+        tool_name=payload.tool_name,
+        tool_input=payload.tool_input,
+        autonomy_level=payload.autonomy_level,
+        reason=payload.reason,
+    )
 
 
 @router.get("", response_model=list[PermissionRequestOut])

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -663,3 +663,27 @@ class PermissionDecisionIn(BaseModel):
         if v not in ("approve", "deny"):
             raise ValueError("decision must be 'approve' or 'deny'")
         return v
+
+
+class PermissionCreateIn(BaseModel):
+    """Agent-side payload to raise a new permission request.
+
+    Used by the policy engine when it would otherwise deny-return at
+    manual/assisted — writes a row + emits the SSE event so the tray
+    can pop in real time.
+    """
+    request_id: str
+    run_id: str
+    agent_id: str
+    tool_name: str
+    tool_input: dict[str, Any]
+    autonomy_level: str
+    reason: str | None = None
+
+    @field_validator("autonomy_level")
+    @classmethod
+    def _validate_level(cls, v: str) -> str:
+        v = (v or "").strip().lower()
+        if v not in ("manual", "assisted", "auto"):
+            raise ValueError("autonomy_level must be manual/assisted/auto")
+        return v

--- a/dashboard/backend/tests/test_tray_referral.py
+++ b/dashboard/backend/tests/test_tray_referral.py
@@ -1,0 +1,349 @@
+"""Unit tests for the tray-referral helper — ADR-0001 (deferred Phase 2).
+
+Covers:
+- When STATION_TRAY_REFERRAL is off, destructive calls deny-return as before.
+- When on, a referral row is posted and polled; approve → allow, deny → deny,
+  timeout → deny.
+- ALWAYS_DENY patterns never reach the tray (no row posted).
+- Post failure → deny fallback (agent never silently proceeds).
+- Audit row written for every referral outcome.
+- `auto` level bypasses the referral path entirely for destructive bash.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent.auto_mode import AutonomyLevel, policy_decide
+from agent.tray_referral import refer_to_operator, referral_enabled
+from claude_agent_sdk.types import PermissionResultAllow, PermissionResultDeny
+
+
+def _init_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        """
+        CREATE TABLE agent_events (
+            event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+            workflow_id TEXT NOT NULL,
+            run_id TEXT,
+            agent_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            team_name TEXT,
+            event_data TEXT NOT NULL,
+            parent_event_id INTEGER,
+            created_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE permission_requests (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            request_id TEXT NOT NULL UNIQUE,
+            run_id TEXT NOT NULL,
+            agent_id TEXT NOT NULL,
+            tool_name TEXT NOT NULL,
+            tool_input TEXT NOT NULL,
+            autonomy_level TEXT NOT NULL,
+            reason TEXT,
+            status TEXT NOT NULL DEFAULT 'pending',
+            resolution_note TEXT,
+            created_at TEXT,
+            resolved_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _set_row_status(path: Path, request_id: str, status: str, note: str | None = None) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "UPDATE permission_requests SET status = ?, resolution_note = ? WHERE request_id = ?",
+        (status, note, request_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _fetch_audit(path: Path) -> list[dict[str, Any]]:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    rows = [dict(r) for r in conn.execute("SELECT * FROM agent_events ORDER BY event_id")]
+    conn.close()
+    return rows
+
+
+def _fetch_tray(path: Path) -> list[dict[str, Any]]:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    rows = [dict(r) for r in conn.execute("SELECT * FROM permission_requests")]
+    conn.close()
+    return rows
+
+
+# --- Flag gating -----------------------------------------------------------
+
+
+def test_referral_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("STATION_TRAY_REFERRAL", raising=False)
+    assert referral_enabled() is False
+
+
+@pytest.mark.parametrize("v", ["1", "true", "TRUE", "yes", "on"])
+def test_referral_enabled_flag_accepts_common_truthy(monkeypatch, v):
+    monkeypatch.setenv("STATION_TRAY_REFERRAL", v)
+    assert referral_enabled() is True
+
+
+@pytest.mark.parametrize("v", ["0", "false", "", "no", "off"])
+def test_referral_disabled_flag_values(monkeypatch, v):
+    monkeypatch.setenv("STATION_TRAY_REFERRAL", v)
+    assert referral_enabled() is False
+
+
+# --- Integration via policy_decide (flag OFF) ------------------------------
+
+
+async def test_destructive_bash_denies_when_flag_off(monkeypatch):
+    """Legacy behaviour: flag off → deny-return identical to pre-wiring."""
+    monkeypatch.delenv("STATION_TRAY_REFERRAL", raising=False)
+    result = await policy_decide(
+        "Bash",
+        {"command": "rm -rf node_modules"},
+        None,
+        AutonomyLevel.ASSISTED,
+        run_id="run-001",
+    )
+    assert isinstance(result, PermissionResultDeny)
+    assert "destructive bash at assisted" in result.message
+
+
+async def test_edit_denies_at_manual_when_flag_off(monkeypatch):
+    monkeypatch.delenv("STATION_TRAY_REFERRAL", raising=False)
+    result = await policy_decide(
+        "Edit", {"file_path": "/tmp/x"}, None, AutonomyLevel.MANUAL, run_id="run-001",
+    )
+    assert isinstance(result, PermissionResultDeny)
+
+
+async def test_always_deny_still_wins_even_with_flag_on(monkeypatch, tmp_path):
+    """ALWAYS_DENY never gets referred — push-to-main etc. stays deny-return."""
+    monkeypatch.setenv("STATION_TRAY_REFERRAL", "1")
+    db = tmp_path / "test.db"
+    _init_db(db)
+    monkeypatch.setenv("STATION_DB_PATH", str(db))
+
+    result = await policy_decide(
+        "Bash",
+        {"command": "git push --force origin main"},
+        None,
+        AutonomyLevel.ASSISTED,
+        run_id="run-001",
+    )
+    assert isinstance(result, PermissionResultDeny)
+    assert "always-deny" in result.message
+    assert _fetch_tray(db) == []  # no row posted
+
+
+async def test_auto_level_bypasses_referral_for_destructive_bash(monkeypatch, tmp_path):
+    monkeypatch.setenv("STATION_TRAY_REFERRAL", "1")
+    db = tmp_path / "test.db"
+    _init_db(db)
+    monkeypatch.setenv("STATION_DB_PATH", str(db))
+
+    result = await policy_decide(
+        "Bash",
+        {"command": "rm -rf stale-build"},
+        None,
+        AutonomyLevel.AUTO,
+        run_id="run-001",
+    )
+    assert isinstance(result, PermissionResultAllow)
+    assert _fetch_tray(db) == []
+
+
+# --- refer_to_operator (direct) -------------------------------------------
+
+
+def _stub_post_ok(monkeypatch, tmp_path: Path):
+    """Patch _post_request to insert the row directly into sqlite, emulating
+    what the backend's POST /api/permissions would do, without the HTTP hop."""
+    db = tmp_path / "test.db"
+    _init_db(db)
+    monkeypatch.setenv("STATION_DB_PATH", str(db))
+
+    def _fake_post(payload: dict) -> bool:
+        import json as _json
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            """INSERT INTO permission_requests
+               (request_id, run_id, agent_id, tool_name, tool_input,
+                autonomy_level, reason, status)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')""",
+            (
+                payload["request_id"], payload["run_id"], payload["agent_id"],
+                payload["tool_name"], _json.dumps(payload["tool_input"]),
+                payload["autonomy_level"], payload.get("reason"),
+            ),
+        )
+        conn.commit()
+        conn.close()
+        return True
+
+    monkeypatch.setattr("agent.tray_referral._post_request", _fake_post)
+    return db
+
+
+async def test_approve_resolution_returns_allow(monkeypatch, tmp_path):
+    db = _stub_post_ok(monkeypatch, tmp_path)
+
+    # Resolve the request BEFORE calling refer_to_operator — the first poll
+    # will see the approved row and return immediately.
+    import uuid as _uuid
+    orig_uuid4 = _uuid.uuid4
+    captured: list[str] = []
+    def _fake_uuid4():
+        val = orig_uuid4()
+        captured.append(val.hex[:16])
+        return val
+    monkeypatch.setattr("uuid.uuid4", _fake_uuid4)
+
+    import asyncio
+    async def _run():
+        # Start referral; preapprove in a side task.
+        task = asyncio.create_task(refer_to_operator(
+            run_id="run-001", agent_id="lead", level=AutonomyLevel.ASSISTED,
+            tool_name="Bash", tool_input={"command": "rm -rf build"},
+            reason="destructive",
+            poll_interval_seconds=0.05, timeout_seconds=5,
+        ))
+        # Wait a beat, then flip the row.
+        await asyncio.sleep(0.1)
+        request_id = f"tray-{captured[0]}"
+        _set_row_status(db, request_id, "approved", note="operator sign-off")
+        return await task
+
+    result = await _run()
+    assert isinstance(result, PermissionResultAllow)
+    audit = _fetch_audit(db)
+    assert len(audit) == 1
+    assert audit[0]["event_type"] == "auto_mode_referral"
+    assert '"final_status": "approved"' in audit[0]["event_data"]
+
+
+async def test_deny_resolution_returns_deny(monkeypatch, tmp_path):
+    db = _stub_post_ok(monkeypatch, tmp_path)
+
+    captured: list[str] = []
+    import uuid as _uuid
+    orig = _uuid.uuid4
+    def _fake():
+        val = orig()
+        captured.append(val.hex[:16])
+        return val
+    monkeypatch.setattr("uuid.uuid4", _fake)
+
+    import asyncio
+    async def _run():
+        task = asyncio.create_task(refer_to_operator(
+            run_id="run-002", agent_id="lead", level=AutonomyLevel.MANUAL,
+            tool_name="Edit", tool_input={"file_path": "/tmp/x"},
+            reason="edit at manual",
+            poll_interval_seconds=0.05, timeout_seconds=5,
+        ))
+        await asyncio.sleep(0.1)
+        _set_row_status(db, f"tray-{captured[0]}", "denied", note="nope")
+        return await task
+
+    result = await _run()
+    assert isinstance(result, PermissionResultDeny)
+    assert "operator denied" in result.message
+    assert "nope" in result.message
+
+
+async def test_timeout_resolution_returns_deny(monkeypatch, tmp_path):
+    _stub_post_ok(monkeypatch, tmp_path)
+
+    result = await refer_to_operator(
+        run_id="run-003", agent_id="lead", level=AutonomyLevel.ASSISTED,
+        tool_name="Bash", tool_input={"command": "rm -rf out"},
+        reason="destructive",
+        poll_interval_seconds=0.05, timeout_seconds=1,  # short
+    )
+    assert isinstance(result, PermissionResultDeny)
+    assert "timed_out" in result.message
+
+
+async def test_post_failure_denies_and_audits(monkeypatch, tmp_path):
+    db = tmp_path / "test.db"
+    _init_db(db)
+    monkeypatch.setenv("STATION_DB_PATH", str(db))
+    monkeypatch.setattr("agent.tray_referral._post_request", lambda payload: False)
+
+    result = await refer_to_operator(
+        run_id="run-004", agent_id="lead", level=AutonomyLevel.ASSISTED,
+        tool_name="Bash", tool_input={"command": "rm -rf /tmp/x"},
+        reason="destructive", poll_interval_seconds=0.05, timeout_seconds=1,
+    )
+    assert isinstance(result, PermissionResultDeny)
+    assert "unreachable" in result.message
+    audit = _fetch_audit(db)
+    assert len(audit) == 1
+    assert '"final_status": "post_failed"' in audit[0]["event_data"]
+
+
+# --- policy_decide routing (flag ON) --------------------------------------
+
+
+async def test_destructive_bash_routes_to_tray_when_flag_on(monkeypatch, tmp_path):
+    db = _stub_post_ok(monkeypatch, tmp_path)
+    monkeypatch.setenv("STATION_TRAY_REFERRAL", "1")
+
+    captured: list[str] = []
+    import uuid as _uuid
+    orig = _uuid.uuid4
+    def _fake():
+        val = orig()
+        captured.append(val.hex[:16])
+        return val
+    monkeypatch.setattr("uuid.uuid4", _fake)
+
+    import asyncio
+    async def _run():
+        task = asyncio.create_task(policy_decide(
+            "Bash", {"command": "git reset --hard HEAD~1"}, None,
+            AutonomyLevel.ASSISTED,
+            run_id="run-200", agent_id="teammate-issue-worker",
+        ))
+        await asyncio.sleep(0.1)
+        _set_row_status(db, f"tray-{captured[0]}", "approved")
+        return await task
+
+    result = await _run()
+    assert isinstance(result, PermissionResultAllow)
+    tray = _fetch_tray(db)
+    assert len(tray) == 1
+    assert tray[0]["agent_id"] == "teammate-issue-worker"
+    assert tray[0]["autonomy_level"] == "assisted"
+
+
+async def test_no_run_id_skips_referral_even_when_flag_on(monkeypatch, tmp_path):
+    """Without run_id we can't tag the row — fall back to deny so the agent
+    never proceeds on an un-auditable call."""
+    monkeypatch.setenv("STATION_TRAY_REFERRAL", "1")
+    db = tmp_path / "test.db"
+    _init_db(db)
+    monkeypatch.setenv("STATION_DB_PATH", str(db))
+
+    result = await policy_decide(
+        "Bash", {"command": "rm -rf build"}, None, AutonomyLevel.ASSISTED,
+    )
+    assert isinstance(result, PermissionResultDeny)
+    assert _fetch_tray(db) == []

--- a/docs/adr/0001-autonomy-levels.md
+++ b/docs/adr/0001-autonomy-levels.md
@@ -39,7 +39,7 @@ Introduce three autonomy levels — `manual`, `assisted`, `auto` — persisted p
 | Always-deny — critical       | `git push … main`, `git push --force`, `rm -rf /`, `DROP TABLE/DATABASE`, service stop/restart, secret echo | Deny | Deny | Deny |
 | Unknown tool                 | Anything not in the table above         | Deny      | Deny       | Deny   |
 
-"Defer" means the policy engine returns an `await-tray` decision: the agent pauses, a row is inserted into `permission_requests`, and the SSE bus notifies the dashboard tray (built in Phase 2). Default timeout: 5 minutes → auto-deny.
+"Defer" means the policy engine refers the call to the operator: a row is inserted into `permission_requests` (via `POST /api/permissions` in the backend), the SSE bus publishes `permission_request`, the dashboard tray surfaces the prompt, and the agent blocks on polling `permission_requests.status` until the row leaves `pending`. Default timeout: 5 minutes → auto-deny. The defer path is gated by `STATION_TRAY_REFERRAL=1`; when off, deferred calls deny-return (the Phase 1 posture). `ALWAYS_DENY` is never deferred — those calls always deny-return regardless of the flag.
 
 ### Human gates (always manual, regardless of level)
 


### PR DESCRIPTION
## Summary
- Closes the deferred Phase 2 item: the policy engine now creates real `permission_requests` rows instead of deny-returning, and the agent blocks until the operator resolves.
- Gated by `STATION_TRAY_REFERRAL=1` — default OFF so this merges safely; flip the flag to activate.
- `ALWAYS_DENY` never refers. `auto` bypasses referral for destructive bash. Post/backend failure → safe deny fallback.

## How it works
1. `policy_decide` at manual/assisted hits the referral path via a new `_defer_or_deny` helper.
2. `agent/tray_referral.py` POSTs `/api/permissions` (backend inserts the row + publishes `permission_request` SSE).
3. Agent polls sqlite every second until `status != 'pending'`, deadline = `STATION_PERMISSION_TRAY_TIMEOUT_SECONDS` (default 300s).
4. Approve → `PermissionResultAllow`; deny/timeout/error → `PermissionResultDeny`.
5. Every referral writes one `auto_mode_referral` audit row; the outer `make_audited_policy` still writes its `auto_mode_decision` row with the final outcome, so P3.T8 will have both breadcrumbs.

## Why the flag
Merging the wiring without the flag would be a user-visible behaviour change on the first run after merge (deny-return → operator-gated block). Shipping it OFF lets us:
- Confirm the tray UI path end-to-end against a real orchestrator run before flipping.
- Roll back by unsetting one env var — no code revert needed.

## Test plan
- [x] `test_tray_referral.py` — 21 tests green (flag gating, approve/deny/timeout, ALWAYS_DENY never refers, auto bypasses, post failure denies with audit, no run_id falls back to deny).
- [x] `test_auto_mode.py` — 85 tests still green (signature change kept backward-compatible via keyword defaults).
- [x] `test_audit_hook.py` + `test_permissions.py` green.
- [x] Full suite: 593 passed, 53 skipped locally.
- [ ] Post-merge: restart dashboard, set `STATION_TRAY_REFERRAL=1` in the systemd unit, trigger a run that touches `git reset --hard`, confirm tray pops and approve resumes the agent.

## Rollback
`git revert <merge-sha>` is clean. Or leave merged, unset `STATION_TRAY_REFERRAL` — policy reverts to deny-return identical to pre-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)