### PR TITLE
fix(ui): P3 polish bundle [P3.T1,T2,T5,T6,T7]

### DIFF
--- a/dashboard/frontend/e2e/pages.spec.ts
+++ b/dashboard/frontend/e2e/pages.spec.ts
@@ -7,9 +7,9 @@ test('Dashboard page loads', async ({ page }) => {
   await page.screenshot({ path: 'screenshots/01-dashboard.png', fullPage: true });
 });
 
-test('Agents page loads (idle or active)', async ({ page }) => {
-  await page.goto('/agents');
-  // /agents redirects to /agent-teams. Accept either state:
+test('Agent Teams page loads (idle or active)', async ({ page }) => {
+  await page.goto('/agent-teams');
+  // Accept either state:
   //   - idle: "The Team is Off-Duty" heading
   //   - active: Team Lead card rendered
   const idleHeading = page.getByRole('heading', { name: /off-duty/i });

--- a/dashboard/frontend/src/components/layout/TopNav.svelte
+++ b/dashboard/frontend/src/components/layout/TopNav.svelte
@@ -81,11 +81,17 @@
     <button
       onclick={onTrigger}
       disabled={triggering}
+      class="trigger-btn"
       style="padding: 10px 22px; border: none; border-radius: 12px; font-size: 14px; font-weight: 700; font-family: inherit; cursor: pointer; background: linear-gradient(135deg, #4A3728 0%, #5C4435 100%); color: #FFF5EE; box-shadow: 0 2px 8px rgba(74,55,40,0.18); transition: transform 0.15s, box-shadow 0.2s; opacity: {triggering ? '0.7' : '1'};"
-      onmouseenter={(e) => { if (!triggering) { e.currentTarget.style.transform = 'scale(1.04)'; e.currentTarget.style.boxShadow = '0 4px 20px rgba(74,55,40,0.25)'; }}}
-      onmouseleave={(e) => { e.currentTarget.style.transform = 'scale(1)'; e.currentTarget.style.boxShadow = '0 2px 8px rgba(74,55,40,0.18)'; }}
     >
       {triggering ? '⏳ Triggering...' : '▶ Trigger Run'}
     </button>
   </div>
 </nav>
+
+<style>
+  .trigger-btn:not(:disabled):hover {
+    transform: scale(1.04);
+    box-shadow: 0 4px 20px rgba(74, 55, 40, 0.25);
+  }
+</style>

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -46,21 +46,25 @@ export interface ConversationEntry {
 
 import { themeStore } from './theme.svelte';
 
+// Mirrors theme.svelte.ts ROLE_COLORS so the first paint uses the same palette
+// as subsequent renders — prevents a cold-load colour flash when the theme
+// store is evaluated a few ms after the component mounts.
+const THEME_ROLE_COLORS: Record<string, string> = {
+  manager: '#B06030',
+  'dev-0': '#2E7D32',
+  'dev-1': 'rgba(99,102,180,1)',
+  'dev-2': '#06B6D4',
+  coordinator: '#4A3728',
+  analyst: '#B06030',
+  planner: '#2E7D32',
+  assigner: '#B06030',
+};
+
 function getRoleColors(): Record<string, string> {
   try {
     return themeStore.getRoleColors();
   } catch {
-    // Fallback if theme store isn't initialised yet (SSR, tests, etc.)
-    return {
-      manager: '#f59e0b',
-      'dev-0': '#3b82f6',
-      'dev-1': '#6366f1',
-      'dev-2': '#06b6d4',
-      coordinator: '#a855f7',
-      analyst: '#8b5cf6',
-      planner: '#10b981',
-      assigner: '#f43f5e',
-    };
+    return { ...THEME_ROLE_COLORS };
   }
 }
 
@@ -240,10 +244,6 @@ function handleWsMessage(data: string) {
     : (agentPresence.agents.find(a => a.status === 'active' && a.role !== 'manager')
        ?? agentPresence.agents.find(a => a.status === 'active')
        ?? agentPresence.agents[0]); // fallback to first agent if none active
-  // Debug: log first few messages to understand mapping
-  if (agentPresence.conversationLog.length < 3) {
-    console.log('[AgentPresence] WS msg:', { agents: agentPresence.agents.map(a => a.name), activeAgent: activeAgent?.name, phase: agentPresence.phase, eventTypes: events.map(e => e.type) });
-  }
   const agentName = activeAgent?.name ?? 'Lead';
   const agentColor = activeAgent?.color ?? getRoleColors()['dev-0'];
 

--- a/dashboard/frontend/src/lib/router.svelte.ts
+++ b/dashboard/frontend/src/lib/router.svelte.ts
@@ -18,29 +18,6 @@ export interface Route {
   param: string | null;
 }
 
-/** Map legacy routes to new equivalents.
- *
- * `/theater`, `/team-comms`, `/observatory`, `/workspace` are historic names
- * for the Agent Teams canvas — they are kept here so old bookmarks still
- * resolve, but they no longer appear in the Page enum. */
-const REDIRECTS: Record<string, string> = {
-  '/ops': '/',
-  '/command': '/',
-  '/dashboard': '/',
-  '/pulse': '/',
-  '/stream': '/runs',
-  '/coordinator': '/runs',
-  '/logs': '/runs',
-  '/decide': '/queue',
-  '/config': '/settings',
-  '/prompts': '/settings',
-  '/system': '/settings',
-  '/observatory': '/agent-teams',
-  '/workspace': '/agent-teams',
-  '/theater': '/agent-teams',
-  '/team-comms': '/agent-teams',
-};
-
 function parsePath(): Route {
   let path = window.location.pathname || '/';
 
@@ -59,34 +36,11 @@ function parsePath(): Route {
 
   // Parameterized routes
   if (raw === 'runs' && parts.length > 1) return { page: 'run-detail', param: parts[1] };
-  if (raw === 'stream' && parts.length > 1) {
-    navigate(`/runs/${parts[1]}`, true);
-    return { page: 'run-detail', param: parts[1] };
-  }
   if (raw === 'queue' && parts.length > 1) return { page: 'queue-detail', param: parts[1] };
-  if (raw === 'decide' && parts.length > 1) {
-    navigate(`/queue/${parts[1]}`, true);
-    return { page: 'queue-detail', param: parts[1] };
-  }
   if (raw === 'projects' && parts.length > 1) return { page: 'project-detail', param: parts[1] };
   if (raw === 'settings' && parts.length > 1) return { page: 'settings', param: parts[1] };
 
-  // Redirect old routes (without params)
-  const redirect = REDIRECTS[`/${raw}`];
-  if (redirect) {
-    navigate(redirect, true);
-    const rParts = redirect.split('/').filter(Boolean);
-    if (rParts.length === 0) return { page: 'command-center', param: null };
-    return { page: rParts[0] as Page, param: null };
-  }
-
-  // Standard routes. `theater` / `team-comms` are kept here solely so a bare
-  // URL hit renders the Agent Teams canvas without a redirect flash; the Page
-  // enum no longer contains those names.
   const routeMap: Record<string, Page> = {
-    theater: 'agent-teams',
-    agents: 'agent-teams',
-    'team-comms': 'agent-teams',
     'agent-teams': 'agent-teams',
     runs: 'runs',
     queue: 'queue',


### PR DESCRIPTION
## Summary
- **P3.T1** remove stray `console.log` in agent-presence WS handler
- **P3.T2** drop legacy URL redirects (theater/team-comms/observatory/workspace/ops/command/dashboard/pulse/stream/coordinator/logs/decide/config/prompts/system) + their parametric variants
- **P3.T5** verified — `Modal.svelte` already uses `use:portal` (P0.T1 shipped it); REFACTOR-PLAN line 202 claim is accurate, no-op
- **P3.T6** TopNav trigger button: `onmouseenter`/`onmouseleave` → CSS `:hover`
- **P3.T7** align agent-presence fallback colours with the theme palette so the pre-hydration paint doesn't flash bright tailwind defaults

## Test plan
- [x] `npm run build` clean (174.91 kB bundle)
- [ ] Click through Runs/Queue/Projects/Agent Teams/Settings — all nav resolves
- [ ] Hover Trigger Run button — still scales 1.04 + shadow bumps
- [ ] Cold-load dashboard — presence pills don't flash blue/amber before theme applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)