### PR TITLE
feat(ui): Autonomy Audit subpage + analytics [P3.T8, P3.T9]

### DIFF
--- a/dashboard/backend/app/routers/analytics.py
+++ b/dashboard/backend/app/routers/analytics.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy import and_, case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_db
-from app.models import Project, Run
+from app.models import AgentEvent, Project, Run
 from app.schemas import (
     AnalyticsResponse,
     DailyRunCount,
@@ -17,6 +19,8 @@ from app.schemas import (
     ProjectTokenUsage,
     VerdictDistribution,
 )
+
+AUTONOMY_EVENT_TYPES = ("auto_mode_decision", "auto_mode_referral")
 
 router = APIRouter(prefix="/api/analytics", tags=["analytics"])
 
@@ -170,3 +174,145 @@ async def get_analytics(
         project_token_usage=project_token_usage,
         daily_run_counts=daily_run_counts,
     )
+
+
+# --- Autonomy audit + analytics (P3.T8, P3.T9) -----------------------------
+
+
+def _parse_event_data(raw: str | None) -> dict[str, Any]:
+    if not raw:
+        return {}
+    try:
+        value = json.loads(raw)
+        return value if isinstance(value, dict) else {}
+    except (TypeError, ValueError):
+        return {}
+
+
+def _decision_from_event(event_type: str, data: dict[str, Any]) -> str:
+    """Normalise the decision outcome across both event types.
+
+    `auto_mode_decision` stores 'allow' / 'deny' directly.
+    `auto_mode_referral` stores `final_status` ∈ {approved, denied, timed_out,
+    post_failed}. Approved maps to 'allow'; anything else to 'deny'.
+    """
+    if event_type == "auto_mode_decision":
+        return str(data.get("decision", "unknown"))
+    final = str(data.get("final_status", ""))
+    return "allow" if final == "approved" else "deny"
+
+
+@router.get("/autonomy-audit")
+async def get_autonomy_audit(
+    run_id: str | None = Query(None, description="Filter to one run"),
+    tool_name: str | None = Query(None, description="Filter by tool name"),
+    decision: str | None = Query(None, description="Filter allow/deny"),
+    event_type: str | None = Query(None, description="Filter auto_mode_decision or auto_mode_referral"),
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Raw audit trail of policy-engine decisions.
+
+    Powers the Autonomy Audit subpage. Returns newest-first so operators
+    land on the latest decisions without pagination. The decision field is
+    normalised across `auto_mode_decision` and `auto_mode_referral` rows.
+    """
+    types = [event_type] if event_type in AUTONOMY_EVENT_TYPES else list(AUTONOMY_EVENT_TYPES)
+
+    stmt = select(AgentEvent).where(AgentEvent.event_type.in_(types))
+    if run_id:
+        stmt = stmt.where(AgentEvent.run_id == run_id)
+    stmt = stmt.order_by(AgentEvent.created_at.desc())
+
+    # We post-filter on event_data (JSON) because it's stored as TEXT — SQLite
+    # doesn't have native JSON ops pre-3.45 across all deployments. For
+    # pragmatic scale (audit rows are bounded by runs-per-day), over-fetch a
+    # window and filter in Python; if this ever pressures the DB we'll promote
+    # decision/tool_name to first-class columns.
+    result = await db.execute(stmt.limit(max(limit + offset, 1) * 4))
+    rows = list(result.scalars().all())
+
+    items: list[dict[str, Any]] = []
+    for row in rows:
+        data = _parse_event_data(row.event_data)
+        row_decision = _decision_from_event(row.event_type, data)
+        row_tool = str(data.get("tool_name", ""))
+        if tool_name and row_tool != tool_name:
+            continue
+        if decision and row_decision != decision:
+            continue
+        items.append({
+            "event_id": row.event_id,
+            "event_type": row.event_type,
+            "workflow_id": row.workflow_id,
+            "run_id": row.run_id,
+            "agent_id": row.agent_id,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+            "tool_name": row_tool,
+            "decision": row_decision,
+            "level": data.get("level"),
+            "reason": data.get("reason"),
+            "request_id": data.get("request_id"),
+            "tool_input": data.get("tool_input") or {},
+        })
+
+    total = len(items)
+    return {
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "items": items[offset : offset + limit],
+    }
+
+
+@router.get("/autonomy")
+async def get_autonomy_summary(
+    days: int = Query(30, ge=1, le=365, description="Window in days"),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Aggregated policy-engine decision counts for the donut chart.
+
+    Returns counts by autonomy level, by decision outcome, by tool, plus a
+    `by_level_decision` cross-tab used to drive the donut + legend.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    stmt = (
+        select(AgentEvent)
+        .where(
+            AgentEvent.event_type.in_(AUTONOMY_EVENT_TYPES),
+            AgentEvent.created_at >= cutoff,
+        )
+    )
+    result = await db.execute(stmt)
+    rows = list(result.scalars().all())
+
+    by_level: dict[str, int] = {}
+    by_decision: dict[str, int] = {}
+    by_tool: dict[str, int] = {}
+    by_level_decision: dict[str, dict[str, int]] = {}
+    by_event_type: dict[str, int] = {t: 0 for t in AUTONOMY_EVENT_TYPES}
+
+    for row in rows:
+        data = _parse_event_data(row.event_data)
+        level = str(data.get("level", "unknown"))
+        decision = _decision_from_event(row.event_type, data)
+        tool = str(data.get("tool_name", "unknown"))
+
+        by_level[level] = by_level.get(level, 0) + 1
+        by_decision[decision] = by_decision.get(decision, 0) + 1
+        by_tool[tool] = by_tool.get(tool, 0) + 1
+        by_event_type[row.event_type] = by_event_type.get(row.event_type, 0) + 1
+
+        bucket = by_level_decision.setdefault(level, {})
+        bucket[decision] = bucket.get(decision, 0) + 1
+
+    return {
+        "days": days,
+        "total_decisions": len(rows),
+        "by_level": by_level,
+        "by_decision": by_decision,
+        "by_tool": dict(sorted(by_tool.items(), key=lambda x: x[1], reverse=True)[:10]),
+        "by_level_decision": by_level_decision,
+        "by_event_type": by_event_type,
+    }

--- a/dashboard/backend/tests/test_autonomy_analytics.py
+++ b/dashboard/backend/tests/test_autonomy_analytics.py
@@ -1,0 +1,215 @@
+"""Tests for the autonomy audit + analytics endpoints (P3.T8, P3.T9).
+
+Covers both `auto_mode_decision` and `auto_mode_referral` event shapes,
+filtering by run_id/tool/decision/event_type, and the aggregation shape
+returned by `/api/analytics/autonomy`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import Base, async_session, engine
+from app.main import app
+from app.models import AgentEvent
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _add_event(
+    *,
+    event_type: str,
+    data: dict,
+    run_id: str = "run-1",
+    agent_id: str = "lead",
+    created_at: datetime | None = None,
+) -> None:
+    async with async_session() as session:
+        row = AgentEvent(
+            workflow_id=run_id,
+            run_id=run_id,
+            agent_id=agent_id,
+            event_type=event_type,
+            team_name=None,
+            event_data=json.dumps(data),
+        )
+        if created_at is not None:
+            row.created_at = created_at
+        session.add(row)
+        await session.commit()
+
+
+# --- Audit endpoint --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_audit_empty_ok(client):
+    resp = await client.get("/api/analytics/autonomy-audit")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"total": 0, "limit": 200, "offset": 0, "items": []}
+
+
+@pytest.mark.asyncio
+async def test_audit_surfaces_both_event_types(client, setup_db):
+    await _add_event(
+        event_type="auto_mode_decision",
+        data={"level": "assisted", "tool_name": "Read", "decision": "allow",
+              "tool_input": {"file_path": "/etc/hosts"}, "reason": ""},
+    )
+    await _add_event(
+        event_type="auto_mode_referral",
+        data={"level": "manual", "tool_name": "Bash",
+              "tool_input": {"command": "rm -rf build"},
+              "request_id": "tray-abc", "final_status": "approved",
+              "reason": "destructive"},
+    )
+    resp = await client.get("/api/analytics/autonomy-audit")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert len(items) == 2
+    types = {r["event_type"] for r in items}
+    assert types == {"auto_mode_decision", "auto_mode_referral"}
+    # Normalised decision field — approved → allow
+    referral = next(r for r in items if r["event_type"] == "auto_mode_referral")
+    assert referral["decision"] == "allow"
+    assert referral["request_id"] == "tray-abc"
+
+
+@pytest.mark.asyncio
+async def test_audit_filter_by_run(client, setup_db):
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "assisted", "tool_name": "Read", "decision": "allow"},
+                     run_id="run-A")
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "manual", "tool_name": "Bash", "decision": "deny"},
+                     run_id="run-B")
+    resp = await client.get("/api/analytics/autonomy-audit?run_id=run-B")
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert [r["run_id"] for r in items] == ["run-B"]
+
+
+@pytest.mark.asyncio
+async def test_audit_filter_by_tool_and_decision(client, setup_db):
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "assisted", "tool_name": "Read", "decision": "allow"})
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "manual", "tool_name": "Bash", "decision": "deny"})
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "assisted", "tool_name": "Bash", "decision": "deny"})
+
+    resp = await client.get("/api/analytics/autonomy-audit?tool_name=Bash&decision=deny")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert all(r["tool_name"] == "Bash" and r["decision"] == "deny" for r in body["items"])
+
+
+@pytest.mark.asyncio
+async def test_audit_filter_by_event_type(client, setup_db):
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "assisted", "tool_name": "Read", "decision": "allow"})
+    await _add_event(event_type="auto_mode_referral",
+                     data={"level": "manual", "tool_name": "Bash",
+                           "final_status": "denied"})
+    resp = await client.get("/api/analytics/autonomy-audit?event_type=auto_mode_referral")
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["event_type"] == "auto_mode_referral"
+
+
+@pytest.mark.asyncio
+async def test_audit_ignores_other_event_types(client, setup_db):
+    await _add_event(event_type="task.claimed", data={"irrelevant": True})
+    resp = await client.get("/api/analytics/autonomy-audit")
+    assert resp.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_audit_newest_first(client, setup_db):
+    # Seed in mixed order; server must return newest first.
+    old = datetime.now(timezone.utc) - timedelta(hours=2)
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "assisted", "tool_name": "Read", "decision": "allow"},
+                     created_at=old)
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "manual", "tool_name": "Bash", "decision": "deny"})
+    resp = await client.get("/api/analytics/autonomy-audit")
+    items = resp.json()["items"]
+    assert items[0]["tool_name"] == "Bash"  # newer
+    assert items[1]["tool_name"] == "Read"
+
+
+# --- Summary endpoint ------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_summary_empty(client):
+    resp = await client.get("/api/analytics/autonomy")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total_decisions"] == 0
+    assert body["by_level"] == {}
+    assert body["by_decision"] == {}
+
+
+@pytest.mark.asyncio
+async def test_summary_crosstab(client, setup_db):
+    # 2 manual denies + 1 assisted allow + 1 auto allow (bash destructive).
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "manual", "tool_name": "Bash", "decision": "deny"})
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "manual", "tool_name": "Edit", "decision": "deny"})
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "assisted", "tool_name": "Read", "decision": "allow"})
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "auto", "tool_name": "Bash", "decision": "allow"})
+    # Referral — approve maps to allow.
+    await _add_event(event_type="auto_mode_referral",
+                     data={"level": "manual", "tool_name": "Bash",
+                           "final_status": "approved"})
+
+    resp = await client.get("/api/analytics/autonomy")
+    body = resp.json()
+    assert body["total_decisions"] == 5
+    assert body["by_level"] == {"manual": 3, "assisted": 1, "auto": 1}
+    assert body["by_decision"] == {"deny": 2, "allow": 3}
+    assert body["by_level_decision"]["manual"] == {"deny": 2, "allow": 1}
+    assert body["by_event_type"]["auto_mode_decision"] == 4
+    assert body["by_event_type"]["auto_mode_referral"] == 1
+
+
+@pytest.mark.asyncio
+async def test_summary_windowed_to_days(client, setup_db):
+    within = datetime.now(timezone.utc) - timedelta(days=2)
+    outside = datetime.now(timezone.utc) - timedelta(days=40)
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "auto", "tool_name": "Bash", "decision": "allow"},
+                     created_at=within)
+    await _add_event(event_type="auto_mode_decision",
+                     data={"level": "auto", "tool_name": "Bash", "decision": "allow"},
+                     created_at=outside)
+
+    resp = await client.get("/api/analytics/autonomy?days=7")
+    body = resp.json()
+    assert body["total_decisions"] == 1

