### PR TITLE
feat: bump default Opus to 4.7 + compose-mode UI awareness

### DIFF
--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -21,6 +21,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY dashboard/backend/ /app/dashboard/backend/
 COPY --from=frontend /build/dist /app/dashboard/frontend/dist
+COPY agent/prompts/ /app/agent/prompts/
 
 # Defaults — override via compose env. The volumes mounted at these paths
 # in compose.yml hold runtime state across restarts.

--- a/agent/agents/issue-worker.md
+++ b/agent/agents/issue-worker.md
@@ -2,7 +2,7 @@
 name: issue-worker
 description: Specialized teammate for agent teams. Works on tasks from the shared task list in an isolated git worktree.
 tools: Read, Edit, Write, Bash, Glob, Grep
-model: claude-opus-4-6
+model: claude-opus-4-7
 permissionMode: bypassPermissions
 maxTurns: 50
 ---

--- a/agent/config/default-config.json
+++ b/agent/config/default-config.json
@@ -11,7 +11,7 @@
   },
   "schedule": "1h",
   "models": {
-    "employee": "claude-opus-4-6",
+    "employee": "claude-opus-4-7",
     "manager": "claude-sonnet-4-6",
     "analyst": "claude-sonnet-4-6",
     "planner": "claude-sonnet-4-6",

--- a/agent/scripts/detect_plan_usage.py
+++ b/agent/scripts/detect_plan_usage.py
@@ -48,18 +48,21 @@ SESSION_RESET_HOURS = 4
 # These are approximate based on publicly documented Claude plan limits.
 PLAN_LIMITS: dict[str, dict[str, int]] = {
     "max_5x": {
+        "claude-opus-4-7": 225_000_000,
         "claude-opus-4-6": 225_000_000,
         "claude-sonnet-4-6": 900_000_000,
         "claude-haiku-4-5-20251001": 4_500_000_000,
         "default": 900_000_000,
     },
     "pro": {
+        "claude-opus-4-7": 45_000_000,
         "claude-opus-4-6": 45_000_000,
         "claude-sonnet-4-6": 180_000_000,
         "claude-haiku-4-5-20251001": 900_000_000,
         "default": 180_000_000,
     },
     "team": {
+        "claude-opus-4-7": 90_000_000,
         "claude-opus-4-6": 90_000_000,
         "claude-sonnet-4-6": 360_000_000,
         "claude-haiku-4-5-20251001": 1_800_000_000,
@@ -70,18 +73,21 @@ PLAN_LIMITS: dict[str, dict[str, int]] = {
 # Session limits per tier (approximate tokens per session window)
 SESSION_LIMITS: dict[str, dict[str, int]] = {
     "max_5x": {
+        "claude-opus-4-7": 32_000_000,
         "claude-opus-4-6": 32_000_000,
         "claude-sonnet-4-6": 128_000_000,
         "claude-haiku-4-5-20251001": 640_000_000,
         "default": 128_000_000,
     },
     "pro": {
+        "claude-opus-4-7": 6_400_000,
         "claude-opus-4-6": 6_400_000,
         "claude-sonnet-4-6": 25_600_000,
         "claude-haiku-4-5-20251001": 128_000_000,
         "default": 25_600_000,
     },
     "team": {
+        "claude-opus-4-7": 12_800_000,
         "claude-opus-4-6": 12_800_000,
         "claude-sonnet-4-6": 51_200_000,
         "claude-haiku-4-5-20251001": 256_000_000,

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -875,7 +875,7 @@ run_employee() {
     fi
 
     local model max_turns
-    model=$(json_get "$CONFIG_FILE" "models.employee" 2>/dev/null || echo "claude-opus-4-6")
+    model=$(json_get "$CONFIG_FILE" "models.employee" 2>/dev/null || echo "claude-opus-4-7")
     max_turns=$(json_get "$CONFIG_FILE" "limits.max_employee_turns" 2>/dev/null || echo "200")
 
     # Apply budget override if provided (from parallel budget calculation)

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -666,9 +666,12 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
         try:
             worker_name, worker_def = load_agent_definition(worker_file)
             employee_override = get_model(config, "employee", "")
-            if employee_override:
+            if employee_override and employee_override != worker_def.model:
+                logger.info(
+                    "Overriding teammate model from config: %s (was %s)",
+                    employee_override, worker_def.model,
+                )
                 worker_def = replace(worker_def, model=employee_override)
-                logger.info("Overriding teammate model from config: %s", employee_override)
             agents_dict = {worker_name: worker_def}
             logger.info("Loaded agent definition: %s from %s (model=%s)", worker_name, worker_file, worker_def.model)
         except Exception as e:

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -21,7 +21,7 @@ import os
 import subprocess
 import sys
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -147,14 +147,6 @@ def get_model(config: dict, key: str, default: str) -> str:
     return config.get("models", {}).get(key, default)
 
 
-# Map full model names to SDK short names
-MODEL_MAP = {
-    "claude-opus-4-6": "opus",
-    "claude-sonnet-4-6": "sonnet",
-    "claude-haiku-4-5": "haiku",
-}
-
-
 def load_agent_definition(path: Path) -> tuple[str, AgentDefinition]:
     """Parse an agent markdown file (with YAML frontmatter) into an AgentDefinition."""
     text = path.read_text()
@@ -173,8 +165,7 @@ def load_agent_definition(path: Path) -> tuple[str, AgentDefinition]:
     name = meta.get("name", path.stem)
     tools_str = meta.get("tools", "")
     tools = [t.strip() for t in tools_str.split(",")] if tools_str else None
-    model_raw = meta.get("model", "")
-    model = MODEL_MAP.get(model_raw, "opus")
+    model = meta.get("model", "") or None
 
     return name, AgentDefinition(
         description=meta.get("description", ""),
@@ -258,7 +249,7 @@ def build_team_prompt(
     issue_list = "\n".join(issue_entries)
 
     max_turns = get_limit(config, "max_employee_turns", 200)
-    teammate_model = get_model(config, "employee", "claude-opus-4-6")
+    teammate_model = get_model(config, "employee", "claude-opus-4-7")
 
     # Determine base branch (always use integration dev branch)
     integration = config.get("integration", {})
@@ -674,8 +665,12 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
     if worker_file.exists():
         try:
             worker_name, worker_def = load_agent_definition(worker_file)
+            employee_override = get_model(config, "employee", "")
+            if employee_override:
+                worker_def = replace(worker_def, model=employee_override)
+                logger.info("Overriding teammate model from config: %s", employee_override)
             agents_dict = {worker_name: worker_def}
-            logger.info("Loaded agent definition: %s from %s", worker_name, worker_file)
+            logger.info("Loaded agent definition: %s from %s (model=%s)", worker_name, worker_file, worker_def.model)
         except Exception as e:
             logger.warning("Failed to load agent definition %s: %s", worker_file, e)
 

--- a/dashboard/backend/app/routers/plan_usage.py
+++ b/dashboard/backend/app/routers/plan_usage.py
@@ -67,18 +67,21 @@ class PlanUsageHistoryOut(BaseModel):
 # Known plan tier token limits (weekly) — mirrors detect_plan_usage.py
 PLAN_LIMITS: dict[str, dict[str, int]] = {
     "max_5x": {
+        "claude-opus-4-7": 225_000_000,
         "claude-opus-4-6": 225_000_000,
         "claude-sonnet-4-6": 900_000_000,
         "claude-haiku-4-5-20251001": 4_500_000_000,
         "default": 900_000_000,
     },
     "pro": {
+        "claude-opus-4-7": 45_000_000,
         "claude-opus-4-6": 45_000_000,
         "claude-sonnet-4-6": 180_000_000,
         "claude-haiku-4-5-20251001": 900_000_000,
         "default": 180_000_000,
     },
     "team": {
+        "claude-opus-4-7": 90_000_000,
         "claude-opus-4-6": 90_000_000,
         "claude-sonnet-4-6": 360_000_000,
         "claude-haiku-4-5-20251001": 1_800_000_000,

--- a/dashboard/backend/app/routers/system.py
+++ b/dashboard/backend/app/routers/system.py
@@ -27,6 +27,7 @@ async def system_status():
     svc = await service_control.get_agent_status()
     resources = await get_system_resources()
     return {
+        "deploy_mode": service_control.deploy_mode(),
         "service": {
             "active": svc["service_active"],
         },

--- a/dashboard/backend/app/services/service_control.py
+++ b/dashboard/backend/app/services/service_control.py
@@ -25,14 +25,21 @@ logger = logging.getLogger(__name__)
 DEFAULT_AGENT_UNIT = "claude-agent.service"
 
 
+_VALID_DEPLOY_MODES = ("systemd", "compose")
+
+
 def deploy_mode() -> str:
-    """Return the active deploy mode (``"systemd"`` or ``"compose"``).
+    """Return the active deploy mode — exactly ``"systemd"`` or ``"compose"``.
 
     Public API — other services that need to branch on the deploy shape
     (e.g. the stale-run reaper) should call this instead of reading the
-    env var directly so the dispatch decision lives in one place.
+    env var directly so the dispatch decision lives in one place. The
+    return value is also surfaced by ``/api/system/status`` and typed as
+    ``'systemd' | 'compose'`` on the frontend, so anything outside that
+    set falls back to ``"systemd"`` rather than leaking through.
     """
-    return os.environ.get("STATION_DEPLOY_MODE", "systemd").lower()
+    raw = os.environ.get("STATION_DEPLOY_MODE", "systemd").lower()
+    return raw if raw in _VALID_DEPLOY_MODES else "systemd"
 
 
 # Alias retained for the existing internal call sites; new code should use

--- a/dashboard/frontend/src/components/agent-teams/TeammateCard.svelte
+++ b/dashboard/frontend/src/components/agent-teams/TeammateCard.svelte
@@ -4,7 +4,7 @@
 
   let {
     name,
-    model = 'claude-opus-4-6',
+    model = 'claude-opus-4-7',
     task = '',
     status = '',
     statusType = 'idle',

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -339,6 +339,7 @@ export interface TokenUsage {
 
 // --- System ---
 export interface SystemStatus {
+  deploy_mode: 'systemd' | 'compose';
   service: { active: boolean; status: string };
   timer: { active: boolean; next_trigger: string | null };
   resources: {

--- a/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
+++ b/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
@@ -89,7 +89,7 @@
         // Teammates run as Opus per CLAUDE.md; the lead (Sonnet) is the
         // TeamLeadCard above. If a real model name arrives on the task it
         // will override this default.
-        model: (t as { model?: string | null }).model ?? 'claude-opus-4-6',
+        model: (t as { model?: string | null }).model ?? 'claude-opus-4-7',
         task: t.title ?? 'Untitled task',
         status: t.status === 'running' ? (t.result_summary || 'Working...') :
                 t.status === 'completed' ? 'Completed' :

--- a/dashboard/frontend/src/pages/SettingsPage.svelte
+++ b/dashboard/frontend/src/pages/SettingsPage.svelte
@@ -12,6 +12,26 @@
 
   let { tab = null }: { tab?: string | null } = $props();
 
+  const MODEL_OPTIONS = [
+    { id: 'claude-opus-4-7',           label: 'Opus 4.7 — most capable' },
+    { id: 'claude-sonnet-4-6',         label: 'Sonnet 4.6 — balanced' },
+    { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5 — fast & cheap' },
+  ];
+
+  const ROLE_DEFAULTS: Record<string, string> = {
+    employee: 'claude-opus-4-7',
+    manager:  'claude-sonnet-4-6',
+    analyst:  'claude-sonnet-4-6',
+    planner:  'claude-sonnet-4-6',
+    router:   'claude-haiku-4-5-20251001',
+  };
+
+  function defaultLabel(role: string): string {
+    const id = ROLE_DEFAULTS[role];
+    const opt = MODEL_OPTIONS.find(o => o.id === id);
+    return opt ? `Default — ${opt.label}` : 'Default';
+  }
+
   let config = $state<Record<string, any>>({});
   let prompts = $state<PromptInfo[]>([]);
   let systemStatus = $state<SystemStatus | null>(null);
@@ -270,16 +290,23 @@
     <div class="card p-5 space-y-4">
       <h2 class="section-header">Model Assignments</h2>
       <p class="text-xs text-tertiary">Configure which Claude model each agent role uses</p>
-      {#each ['employee', 'manager', 'analyst', 'planner'] as role}
+      {#each ['employee', 'manager', 'analyst', 'planner', 'router'] as role}
+        {@const current = config.models?.[role] ?? ''}
         <div class="flex items-center justify-between gap-4">
           <span class="text-sm text-secondary capitalize font-medium w-24">{role}</span>
-          <input
-            type="text"
-            value={config.models?.[role] ?? ''}
-            onchange={(e) => saveConfig('models', { ...config.models, [role]: (e.target as HTMLInputElement).value })}
+          <select
+            value={current}
+            onchange={(e) => saveConfig('models', { ...config.models, [role]: (e.target as HTMLSelectElement).value })}
             class="input font-mono text-xs flex-1"
-            placeholder="claude-opus-4-6"
-          />
+          >
+            <option value="">{defaultLabel(role)}</option>
+            {#each MODEL_OPTIONS as opt}
+              <option value={opt.id}>{opt.label}</option>
+            {/each}
+            {#if current && !MODEL_OPTIONS.some(o => o.id === current)}
+              <option value={current}>{current} (custom)</option>
+            {/if}
+          </select>
         </div>
       {/each}
     </div>
@@ -295,10 +322,12 @@
         <div class="flex gap-2">
           <button onclick={() => handleServiceAction('start')} class="btn btn-sm" style="background: rgba(46,125,50,0.10); color: #2E7D32;">Start</button>
           <button onclick={() => handleServiceAction('stop')} class="btn btn-sm" style="background: rgba(208,96,80,0.10); color: #D06050;">Stop</button>
-          <button onclick={() => handleServiceAction('restart')} class="btn btn-sm" style="background: rgba(176,96,48,0.10); color: #B06030;">Restart</button>
+          {#if systemStatus?.deploy_mode !== 'compose'}
+            <button onclick={() => handleServiceAction('restart')} class="btn btn-sm" style="background: rgba(176,96,48,0.10); color: #B06030;">Restart</button>
+          {/if}
         </div>
       </div>
-      {#if systemStatus?.timer}
+      {#if systemStatus?.timer && systemStatus?.deploy_mode !== 'compose'}
         <div class="flex items-center justify-between text-sm">
           <div>
             <div class="text-primary">Timer</div>


### PR DESCRIPTION
## Summary

Three small, related improvements that were sitting on `dev` as work-in-progress before the issue #179 / PR #249 security work began. Kept as a single commit because `SettingsPage.svelte` straddles both the model-dropdown and compose-mode changes.

### Opus 4.7 default
The agent now defaults to `claude-opus-4-7` for the `employee` role across the full stack:
- `agent/agents/issue-worker.md` frontmatter
- `agent/config/default-config.json` `models.employee`
- `agent/scripts/run-manager.sh` fallback
- `agent/station_orchestrator.py` `build_team_prompt` default — also drops the now-stale `MODEL_MAP` short-name table; full model names pass through.
- `agent/scripts/detect_plan_usage.py` + `dashboard/backend/app/routers/plan_usage.py` per-tier weekly token-limit maps (mirrors the 4-6 numbers since the plan caps are tier-level, not model-level).
- `dashboard/frontend/src/components/agent-teams/TeammateCard.svelte` + `pages/AgentTeamsCanvas.svelte` default props.
- `dashboard/frontend/src/pages/SettingsPage.svelte` — replaces the free-text model input with a typed `<select>` listing Opus 4.7, Sonnet 4.6, and Haiku 4.5, with per-role default labels (so the empty option actually names the recommended model instead of just saying "(use default)").

### Compose-mode UI awareness
The dashboard now hides systemd-only controls when running under `STATION_DEPLOY_MODE=compose`:
- `dashboard/backend/app/routers/system.py` emits `deploy_mode` on `/api/system/status`.
- `dashboard/frontend/src/lib/types.ts` adds `deploy_mode` to `SystemStatus`.
- `SettingsPage.svelte` hides the Restart button + Timer row under compose (no `systemctl restart`, no systemd timers).

### Dockerfile.dashboard
Bundles `agent/prompts/` into the dashboard image so compose deploys can reach the prompt files.

## Test plan

- [x] Backend: existing pytest suite still green locally (744 passed, 54 skipped).
- [x] `default-config.json` parses as valid JSON.
- [x] `bash -n` clean on `run-manager.sh`.
- [ ] Manually verify in compose: `/api/system/status` returns `"deploy_mode": "compose"` and the Settings page hides the Restart button.
- [ ] Manually verify in compose: a triggered run uses Opus 4.7 (visible in run-manager logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)