### PR TITLE
fix: harden run-manager.sh shell-into-Python interpolation (#185, #180)

### DIFF
--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -54,12 +54,17 @@ log_error() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [ERROR] $1" >&2; }
 log_ok()    { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [OK]    $1"; }
 
 json_get() {
+    # Read a value from a JSON file by dotted path. Args (file, path) are
+    # passed via argv to the embedded Python — never interpolated into the
+    # source — so quotes/newlines/code-like characters in either are inert.
+    # See issue #185.
     local file="$1" path="$2"
-    python3 -c "
+    python3 - "$file" "$path" 2>/dev/null <<'PYEOF'
 import json, sys
-with open('$file') as f:
+file_path, dotted = sys.argv[1], sys.argv[2]
+with open(file_path) as f:
     data = json.load(f)
-keys = '$path'.split('.')
+keys = dotted.split('.')
 for k in keys:
     if isinstance(data, list):
         data = data[int(k)]
@@ -73,23 +78,25 @@ elif isinstance(data, bool):
     print('true' if data else 'false')
 else:
     print(data)
-" 2>/dev/null
+PYEOF
 }
 
 ensure_gh_token() {
     # Load GH_TOKEN from dashboard-managed file if not already set.
     # Falls back to existing GH_TOKEN env var for backward compatibility.
+    # The token file path is passed via argv to the embedded Python (issue #185).
     local token_file="$HOME/.claude-agent-station/github_token"
     if [ -f "$token_file" ]; then
         local file_token
-        file_token=$(python3 -c "
+        file_token=$(python3 - "$token_file" <<'PYEOF' 2>/dev/null
 import json, sys
 try:
-    with open('$token_file') as f:
+    with open(sys.argv[1]) as f:
         print(json.load(f).get('access_token', ''))
 except Exception:
     pass
-" 2>/dev/null || echo "")
+PYEOF
+) || file_token=""
         if [ -n "$file_token" ]; then
             export GH_TOKEN="$file_token"
             return 0
@@ -116,9 +123,23 @@ notify() {
         webhook)
             local url
             url=$(json_get "$CONFIG_FILE" "notifications.webhook_url" 2>/dev/null || echo "")
-            [ -n "$url" ] && curl -s -X POST "$url" \
-                -H "Content-Type: application/json" \
-                -d "{\"status\":\"$status\",\"message\":\"$message\",\"run_id\":\"$RUN_ID\"}" 2>/dev/null || true
+            if [ -n "$url" ]; then
+                # Build payload via python json.dumps so values containing
+                # quotes/newlines/etc. are escaped correctly (issue #180).
+                local notify_payload
+                notify_payload=$(python3 - "$status" "$message" "$RUN_ID" 2>/dev/null <<'PYEOF'
+import json, sys
+print(json.dumps({
+    "status": sys.argv[1],
+    "message": sys.argv[2],
+    "run_id": sys.argv[3],
+}))
+PYEOF
+)
+                curl -s -X POST "$url" \
+                    -H "Content-Type: application/json" \
+                    -d "$notify_payload" 2>/dev/null || true
+            fi
             ;;
     esac
 }
@@ -127,10 +148,60 @@ notify() {
 # DASHBOARD WEBHOOK (best-effort, never fails the agent run)
 # ============================================================================
 
+build_webhook_json() {
+    # Build a JSON payload using python's json.dumps so that string values
+    # with quotes/newlines/backslashes are escaped correctly. Issue #180.
+    #
+    # Usage: build_webhook_json EVENT RUN_ID [key value]...
+    #   - EVENT and RUN_ID become top-level fields.
+    #   - A "timestamp" field is auto-added (UTC, RFC3339-ish).
+    #   - Remaining argv pairs are interpreted as key/value. Values matching
+    #     "true"/"false"/"null" or numeric (int/float) literals are coerced
+    #     to JSON booleans/null/numbers; everything else stays a string.
+    #   - An odd trailing key with no value is silently skipped.
+    python3 - "$@" 2>/dev/null <<'PYEOF'
+import json, sys, datetime
+argv = sys.argv[1:]
+event = argv[0] if len(argv) > 0 else ""
+run_id = argv[1] if len(argv) > 1 else ""
+out = {
+    "event": event,
+    "run_id": run_id,
+    "timestamp": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+}
+pairs = argv[2:]
+for i in range(0, len(pairs) - 1, 2):
+    k = pairs[i]
+    v = pairs[i + 1]
+    if v == "true":
+        out[k] = True
+    elif v == "false":
+        out[k] = False
+    elif v == "null":
+        out[k] = None
+    else:
+        # Numeric coercion: int first, then float; otherwise keep as string.
+        coerced = v
+        if v.lstrip("-").isdigit():
+            try:
+                coerced = int(v)
+            except ValueError:
+                pass
+        elif v.replace(".", "", 1).lstrip("-").isdigit():
+            try:
+                coerced = float(v)
+            except ValueError:
+                pass
+        out[k] = coerced
+print(json.dumps(out))
+PYEOF
+}
+
 webhook_event() {
+    # webhook_event EVENT [key value]...
+    # Builds a safe JSON payload (issue #180) and POSTs to the dashboard.
     local event="$1"
     shift
-    local payload="$*"
     local webhook_url
     webhook_url=$(json_get "$CONFIG_FILE" "dashboard.webhook_url" 2>/dev/null || echo "")
     # Default to local dashboard if not configured
@@ -142,10 +213,12 @@ webhook_event() {
     if [ -n "$webhook_secret" ]; then
         auth_header=(-H "X-Webhook-Token: $webhook_secret")
     fi
+    local payload
+    payload=$(build_webhook_json "$event" "run-$RUN_ID" "$@")
     curl -s --max-time 3 -X POST "$webhook_url" \
         -H "Content-Type: application/json" \
         "${auth_header[@]}" \
-        -d "{\"event\":\"$event\",\"run_id\":\"run-$RUN_ID\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",${payload}}" \
+        -d "$payload" \
         >/dev/null 2>/dev/null || true
 }
 
@@ -335,7 +408,14 @@ _send_run_complete_on_exit() {
         [ $exit_code -eq 130 ] && status="interrupted"
         local _duration_ms=0
         [ "$_RUN_START_EPOCH" -gt 0 ] && _duration_ms=$(( ($(date +%s) - _RUN_START_EPOCH) * 1000 ))
-        webhook_event "run_complete" "\"status\":\"$status\",\"exit_code\":$exit_code,\"tokens_input\":$_TOTAL_TOKENS_IN,\"tokens_output\":$_TOTAL_TOKENS_OUT,\"tokens_total\":$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT)),\"turns\":$_TOTAL_TURNS,\"duration_ms\":$_duration_ms" || true
+        webhook_event "run_complete" \
+            status "$status" \
+            exit_code "$exit_code" \
+            tokens_input "$_TOTAL_TOKENS_IN" \
+            tokens_output "$_TOTAL_TOKENS_OUT" \
+            tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
+            turns "$_TOTAL_TURNS" \
+            duration_ms "$_duration_ms" || true
         _RUN_COMPLETE_SENT=1
     fi
 }
@@ -709,7 +789,9 @@ $prs_json
 Return ONLY the JSON assignment object, no other text."
 
     # Run assigner with Haiku (fast + cheap)
-    webhook_event "assigner_start" "\"project\":\"$repo\",\"employee_count\":$employee_count"
+    webhook_event "assigner_start" \
+        project "$repo" \
+        employee_count "$employee_count"
     local assigner_prompt_file="$(resolve_prompt assigner)"
     local assignment_output
     assignment_output=$(echo "$assignment_prompt" | claude -p \
@@ -719,11 +801,16 @@ Return ONLY the JSON assignment object, no other text."
         --no-session-persistence \
         --dangerously-skip-permissions \
         --output-format text 2>/dev/null) || {
-        webhook_event "assigner_complete" "\"project\":\"$repo\",\"status\":\"failed\""
+        webhook_event "assigner_complete" \
+            project "$repo" \
+            status "failed"
         log_warn "Assignment agent failed for $repo, employees will self-select"
         return 1
     }
-    webhook_event "assigner_complete" "\"project\":\"$repo\",\"status\":\"success\",\"employee_count\":$employee_count"
+    webhook_event "assigner_complete" \
+        project "$repo" \
+        status "success" \
+        employee_count "$employee_count"
 
     # Extract JSON from output (handle potential markdown wrapping)
     local clean_json
@@ -851,7 +938,9 @@ run_employee() {
         2>/dev/null || true
     # Emit role-specific presence event for planner mode
     if [ "$mode" = "plan" ]; then
-        webhook_event "planner_start" "\"project\":\"$repo\",\"employee_index\":$employee_index"
+        webhook_event "planner_start" \
+            project "$repo" \
+            employee_index "$employee_index"
     fi
 
     # Transition queue item to in_progress
@@ -1335,7 +1424,10 @@ print(f'{t:,}')
 
     # Emit planner_complete if this was a plan-mode employee
     if [ "$mode" = "plan" ]; then
-        webhook_event "planner_complete" "\"project\":\"$repo\",\"employee_index\":$employee_index,\"exit_code\":$exit_code"
+        webhook_event "planner_complete" \
+            project "$repo" \
+            employee_index "$employee_index" \
+            exit_code "$exit_code"
     fi
 
     # Use employee-specific run_id to complete the correct Run record
@@ -1564,7 +1656,7 @@ run_manager_review() {
     log_info "MANAGER: Reviewing employee work" >&2
     log_info "==========================================" >&2
 
-    webhook_event "manager_review" "\"review_package\":\"$review_package\"" >&2
+    webhook_event "manager_review" review_package "$review_package" >&2
 
     local model max_turns
     model=$(json_get "$CONFIG_FILE" "models.manager" 2>/dev/null || echo "claude-sonnet-4-6")
@@ -1707,12 +1799,17 @@ print(json.dumps(v))
         log_info "Project: $project | Verdict: $verdict | Issue: #$issue_number | Branch: $branch"
         log_info "Reasoning: $reasoning"
 
-        # Escape reasoning for JSON (replace newlines and quotes)
-        local escaped_reasoning
-        escaped_reasoning=$(echo "$reasoning" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip())[1:-1])" 2>/dev/null || echo "$reasoning")
+        # build_webhook_json handles string escaping (json.dumps); pass the
+        # reasoning verbatim. Use literal "null" for missing issue_number so
+        # the helper coerces it to a JSON null.
         local issue_num_json="null"
         [ -n "$issue_number" ] && issue_num_json="$issue_number"
-        webhook_event "verdict_execute" "\"project\":\"$project\",\"verdict\":\"$verdict\",\"issue_number\":$issue_num_json,\"branch\":\"$branch\",\"reasoning\":\"$escaped_reasoning\""
+        webhook_event "verdict_execute" \
+            project "$project" \
+            verdict "$verdict" \
+            issue_number "$issue_num_json" \
+            branch "$branch" \
+            reasoning "$reasoning"
 
         # Intelligence: record outcome for the learning loop
         local _report_confidence="" _report_tokens="" _report_duration="" _report_complexity="" _report_mode_used="" _report_model_used="" _report_esc_rung="0"
@@ -1951,7 +2048,10 @@ Rate limit: max 1 auto-draft PR per project per hour. Regenerated at $(date -u +
                                 if [ -n "$pr_url" ]; then
                                     log_ok "Draft PR created: $pr_url"
                                     auto_draft_rate_limit_record "$project"
-                                    webhook_event "auto_draft_pr_opened" "\"project\":\"$project\",\"branch\":\"$branch\",\"pr_url\":\"$pr_url\"" >&2
+                                    webhook_event "auto_draft_pr_opened" \
+                                        project "$project" \
+                                        branch "$branch" \
+                                        pr_url "$pr_url" >&2
                                 else
                                     log_error "Auto-draft PR creation failed for $branch"
                                 fi
@@ -2294,7 +2394,11 @@ main() {
     log_info "Concurrency: max_concurrent=$max_concurrent, max_per_project=$max_per_project, strategy=$budget_strategy"
 
     _RUN_START_EPOCH=$(date +%s)
-    webhook_event "run_start" "\"project_count\":$project_count,\"max_concurrent\":$max_concurrent,\"concurrent_group_id\":\"$CONCURRENT_GROUP_ID\",\"log_file\":\"$LOG_DIR/run-${RUN_ID}.log\""
+    webhook_event "run_start" \
+        project_count "$project_count" \
+        max_concurrent "$max_concurrent" \
+        concurrent_group_id "$CONCURRENT_GROUP_ID" \
+        log_file "$LOG_DIR/run-${RUN_ID}.log"
 
     # ---- Count total employees to spawn (for budget calculation) ----
     local total_employees=0
@@ -2471,7 +2575,11 @@ Human review is still required for merge.
 Run: $RUN_ID | \`[auto-pr]\`" 2>/dev/null || echo "")
                             if [ -n "$pr_url" ]; then
                                 log_ok "  Auto-PR created: $pr_url"
-                                webhook_event "intelligence.confidence_gate_passed" "\"project\":\"$repo_cg\",\"confidence\":$conf_confidence,\"branch\":\"$conf_branch\",\"pr_url\":\"$pr_url\""
+                                webhook_event "intelligence.confidence_gate_passed" \
+                                    project "$repo_cg" \
+                                    confidence "$conf_confidence" \
+                                    branch "$conf_branch" \
+                                    pr_url "$pr_url"
                                 auto_pr_projects+=("$repo_cg")
                             fi
                         else
@@ -2611,7 +2719,13 @@ print(json.dumps(result))
         notify "complete" "Run $RUN_ID finished (no work to review)"
         local _duration_ms_nr=0
         [ "$_RUN_START_EPOCH" -gt 0 ] && _duration_ms_nr=$(( ($(date +%s) - _RUN_START_EPOCH) * 1000 ))
-        webhook_event "run_complete" "\"status\":\"no_reports\",\"tokens_input\":$_TOTAL_TOKENS_IN,\"tokens_output\":$_TOTAL_TOKENS_OUT,\"tokens_total\":$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT)),\"turns\":$_TOTAL_TURNS,\"duration_ms\":$_duration_ms_nr"
+        webhook_event "run_complete" \
+            status "no_reports" \
+            tokens_input "$_TOTAL_TOKENS_IN" \
+            tokens_output "$_TOTAL_TOKENS_OUT" \
+            tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
+            turns "$_TOTAL_TURNS" \
+            duration_ms "$_duration_ms_nr"
         _RUN_COMPLETE_SENT=1
         exit 0
     fi
@@ -2621,7 +2735,13 @@ print(json.dumps(result))
         notify "rate_limit" "Rate limit reached before manager review in run $RUN_ID"
         local _duration_ms_rl=0
         [ "$_RUN_START_EPOCH" -gt 0 ] && _duration_ms_rl=$(( ($(date +%s) - _RUN_START_EPOCH) * 1000 ))
-        webhook_event "run_complete" "\"status\":\"rate_limited\",\"tokens_input\":$_TOTAL_TOKENS_IN,\"tokens_output\":$_TOTAL_TOKENS_OUT,\"tokens_total\":$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT)),\"turns\":$_TOTAL_TURNS,\"duration_ms\":$_duration_ms_rl"
+        webhook_event "run_complete" \
+            status "rate_limited" \
+            tokens_input "$_TOTAL_TOKENS_IN" \
+            tokens_output "$_TOTAL_TOKENS_OUT" \
+            tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
+            turns "$_TOTAL_TURNS" \
+            duration_ms "$_duration_ms_rl"
         _RUN_COMPLETE_SENT=1
         exit 0
     fi
@@ -2767,7 +2887,13 @@ print(json.dumps(result))
     notify "complete" "Run $RUN_ID finished successfully"
     local _duration_ms_ok=0
     [ "$_RUN_START_EPOCH" -gt 0 ] && _duration_ms_ok=$(( ($(date +%s) - _RUN_START_EPOCH) * 1000 ))
-    webhook_event "run_complete" "\"status\":\"success\",\"tokens_input\":$_TOTAL_TOKENS_IN,\"tokens_output\":$_TOTAL_TOKENS_OUT,\"tokens_total\":$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT)),\"turns\":$_TOTAL_TURNS,\"duration_ms\":$_duration_ms_ok"
+    webhook_event "run_complete" \
+        status "success" \
+        tokens_input "$_TOTAL_TOKENS_IN" \
+        tokens_output "$_TOTAL_TOKENS_OUT" \
+        tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
+        turns "$_TOTAL_TURNS" \
+        duration_ms "$_duration_ms_ok"
     _RUN_COMPLETE_SENT=1
 }
 

--- a/agent/scripts/tests/test_run_manager_helpers.sh
+++ b/agent/scripts/tests/test_run_manager_helpers.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# test_run_manager_helpers.sh - Smoke tests for run-manager.sh helpers
+# Covers issues #185 (json_get / ensure_gh_token shell-into-Python interpolation)
+# and #180 (build_webhook_json / webhook_event JSON construction).
+#
+# Run with: bash agent/scripts/tests/test_run_manager_helpers.sh
+# Exits 0 on success, non-zero on failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_MANAGER="$SCRIPT_DIR/../run-manager.sh"
+
+if [ ! -f "$RUN_MANAGER" ]; then
+    echo "ERROR: cannot find $RUN_MANAGER" >&2
+    exit 2
+fi
+
+# Sourcing run-manager.sh requires sourcing integration-branch.sh which is
+# fine — it only defines functions. Suppress its lib-source side effects by
+# providing a placeholder STATION_CONFIG so json_get can be exercised.
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Source the script in test mode (BASH_SOURCE differs from $0 -> main NOT run).
+# shellcheck source=../run-manager.sh
+. "$RUN_MANAGER"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $name"
+    else
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$name: expected [$expected] got [$actual]")
+        echo "  FAIL: $name"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+    fi
+}
+
+assert_contains() {
+    local name="$1" needle="$2" haystack="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $name"
+    else
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$name: substring [$needle] not found in [$haystack]")
+        echo "  FAIL: $name"
+        echo "    needle:   $needle"
+        echo "    haystack: $haystack"
+    fi
+}
+
+assert_json_valid() {
+    local name="$1" payload="$2"
+    if printf '%s' "$payload" | python3 -c "import json,sys; json.loads(sys.stdin.read())" 2>/dev/null; then
+        PASS=$((PASS + 1))
+        echo "  PASS: $name"
+    else
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$name: payload is not valid JSON: $payload")
+        echo "  FAIL: $name"
+        echo "    payload: $payload"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Issue #185 — json_get / ensure_gh_token must use argv, not interpolation
+# ---------------------------------------------------------------------------
+echo "[#185] json_get tests"
+
+# Test fixture: simple nested JSON
+cat > "$TMPDIR/config.json" <<'JSON'
+{
+    "projects": [
+        {"name": "alpha", "enabled": true},
+        {"name": "beta", "enabled": false}
+    ],
+    "limits": {"max_concurrent": 3},
+    "value_with_quote": "it's tricky",
+    "missing_friendly": null
+}
+JSON
+
+assert_eq "json_get nested string" "alpha" "$(json_get "$TMPDIR/config.json" "projects.0.name")"
+assert_eq "json_get nested bool true" "true" "$(json_get "$TMPDIR/config.json" "projects.0.enabled")"
+assert_eq "json_get nested bool false" "false" "$(json_get "$TMPDIR/config.json" "projects.1.enabled")"
+assert_eq "json_get integer" "3" "$(json_get "$TMPDIR/config.json" "limits.max_concurrent")"
+assert_eq "json_get value containing single quote" "it's tricky" "$(json_get "$TMPDIR/config.json" "value_with_quote")"
+
+# Missing key returns non-zero and empty stdout
+missing_out="$(json_get "$TMPDIR/config.json" "projects.0.does_not_exist" || echo "MISSING")"
+assert_eq "json_get missing key returns MISSING sentinel" "MISSING" "$missing_out"
+
+# Path containing single quote and Python source — must NOT execute as code,
+# and must NOT crash json_get; expected to fail-key-lookup cleanly.
+INJECT_PATH="x';__import__('os').system('echo PWNED > $TMPDIR/pwned.txt')#"
+inj_out="$(json_get "$TMPDIR/config.json" "$INJECT_PATH" || echo "SAFE")"
+assert_eq "json_get injection path returns SAFE" "SAFE" "$inj_out"
+if [ -f "$TMPDIR/pwned.txt" ]; then
+    FAIL=$((FAIL + 1))
+    FAILURES+=("json_get path injection executed code (pwned.txt was created)")
+    echo "  FAIL: json_get path injection did NOT execute"
+else
+    PASS=$((PASS + 1))
+    echo "  PASS: json_get path injection did NOT execute"
+fi
+
+# File path containing a single quote should still work
+QUOTED_DIR="$TMPDIR/o'brien"
+mkdir -p "$QUOTED_DIR"
+cp "$TMPDIR/config.json" "$QUOTED_DIR/config.json"
+assert_eq "json_get with quoted file path" "alpha" "$(json_get "$QUOTED_DIR/config.json" "projects.0.name")"
+
+# Returns full nested object as JSON
+nested="$(json_get "$TMPDIR/config.json" "limits")"
+assert_json_valid "json_get returns valid JSON for object" "$nested"
+assert_contains "json_get nested object contents" "max_concurrent" "$nested"
+
+# ---------------------------------------------------------------------------
+# Issue #185 — ensure_gh_token also uses argv-safe Python
+# ---------------------------------------------------------------------------
+echo "[#185] ensure_gh_token tests"
+
+# Build a fake token file; verify ensure_gh_token loads it. Override $HOME.
+SAVED_HOME="$HOME"
+SAVED_GH_TOKEN="${GH_TOKEN:-}"
+export HOME="$TMPDIR/fakehome"
+mkdir -p "$HOME/.claude-agent-station"
+cat > "$HOME/.claude-agent-station/github_token" <<'JSON'
+{"access_token": "ghs_safe_test_token_42"}
+JSON
+unset GH_TOKEN
+ensure_gh_token
+assert_eq "ensure_gh_token loads access_token from file" "ghs_safe_test_token_42" "${GH_TOKEN:-}"
+
+# A token file path with a single quote should also work (we'll override
+# the function's expectation by constructing $HOME with a quote in it).
+unset GH_TOKEN
+QUOTED_HOME="$TMPDIR/o'brien-home"
+mkdir -p "$QUOTED_HOME/.claude-agent-station"
+cat > "$QUOTED_HOME/.claude-agent-station/github_token" <<'JSON'
+{"access_token": "ghs_quoted_path_token"}
+JSON
+HOME="$QUOTED_HOME" ensure_gh_token
+assert_eq "ensure_gh_token works with quoted HOME path" "ghs_quoted_path_token" "${GH_TOKEN:-}"
+
+export HOME="$SAVED_HOME"
+if [ -n "$SAVED_GH_TOKEN" ]; then
+    export GH_TOKEN="$SAVED_GH_TOKEN"
+else
+    unset GH_TOKEN
+fi
+
+# ---------------------------------------------------------------------------
+# Issue #180 — build_webhook_json constructs valid JSON via json.dumps
+# ---------------------------------------------------------------------------
+echo "[#180] build_webhook_json tests"
+
+simple="$(build_webhook_json "run_start" "run-1" project "owner/repo" project_count 5)"
+assert_json_valid "build_webhook_json simple call is valid JSON" "$simple"
+assert_contains "build_webhook_json includes event field" '"event": "run_start"' "$simple"
+assert_contains "build_webhook_json includes run_id" '"run_id": "run-1"' "$simple"
+assert_contains "build_webhook_json string field quoted" '"project": "owner/repo"' "$simple"
+# project_count must be numeric (no quotes around 5)
+assert_contains "build_webhook_json int field unquoted" '"project_count": 5' "$simple"
+
+# Boolean and null coercion
+bool_out="$(build_webhook_json "evt" "run-1" enabled true paused false placeholder null)"
+assert_contains "build_webhook_json true unquoted" '"enabled": true' "$bool_out"
+assert_contains "build_webhook_json false unquoted" '"paused": false' "$bool_out"
+assert_contains "build_webhook_json null unquoted" '"placeholder": null' "$bool_out"
+
+# Float coercion
+float_out="$(build_webhook_json "evt" "run-1" confidence 0.85)"
+assert_contains "build_webhook_json float unquoted" '"confidence": 0.85' "$float_out"
+
+# Reasoning with quotes / newlines / backslashes round-trips correctly
+NASTY=$'It\'s a "great" fix\nwith newlines and a backslash \\'
+nasty_out="$(build_webhook_json "verdict_execute" "run-1" reasoning "$NASTY")"
+assert_json_valid "build_webhook_json nasty string is valid JSON" "$nasty_out"
+roundtrip="$(printf '%s' "$nasty_out" | python3 -c "import json,sys; print(json.load(sys.stdin)['reasoning'])")"
+assert_eq "build_webhook_json reasoning round-trips" "$NASTY" "$roundtrip"
+
+# Empty string allowed
+empty_out="$(build_webhook_json "evt" "run-1" branch "")"
+assert_contains "build_webhook_json empty string preserved" '"branch": ""' "$empty_out"
+
+# Negative integer
+neg_out="$(build_webhook_json "evt" "run-1" exit_code -1)"
+assert_contains "build_webhook_json negative int unquoted" '"exit_code": -1' "$neg_out"
+
+# Number-looking string with leading zero stays numeric only if isdigit
+# (Plain integer literals — '0' should stay int(0); '007' is also int(7).)
+zero_out="$(build_webhook_json "evt" "run-1" exit_code 0)"
+assert_contains "build_webhook_json zero int unquoted" '"exit_code": 0' "$zero_out"
+
+# Timestamp is auto-injected
+ts_out="$(build_webhook_json "evt" "run-1")"
+assert_contains "build_webhook_json adds timestamp" '"timestamp"' "$ts_out"
+
+# Odd number of kv args: trailing key without value is ignored, no crash
+trail_out="$(build_webhook_json "evt" "run-1" key1 v1 dangling)"
+assert_json_valid "build_webhook_json odd-kv tail is still valid JSON" "$trail_out"
+assert_contains "build_webhook_json odd-kv keeps prior pair" '"key1": "v1"' "$trail_out"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo
+echo "============================================"
+echo "Tests passed: $PASS"
+echo "Tests failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+    echo
+    echo "Failures:"
+    for f in "${FAILURES[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #185
Closes #180

## Summary

`agent/scripts/run-manager.sh` had three classes of unsafe shell-into-Python / shell-into-JSON interpolation. This PR closes both linked issues in a single PR because they touch overlapping code (`json_get` is called by `webhook_event`, etc.) and would have created merge conflicts otherwise.

### Issue #185 — `json_get` / `ensure_gh_token` inline bash vars into Python source

Both helpers used `python3 -c "..."` with `'$file'` / `'$path'` / `'$token_file'` substituted directly into the source text. A single quote in any value silently broke the helper (callers got an empty string and fell through to defaults), and an untrusted value would have been straight code execution.

Fix: convert both to heredoc-quoted (`<<'PYEOF'`) Python programs that receive the file path / dotted path via argv. The single-quoted heredoc disables bash variable expansion inside the Python source, and the OS argument-passing mechanism is what makes the values inert.

### Issue #180 — `webhook_event` builds JSON by string interpolation

`webhook_event` (and the `notify()` webhook branch) built the request body with f-string-style interpolation, e.g. ``-d "{\"reasoning\":\"$reasoning\",..."``. Verdict reasoning routinely contains quotes and newlines; the only call site that worked was `verdict_execute`, which manually pre-escaped via `json.dumps[1:-1]`. Anything else with a quote in the value would have produced malformed JSON or been silently truncated by the backend.

Fix: introduced `build_webhook_json EVENT RUN_ID [key value]...` which builds the payload with `python3 json.dumps`. Values matching `true`/`false`/`null` or numeric literals are auto-coerced to JSON booleans/null/numbers so existing typed fields (`exit_code: 3`, `enabled: true`) keep their wire format. Rewrote `webhook_event` to call it, and updated all 15 callers across the script (lines 338, 712, 722, 726, 854, 1338, 1567, 1715, 1954, 2297, 2474, 2614, 2624, 2770) plus the `notify()` webhook branch (lines 88-92) to pass kv pairs as separate args.

### Backward compatibility

The dashboard webhook backend (`WebhookRunEvent` in `dashboard/backend/app/schemas.py`) accepts the same field names; Pydantic is non-strict so extra fields like `exit_code`/`webhook_url`/`pr_url` continue to be ignored as before. No backend changes were needed.

## Test plan

- [x] `bash agent/scripts/tests/test_run_manager_helpers.sh` — 30 tests pass; covers nested gets, bool/int/missing-key handling, file paths with single quotes, and a path-injection probe (`x';__import__('os').system(...)#`) that confirms arbitrary code is no longer executable through `json_get`. Also exercises `build_webhook_json` for valid-JSON output, numeric/bool/null coercion, and a reasoning string with quotes/newlines/backslashes that round-trips correctly.
- [x] `bash -n agent/scripts/run-manager.sh` — clean.
- [x] `python3 -m pytest dashboard/backend/tests/ -x` — 767 passed, 54 skipped (the run-manager change shouldn't affect the backend, verified).
- [ ] Manual: trigger a real run on the staging VM and confirm `run_start` / `verdict_execute` / `run_complete` events still land on the dashboard with the same field shapes.

## Out of scope / risks

- Two raw curl POSTs at lines 850 and 1345 (`employee_start` / `employee_complete`) still build JSON via shell-string interpolation. Their inputs are internal vars (`$repo`, `$mode`, `$employee_index`, etc.) and not user-controlled, but they share the same anti-pattern. Left untouched per the no-unrelated-refactor constraint — worth a follow-up issue.
- shellcheck wasn't available on the worker VM so this PR didn't add a shellcheck pass; `bash -n` is clean.