--- a/dashboard/frontend/src/App.svelte
+++ b/dashboard/frontend/src/App.svelte
@@ -27,6 +27,7 @@
   import QueueBoard from './pages/QueueBoard.svelte';
   import ProjectsPage from './pages/ProjectsPage.svelte';
   import ProjectDetail from './pages/ProjectDetail.svelte';
+  import AutonomyAudit from './pages/AutonomyAudit.svelte';
   import SettingsPage from './pages/SettingsPage.svelte';
 
   // --- App State ---
@@ -122,6 +123,8 @@
       <ProjectsPage />
     {:else if route.page === 'project-detail'}
       <ProjectDetail projectId={route.param ?? ''} />
+    {:else if route.page === 'autonomy-audit'}
+      <AutonomyAudit />
     {:else if route.page === 'settings'}
       <SettingsPage tab={route.param} />
     {:else}

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -308,6 +308,51 @@ export const getRunLogs = (runId: string, limit?: number, offset?: number) =>
 export const getAnalytics = (params?: { days?: number; project_id?: number }) =>
   request<AnalyticsResponse>(`/api/analytics${qs(params ?? {})}`);
 
+export interface AutonomySummary {
+  days: number;
+  total_decisions: number;
+  by_level: Record<string, number>;
+  by_decision: Record<string, number>;
+  by_tool: Record<string, number>;
+  by_level_decision: Record<string, Record<string, number>>;
+  by_event_type: Record<string, number>;
+}
+
+export interface AutonomyAuditRow {
+  event_id: number;
+  event_type: 'auto_mode_decision' | 'auto_mode_referral';
+  workflow_id: string;
+  run_id: string | null;
+  agent_id: string;
+  created_at: string | null;
+  tool_name: string;
+  decision: string;
+  level: string | null;
+  reason: string | null;
+  request_id: string | null;
+  tool_input: Record<string, unknown>;
+}
+
+export interface AutonomyAuditResponse {
+  total: number;
+  limit: number;
+  offset: number;
+  items: AutonomyAuditRow[];
+}
+
+export const getAutonomySummary = (days = 30) =>
+  request<AutonomySummary>(`/api/analytics/autonomy${qs({ days })}`);
+
+export const getAutonomyAudit = (params?: {
+  run_id?: string;
+  tool_name?: string;
+  decision?: string;
+  event_type?: string;
+  limit?: number;
+  offset?: number;
+}) =>
+  request<AutonomyAuditResponse>(`/api/analytics/autonomy-audit${qs(params ?? {})}`);
+
 // --- Prompts ---
 
 export const listPrompts = () =>

