### PR TITLE
fix: replace tempfile.mktemp with mkstemp in test fixtures (#192)

### DIFF
--- a/dashboard/backend/tests/conftest.py
+++ b/dashboard/backend/tests/conftest.py
@@ -4,5 +4,6 @@ import os
 import tempfile
 
 # Must set env var BEFORE any app imports to override settings.db_path
-_tmp_db = tempfile.mktemp(suffix=".db")
+_fd, _tmp_db = tempfile.mkstemp(suffix=".db")
+os.close(_fd)
 os.environ["STATION_DB_PATH"] = _tmp_db

--- a/dashboard/backend/tests/test_migrations.py
+++ b/dashboard/backend/tests/test_migrations.py
@@ -7,7 +7,8 @@ import tempfile
 import pytest
 
 # Override DB path before any app imports
-_tmp_db = tempfile.mktemp(suffix=".db")
+_fd, _tmp_db = tempfile.mkstemp(suffix=".db")
+os.close(_fd)
 os.environ["STATION_DB_PATH"] = _tmp_db
 
 


### PR DESCRIPTION
Closes #192

## Summary

- Replaced deprecated `tempfile.mktemp()` with `tempfile.mkstemp()` in two test fixture files
- `mkstemp()` atomically creates the temp file, eliminating the TOCTOU race window that `mktemp()` leaves between returning a path and the caller creating the file
- The fd returned by `mkstemp()` is closed immediately so the test fixtures can recreate/use the path normally

## Files changed

- `dashboard/backend/tests/conftest.py`
- `dashboard/backend/tests/test_migrations.py`

## Test plan

- [x] Full test suite passes: `python3 -m pytest tests/ -x` — 767 passed, 54 skipped
- [x] No `mktemp` calls remain in either file

**Note on out-of-scope DeprecationWarnings**: Running with `-W error::DeprecationWarning` fails due to `pytest_asyncio` using the deprecated `asyncio.AbstractEventLoopPolicy` on Python 3.14 — this is unrelated to this fix and pre-exists on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)