### PR TITLE
fix: SSRF in notifier — validate webhook_url scheme + host (#193)

### DIFF
--- a/dashboard/backend/app/routers/config_router.py
+++ b/dashboard/backend/app/routers/config_router.py
@@ -19,7 +19,11 @@ from app.config import settings
 from app.dependencies import get_db
 from app.models import ConfigEntry, Run
 from app.services.config_sync import _read_config_json, _write_config_json, sync_config_to_db
-from app.services.notifier import send_test_notification
+from app.services.notifier import (
+    WebhookUrlValidationError,
+    send_test_notification,
+    validate_notifications_config,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +118,18 @@ async def update_config(body: StationConfigUpdate, db: AsyncSession = Depends(ge
     # Read current config to preserve any fields not sent by frontend
     current = await asyncio.to_thread(_read_config_json)
     # Merge: update only keys the frontend sends
-    for key, value in body.model_dump(exclude_none=True).items():
+    update_payload = body.model_dump(exclude_none=True)
+
+    # SSRF protection: validate every webhook URL in incoming notifications
+    # block (top-level webhook_url and each targets[*].webhook_url).  Reject
+    # the whole request with HTTP 400 if any URL is invalid.
+    if "notifications" in update_payload:
+        try:
+            validate_notifications_config(update_payload["notifications"])
+        except WebhookUrlValidationError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+    for key, value in update_payload.items():
         current[key] = value
 
     # Normalize limits (migrate old -> new) before persisting

--- a/dashboard/backend/app/services/notifier.py
+++ b/dashboard/backend/app/services/notifier.py
@@ -19,8 +19,10 @@ Transient HTTP errors (5xx) are retried once after a 1-second delay.
 """
 
 import asyncio
+import ipaddress
 import logging
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -32,6 +34,125 @@ logger = logging.getLogger(__name__)
 # Retry settings for transient (5xx) failures
 _MAX_RETRIES = 1
 _RETRY_DELAY_SECONDS = 1.0
+
+
+# ---------------------------------------------------------------------------
+# SSRF protection: webhook URL validation
+# ---------------------------------------------------------------------------
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+# Hostnames that always resolve into reserved space and are therefore rejected
+# without any DNS lookup.  Anything else is checked only if it parses as a
+# literal IP address -- DNS resolution is intentionally skipped (we rely on
+# outbound network egress controls for hostnames).
+_BLOCKED_HOSTNAMES = frozenset({"localhost", "ip6-localhost", "ip6-loopback"})
+
+
+class WebhookUrlValidationError(ValueError):
+    """Raised when a webhook URL is rejected by SSRF protection."""
+
+
+def _ip_is_blocked(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True for IPs in private, loopback, link-local, multicast,
+    reserved, or unspecified ranges (i.e. anything that should not be
+    callable from a public webhook config)."""
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_multicast
+        or ip.is_reserved
+        or ip.is_unspecified
+    )
+
+
+def validate_webhook_url(url: str) -> None:
+    """Validate *url* for use as a webhook target.
+
+    Raises :class:`WebhookUrlValidationError` if the URL:
+
+    - has a scheme other than ``http`` / ``https``
+    - is missing a hostname / netloc
+    - has a hostname literal that resolves into private, loopback,
+      link-local, multicast, reserved, or unspecified address space
+    - has a hostname in :data:`_BLOCKED_HOSTNAMES` (e.g. ``localhost``)
+
+    DNS resolution is intentionally skipped for non-IP hostnames; the caller
+    relies on outbound network egress controls for that defence layer.
+    """
+    if not isinstance(url, str) or not url:
+        raise WebhookUrlValidationError("webhook_url must be a non-empty string")
+
+    try:
+        parsed = urlparse(url)
+    except ValueError as e:
+        raise WebhookUrlValidationError(f"webhook_url is not a valid URL: {e}") from e
+
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise WebhookUrlValidationError(
+            f"webhook_url scheme must be http or https (got '{scheme or 'missing'}')"
+        )
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise WebhookUrlValidationError("webhook_url is missing a hostname")
+
+    host_lc = hostname.lower()
+    if host_lc in _BLOCKED_HOSTNAMES:
+        raise WebhookUrlValidationError(
+            f"webhook_url hostname '{hostname}' is not allowed"
+        )
+
+    # If the hostname is a literal IP address, reject any reserved range.
+    # IPv6 hostnames come back from urlparse without surrounding brackets.
+    try:
+        ip = ipaddress.ip_address(host_lc)
+    except ValueError:
+        # Not an IP literal -- accept (rely on egress controls).
+        return
+
+    if _ip_is_blocked(ip):
+        raise WebhookUrlValidationError(
+            f"webhook_url points to a non-public IP address ({ip})"
+        )
+
+
+def validate_notifications_config(notifications: dict[str, Any]) -> None:
+    """Validate every webhook URL inside a ``notifications`` config block.
+
+    Validates both the legacy top-level ``webhook_url`` and every
+    ``targets[*].webhook_url`` entry.  Empty / missing URLs are skipped
+    (they're harmless -- the notifier simply won't send).
+
+    Raises :class:`WebhookUrlValidationError` if any URL is invalid.
+    """
+    if not isinstance(notifications, dict):
+        return
+
+    top_url = notifications.get("webhook_url")
+    if isinstance(top_url, str) and top_url:
+        try:
+            validate_webhook_url(top_url)
+        except WebhookUrlValidationError as e:
+            raise WebhookUrlValidationError(
+                f"Invalid notifications.webhook_url: {e}"
+            ) from e
+
+    targets = notifications.get("targets")
+    if isinstance(targets, list):
+        for idx, target in enumerate(targets):
+            if not isinstance(target, dict):
+                continue
+            t_url = target.get("webhook_url")
+            if isinstance(t_url, str) and t_url:
+                try:
+                    validate_webhook_url(t_url)
+                except WebhookUrlValidationError as e:
+                    raise WebhookUrlValidationError(
+                        f"Invalid notifications.targets[{idx}].webhook_url: {e}"
+                    ) from e
 
 
 # ---------------------------------------------------------------------------
@@ -172,6 +293,19 @@ async def _send_to_target(
         webhook_url = target["webhook_url"]
         webhook_type = target.get("webhook_type", "generic").lower()
         dashboard_url = target.get("dashboard_url", "").rstrip("/") or None
+
+        # Defense-in-depth: re-validate the URL before issuing the request.
+        # If a malicious config slipped past write-time validation (e.g.
+        # via direct file edit), refuse to make the outbound call.
+        try:
+            validate_webhook_url(webhook_url)
+        except WebhookUrlValidationError as e:
+            detail = f"Refusing to send to invalid webhook_url: {e}"
+            logger.warning(
+                "Notification blocked by SSRF guard (url=%s): %s",
+                webhook_url, e,
+            )
+            return (False, detail)
 
         adapter = get_adapter(webhook_type)
 

--- a/dashboard/backend/tests/test_webhook_url_validation.py
+++ b/dashboard/backend/tests/test_webhook_url_validation.py
@@ -1,0 +1,289 @@
+"""Tests for SSRF protection on webhook URLs (issue #193).
+
+Covers:
+- ``validate_webhook_url`` rejects non-http(s) schemes (file://, ftp://, gopher://, javascript:)
+- ``validate_webhook_url`` rejects empty / missing netloc
+- ``validate_webhook_url`` rejects literal private/loopback/link-local IPs
+- ``validate_webhook_url`` accepts legitimate https hostnames
+- Config router rejects PUT /api/config with malicious notifications.webhook_url
+- Config router rejects PUT /api/config with malicious notifications.targets[*].webhook_url
+- Config router rejects update if any single target entry is bad
+- ``_send_to_target`` performs defense-in-depth re-validation and never makes the HTTP call
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import Base, engine
+from app.main import app
+from app.services.notifier import (
+    WebhookUrlValidationError,
+    _send_to_target,
+    validate_webhook_url,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: validate_webhook_url
+# ---------------------------------------------------------------------------
+
+class TestValidateWebhookUrlScheme:
+    """Reject non-http(s) schemes."""
+
+    @pytest.mark.parametrize("url", [
+        "file:///etc/passwd",
+        "ftp://example.com/x",
+        "gopher://example.com/x",
+        "javascript:alert(1)",
+        "data:text/plain,hello",
+        "ssh://example.com",
+        "ldap://example.com",
+        "://example.com",
+        "example.com/no-scheme",
+    ])
+    def test_rejects_disallowed_scheme(self, url: str):
+        with pytest.raises(WebhookUrlValidationError):
+            validate_webhook_url(url)
+
+    def test_accepts_http(self):
+        # http allowed (some self-hosted webhooks); private-ip check still applies
+        validate_webhook_url("http://hooks.example.com/x")
+
+    def test_accepts_https(self):
+        validate_webhook_url("https://hooks.slack.com/services/T000/B000/abc")
+
+
+class TestValidateWebhookUrlNetloc:
+    """Reject empty / missing netloc."""
+
+    @pytest.mark.parametrize("url", [
+        "",
+        "http://",
+        "https://",
+        "http:///path",
+    ])
+    def test_rejects_empty_or_missing_netloc(self, url: str):
+        with pytest.raises(WebhookUrlValidationError):
+            validate_webhook_url(url)
+
+
+class TestValidateWebhookUrlPrivateIp:
+    """Reject literal IPs that resolve to private/loopback/link-local space."""
+
+    @pytest.mark.parametrize("url", [
+        "http://127.0.0.1/x",
+        "http://127.1.2.3/x",
+        "https://localhost/x",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://10.0.0.1/x",
+        "http://10.255.255.254/x",
+        "http://172.16.0.1/x",
+        "http://172.31.255.254/x",
+        "http://192.168.1.1/x",
+        "http://0.0.0.0/x",
+        "http://[::1]/x",
+        "http://[fe80::1]/x",
+        "http://[fc00::1]/x",
+    ])
+    def test_rejects_private_or_loopback(self, url: str):
+        with pytest.raises(WebhookUrlValidationError):
+            validate_webhook_url(url)
+
+    @pytest.mark.parametrize("url", [
+        "https://hooks.slack.com/services/T000/B000/abc",
+        "https://discord.com/api/webhooks/123/abc",
+        "https://api.telegram.org/bot123:abc/sendMessage",
+        "http://webhook.site/uuid",
+        "https://8.8.8.8/x",  # public IP literal is fine
+    ])
+    def test_accepts_public_url(self, url: str):
+        validate_webhook_url(url)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: PUT /api/config rejects bad webhook URLs
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_url", [
+    "file:///etc/passwd",
+    "ftp://example.com",
+    "gopher://example.com",
+    "http://127.0.0.1/x",
+    "http://localhost/x",
+    "http://169.254.169.254/x",
+    "http://10.0.0.1/x",
+    "http://192.168.1.1/x",
+])
+async def test_put_config_rejects_top_level_bad_webhook_url(client, bad_url: str):
+    """PUT /api/config must reject malicious top-level webhook_url with HTTP 400."""
+    current = {"projects": [], "notifications": {}}
+    with patch("app.routers.config_router._read_config_json", return_value=current):
+        with patch("app.routers.config_router._write_config_json") as mock_write:
+            with patch("app.routers.config_router.sync_config_to_db", new_callable=AsyncMock):
+                resp = await client.put("/api/config", json={
+                    "notifications": {
+                        "enabled": True,
+                        "method": "webhook",
+                        "webhook_url": bad_url,
+                    },
+                })
+    assert resp.status_code == 400
+    assert "webhook_url" in resp.json()["detail"].lower()
+    mock_write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_put_config_accepts_legitimate_webhook_url(client):
+    """PUT /api/config must accept a legitimate https webhook URL."""
+    current = {"projects": [], "notifications": {}}
+    with patch("app.routers.config_router._read_config_json", return_value=current):
+        with patch("app.routers.config_router._write_config_json") as mock_write:
+            with patch("app.routers.config_router.sync_config_to_db", new_callable=AsyncMock):
+                resp = await client.put("/api/config", json={
+                    "notifications": {
+                        "enabled": True,
+                        "method": "webhook",
+                        "webhook_url": "https://hooks.slack.com/services/T000/B000/abc",
+                    },
+                })
+    assert resp.status_code == 200
+    mock_write.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_put_config_rejects_bad_target_url(client):
+    """PUT /api/config must reject when any targets[*].webhook_url is bad."""
+    current = {"projects": [], "notifications": {}}
+    bad_payload = {
+        "notifications": {
+            "enabled": True,
+            "method": "webhook",
+            "targets": [
+                {"webhook_url": "https://hooks.slack.com/services/T000/B000/abc",
+                 "webhook_type": "slack"},
+                {"webhook_url": "http://169.254.169.254/latest/meta-data/",
+                 "webhook_type": "generic"},
+            ],
+        },
+    }
+    with patch("app.routers.config_router._read_config_json", return_value=current):
+        with patch("app.routers.config_router._write_config_json") as mock_write:
+            with patch("app.routers.config_router.sync_config_to_db", new_callable=AsyncMock):
+                resp = await client.put("/api/config", json=bad_payload)
+    assert resp.status_code == 400
+    assert "webhook_url" in resp.json()["detail"].lower()
+    mock_write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_put_config_accepts_all_good_targets(client):
+    """PUT /api/config must accept multiple good target URLs."""
+    current = {"projects": [], "notifications": {}}
+    payload = {
+        "notifications": {
+            "enabled": True,
+            "method": "webhook",
+            "targets": [
+                {"webhook_url": "https://hooks.slack.com/services/T000/B000/abc",
+                 "webhook_type": "slack"},
+                {"webhook_url": "https://discord.com/api/webhooks/123/abc",
+                 "webhook_type": "discord"},
+            ],
+        },
+    }
+    with patch("app.routers.config_router._read_config_json", return_value=current):
+        with patch("app.routers.config_router._write_config_json") as mock_write:
+            with patch("app.routers.config_router.sync_config_to_db", new_callable=AsyncMock):
+                resp = await client.put("/api/config", json=payload)
+    assert resp.status_code == 200
+    mock_write.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_put_config_allows_disabled_notifications_with_empty_url(client):
+    """PUT /api/config must allow saving notifications with empty/missing webhook_url
+    (e.g. user clearing the field while keeping ``enabled=False``)."""
+    current = {"projects": [], "notifications": {}}
+    with patch("app.routers.config_router._read_config_json", return_value=current):
+        with patch("app.routers.config_router._write_config_json") as mock_write:
+            with patch("app.routers.config_router.sync_config_to_db", new_callable=AsyncMock):
+                resp = await client.put("/api/config", json={
+                    "notifications": {"enabled": False, "webhook_url": ""},
+                })
+    assert resp.status_code == 200
+    mock_write.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Defense-in-depth: _send_to_target re-validates before HTTP call
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_to_target_blocks_malicious_url_without_http_call():
+    """If a malicious URL slipped past write-time validation (e.g. direct file
+    edit), ``_send_to_target`` must refuse to make the HTTP request."""
+    target = {
+        "webhook_url": "http://169.254.169.254/latest/meta-data/",
+        "webhook_type": "generic",
+    }
+    with patch("app.services.notifier.httpx.AsyncClient") as mock_client_cls:
+        success, error = await _send_to_target(
+            target=target,
+            event_type="TEST",
+            project="x/y",
+            issue_number=1,
+            issue_title="t",
+            tokens_total=0,
+            summary="s",
+            run_id="r",
+            config={},
+        )
+    assert success is False
+    assert error is not None and "webhook_url" in error.lower()
+    # No httpx client was instantiated -- no outbound request was made
+    mock_client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_url", [
+    "file:///etc/passwd",
+    "http://127.0.0.1/x",
+    "http://localhost/x",
+])
+async def test_send_to_target_blocks_various_malicious_urls(bad_url: str):
+    target = {"webhook_url": bad_url, "webhook_type": "generic"}
+    with patch("app.services.notifier.httpx.AsyncClient") as mock_client_cls:
+        success, error = await _send_to_target(
+            target=target,
+            event_type="TEST",
+            project="x/y",
+            issue_number=None,
+            issue_title=None,
+            tokens_total=None,
+            summary=None,
+            run_id=None,
+            config={},
+        )
+    assert success is False
+    assert error is not None
+    mock_client_cls.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `validate_webhook_url()` in `dashboard/backend/app/services/notifier.py` rejecting non-http(s) schemes, empty netlocs, and literal IPs in private / loopback / link-local / multicast / reserved / unspecified ranges (plus the `localhost` family of hostnames). DNS resolution is intentionally skipped for non-IP hostnames; egress controls remain the second line of defence.
- Wires the validator into `PUT /api/config` (rejects with HTTP 400 on any bad `notifications.webhook_url` or `notifications.targets[*].webhook_url` — no partial writes), and into `_send_to_target` for defense-in-depth (a malicious URL planted via direct file edit still cannot trigger an outbound request because `httpx.AsyncClient` is never instantiated).

Closes #193

## Test plan
- [x] 49 new tests in `dashboard/backend/tests/test_webhook_url_validation.py` cover:
  - [x] reject schemes: `file://`, `ftp://`, `gopher://`, `javascript:`, `data:`, `ssh://`, `ldap://`, missing scheme
  - [x] reject empty / missing netloc
  - [x] reject literal IPs: `127.0.0.1`, `127.1.2.3`, `localhost`, `169.254.169.254`, `10.0.0.1`, `10.255.255.254`, `172.16.0.1`, `172.31.255.254`, `192.168.1.1`, `0.0.0.0`, `::1`, `fe80::1`, `fc00::1`
  - [x] accept `https://hooks.slack.com/...`, `https://discord.com/api/webhooks/...`, `https://api.telegram.org/...`, public IP literals
  - [x] `PUT /api/config` rejects each malicious URL at the top level (HTTP 400, `_write_config_json` not called)
  - [x] `PUT /api/config` rejects when any single `targets[*]` entry is bad (no partial write)
  - [x] `PUT /api/config` accepts multiple legitimate target URLs
  - [x] `PUT /api/config` still allows clearing the URL when notifications are disabled
  - [x] `_send_to_target` returns `(False, error)` for each malicious URL without ever instantiating `httpx.AsyncClient`
- [x] Full backend suite: 816 passed, 54 skipped (matches baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)