--- a/dashboard/frontend/src/lib/router.svelte.ts
+++ b/dashboard/frontend/src/lib/router.svelte.ts
@@ -11,6 +11,7 @@ export type Page =
   | 'queue-detail'
   | 'projects'
   | 'project-detail'
+  | 'autonomy-audit'
   | 'settings';
 
 export interface Route {
@@ -91,6 +92,7 @@ function parsePath(): Route {
     runs: 'runs',
     queue: 'queue',
     projects: 'projects',
+    'autonomy-audit': 'autonomy-audit',
     settings: 'settings',
   };
 
@@ -172,6 +174,7 @@ export function getPageTitle(page: Page): string {
     'queue-detail': 'Queue Item',
     'projects': 'Projects',
     'project-detail': 'Project',
+    'autonomy-audit': 'Autonomy Audit',
     'settings': 'Settings',
   };
   return titles[page] ?? 'Claude Station';

--- a/dashboard/frontend/src/pages/AutonomyAudit.svelte
+++ b/dashboard/frontend/src/pages/AutonomyAudit.svelte
@@ -1,0 +1,244 @@
+<script lang="ts">
+  import {
+    getAutonomyAudit,
+    getAutonomySummary,
+    type AutonomyAuditRow,
+    type AutonomySummary,
+  } from '../lib/api';
+  import { timeAgo } from '../lib/format';
+  import AutonomyBadge from '../components/badges/AutonomyBadge.svelte';
+  import SkeletonLoader from '../components/data-display/SkeletonLoader.svelte';
+  import EmptyState from '../components/data-display/EmptyState.svelte';
+
+  let summary = $state<AutonomySummary | null>(null);
+  let rows = $state<AutonomyAuditRow[]>([]);
+  let total = $state(0);
+  let loading = $state(true);
+  let runFilter = $state('');
+  let toolFilter = $state('');
+  let decisionFilter = $state<'' | 'allow' | 'deny'>('');
+  let typeFilter = $state<'' | 'auto_mode_decision' | 'auto_mode_referral'>('');
+
+  async function load() {
+    loading = true;
+    try {
+      const params: Record<string, unknown> = { limit: 200 };
+      if (runFilter) params.run_id = runFilter;
+      if (toolFilter) params.tool_name = toolFilter;
+      if (decisionFilter) params.decision = decisionFilter;
+      if (typeFilter) params.event_type = typeFilter;
+      const [sum, audit] = await Promise.all([
+        getAutonomySummary(30),
+        getAutonomyAudit(params),
+      ]);
+      summary = sum;
+      rows = audit.items;
+      total = audit.total;
+    } finally {
+      loading = false;
+    }
+  }
+
+  $effect(() => {
+    runFilter; toolFilter; decisionFilter; typeFilter;
+    load();
+  });
+
+  // Donut: compute arc offsets for a pure-SVG ring.
+  const DONUT_SIZE = 120;
+  const DONUT_RADIUS = 48;
+  const DONUT_CIRCUMFERENCE = 2 * Math.PI * DONUT_RADIUS;
+
+  const LEVEL_COLORS: Record<string, string> = {
+    manual: '#6E5D4A',
+    assisted: '#5D5F94',
+    auto: '#2E7D32',
+    unknown: '#A08E7A',
+  };
+
+  interface DonutSlice { label: string; value: number; offset: number; length: number; color: string; }
+
+  let donutSlices = $derived.by<DonutSlice[]>(() => {
+    if (!summary || summary.total_decisions === 0) return [];
+    let cumulative = 0;
+    const slices: DonutSlice[] = [];
+    const entries = Object.entries(summary.by_level).sort((a, b) => b[1] - a[1]);
+    for (const [level, count] of entries) {
+      const fraction = count / summary.total_decisions;
+      const length = fraction * DONUT_CIRCUMFERENCE;
+      slices.push({
+        label: level,
+        value: count,
+        offset: cumulative,
+        length,
+        color: LEVEL_COLORS[level] ?? LEVEL_COLORS.unknown,
+      });
+      cumulative += length;
+    }
+    return slices;
+  });
+
+  function inputPreview(input: Record<string, unknown>): string {
+    if (typeof input.command === 'string') return input.command;
+    if (typeof input.file_path === 'string') return input.file_path;
+    for (const v of Object.values(input)) {
+      if (typeof v === 'string') return v;
+    }
+    return JSON.stringify(input).slice(0, 80);
+  }
+
+  function decisionColor(d: string): string {
+    return d === 'allow' ? '#2E7D32' : '#B06030';
+  }
+</script>
+
+<div class="space-y-4 animate-fade-in" data-testid="autonomy-audit">
+  <div class="flex items-center justify-between">
+    <h1 class="font-heading text-xl">Autonomy Audit</h1>
+    <span class="text-secondary text-sm">Last 30 days · {summary?.total_decisions ?? 0} decisions</span>
+  </div>
+
+  <!-- Summary panel -->
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div class="card p-4 flex items-center gap-4">
+      {#if summary && summary.total_decisions > 0}
+        <svg width={DONUT_SIZE} height={DONUT_SIZE} viewBox="0 0 {DONUT_SIZE} {DONUT_SIZE}" aria-label="Decisions by autonomy level">
+          <circle cx={DONUT_SIZE / 2} cy={DONUT_SIZE / 2} r={DONUT_RADIUS}
+                  fill="none" stroke="rgba(160,142,122,0.15)" stroke-width="14" />
+          {#each donutSlices as slice}
+            <circle cx={DONUT_SIZE / 2} cy={DONUT_SIZE / 2} r={DONUT_RADIUS}
+                    fill="none" stroke={slice.color} stroke-width="14"
+                    stroke-dasharray="{slice.length} {DONUT_CIRCUMFERENCE - slice.length}"
+                    stroke-dashoffset={-slice.offset}
+                    transform="rotate(-90 {DONUT_SIZE / 2} {DONUT_SIZE / 2})" />
+          {/each}
+          <text x={DONUT_SIZE / 2} y={DONUT_SIZE / 2 + 5} text-anchor="middle"
+                style="font-weight: 700; fill: #4A3728;">{summary.total_decisions}</text>
+        </svg>
+      {:else}
+        <div style="width: {DONUT_SIZE}px; height: {DONUT_SIZE}px;" class="flex items-center justify-center text-secondary text-sm">No data</div>
+      {/if}
+      <div class="space-y-1.5">
+        {#each donutSlices as slice}
+          <div class="flex items-center gap-2 text-sm">
+            <span style="display: inline-block; width: 10px; height: 10px; border-radius: 2px; background: {slice.color};"></span>
+            <span class="font-medium capitalize">{slice.label}</span>
+            <span class="text-secondary">{slice.value}</span>
+          </div>
+        {/each}
+      </div>
+    </div>
+
+    <div class="card p-4">
+      <h3 class="text-sm font-semibold mb-2">Decisions</h3>
+      {#if summary}
+        <div class="space-y-1 text-sm">
+          <div class="flex justify-between"><span>Allow</span><span style="color: #2E7D32; font-weight: 600;">{summary.by_decision.allow ?? 0}</span></div>
+          <div class="flex justify-between"><span>Deny</span><span style="color: #B06030; font-weight: 600;">{summary.by_decision.deny ?? 0}</span></div>
+          <div class="flex justify-between text-secondary mt-2 pt-2" style="border-top: 1px solid rgba(160,142,122,0.2);">
+            <span>Referrals</span><span>{summary.by_event_type.auto_mode_referral ?? 0}</span>
+          </div>
+          <div class="flex justify-between text-secondary">
+            <span>Direct decisions</span><span>{summary.by_event_type.auto_mode_decision ?? 0}</span>
+          </div>
+        </div>
+      {/if}
+    </div>
+
+    <div class="card p-4">
+      <h3 class="text-sm font-semibold mb-2">Top tools</h3>
+      {#if summary}
+        <div class="space-y-1 text-sm">
+          {#each Object.entries(summary.by_tool) as [tool, count]}
+            <div class="flex justify-between">
+              <span>{tool}</span><span class="text-secondary">{count}</span>
+            </div>
+          {/each}
+          {#if Object.keys(summary.by_tool).length === 0}
+            <div class="text-secondary">No tool data yet.</div>
+          {/if}
+        </div>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Filters -->
+  <div class="flex flex-wrap gap-2 items-center">
+    <input
+      type="text"
+      placeholder="Filter by run id…"
+      bind:value={runFilter}
+      class="input text-sm"
+      style="min-width: 200px;"
+    />
+    <input
+      type="text"
+      placeholder="Tool name…"
+      bind:value={toolFilter}
+      class="input text-sm"
+      style="min-width: 140px;"
+    />
+    <select bind:value={decisionFilter} class="input text-sm">
+      <option value="">All decisions</option>
+      <option value="allow">Allow</option>
+      <option value="deny">Deny</option>
+    </select>
+    <select bind:value={typeFilter} class="input text-sm">
+      <option value="">All types</option>
+      <option value="auto_mode_decision">Direct decision</option>
+      <option value="auto_mode_referral">Tray referral</option>
+    </select>
+    <span class="text-secondary text-sm">{total} row{total === 1 ? '' : 's'}</span>
+  </div>
+
+  <!-- Audit table -->
+  <div class="card overflow-hidden">
+    {#if loading}
+      <div class="p-4"><SkeletonLoader rows={6} /></div>
+    {:else if rows.length === 0}
+      <EmptyState
+        title="No audit rows yet"
+        description="When the policy engine evaluates a tool call, the decision shows up here."
+      />
+    {:else}
+      <div style="overflow-x: auto;">
+        <table class="w-full text-sm">
+          <thead style="background: rgba(240,220,200,0.15); border-bottom: 1px solid rgba(160,142,122,0.3);">
+            <tr class="text-left">
+              <th class="p-2 font-medium">Time</th>
+              <th class="p-2 font-medium">Run</th>
+              <th class="p-2 font-medium">Agent</th>
+              <th class="p-2 font-medium">Level</th>
+              <th class="p-2 font-medium">Tool</th>
+              <th class="p-2 font-medium">Decision</th>
+              <th class="p-2 font-medium">Type</th>
+              <th class="p-2 font-medium">Input</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each rows as row (row.event_id)}
+              <tr style="border-bottom: 1px solid rgba(160,142,122,0.12);">
+                <td class="p-2 text-secondary whitespace-nowrap">{row.created_at ? timeAgo(row.created_at) : '—'}</td>
+                <td class="p-2 font-mono text-xs">
+                  {#if row.run_id}
+                    <a href="/runs/{row.run_id}" class="link">{row.run_id}</a>
+                  {:else}—{/if}
+                </td>
+                <td class="p-2 text-xs">{row.agent_id}</td>
+                <td class="p-2"><AutonomyBadge level={row.level} size="xs" /></td>
+                <td class="p-2 font-mono text-xs">{row.tool_name}</td>
+                <td class="p-2" style="color: {decisionColor(row.decision)}; font-weight: 600; text-transform: capitalize;">{row.decision}</td>
+                <td class="p-2 text-xs text-secondary">
+                  {row.event_type === 'auto_mode_referral' ? 'referral' : 'direct'}
+                </td>
+                <td class="p-2 font-mono text-xs" style="max-width: 360px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title={inputPreview(row.tool_input)}>
+                  {inputPreview(row.tool_input)}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    {/if}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- New backend `GET /api/analytics/autonomy` (summary cross-tabs for the donut) and `GET /api/analytics/autonomy-audit` (raw filterable rows).
- New frontend `pages/AutonomyAudit.svelte` at `/autonomy-audit` — SVG donut by level, decision/event-type side panels, filterable table.
- Normalises `auto_mode_referral.final_status='approved'` to `decision='allow'` so the UI has one decision axis across both event shapes.

## Why no NavRail entry
Operator-focused tool, not everyday nav. Access via direct URL. Future work can link from the Run Detail autonomy badge once a design decision is taken on how prominent the audit should be.

## Test plan
- [x] `pytest dashboard/backend/tests/test_autonomy_analytics.py` — 10/10 green
- [x] Full backend suite still green (603 passed locally)
- [x] `npm run build` clean (184.28 kB bundle)
- [ ] Post-merge: hit `/autonomy-audit` against prod, confirm donut renders for today's `auto_mode_decision` rows and filters round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)