### PR TITLE
fix: route employee_start/complete events through build_webhook_json (run-manager.sh follow-up)

### DIFF
--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -931,10 +931,16 @@ run_employee() {
     _ewh_secret="${STATION_WEBHOOK_SECRET:-$(json_get "$CONFIG_FILE" "dashboard.webhook_secret" 2>/dev/null || echo "")}"
     local -a _ewh_auth=()
     [ -n "$_ewh_secret" ] && _ewh_auth=(-H "X-Webhook-Token: $_ewh_secret")
+    local _emp_start_payload
+    _emp_start_payload=$(build_webhook_json "employee_start" "$employee_run_id" \
+        project "$repo" \
+        mode "$mode" \
+        employee_index "$employee_index" \
+        concurrent_group_id "${CONCURRENT_GROUP_ID:-run-$RUN_ID}")
     curl -s --max-time 3 -X POST "$_ewh_url" \
         -H "Content-Type: application/json" \
         "${_ewh_auth[@]}" \
-        -d "{\"event\":\"employee_start\",\"run_id\":\"$employee_run_id\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"project\":\"$repo\",\"mode\":\"$mode\",\"employee_index\":$employee_index,\"concurrent_group_id\":\"${CONCURRENT_GROUP_ID:-run-$RUN_ID}\"}" \
+        -d "$_emp_start_payload" \
         2>/dev/null || true
     # Emit role-specific presence event for planner mode
     if [ "$mode" = "plan" ]; then
@@ -1431,10 +1437,20 @@ print(f'{t:,}')
     fi
 
     # Use employee-specific run_id to complete the correct Run record
+    local _emp_complete_payload
+    _emp_complete_payload=$(build_webhook_json "employee_complete" "$employee_run_id" \
+        project "$repo" \
+        exit_code "$exit_code" \
+        employee_index "$employee_index" \
+        concurrent_group_id "${CONCURRENT_GROUP_ID:-run-$RUN_ID}" \
+        tokens_input "$_et_in" \
+        tokens_output "$_et_out" \
+        tokens_total "$_et_total" \
+        turns "$_et_turns")
     curl -s --max-time 3 -X POST "$_ewh_url" \
         -H "Content-Type: application/json" \
         "${_ewh_auth[@]}" \
-        -d "{\"event\":\"employee_complete\",\"run_id\":\"$employee_run_id\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"project\":\"$repo\",\"exit_code\":$exit_code,\"employee_index\":$employee_index,\"concurrent_group_id\":\"${CONCURRENT_GROUP_ID:-run-$RUN_ID}\",\"tokens_input\":$_et_in,\"tokens_output\":$_et_out,\"tokens_total\":$_et_total,\"turns\":$_et_turns}" \
+        -d "$_emp_complete_payload" \
         2>/dev/null || true
 
     # Transition queue item to review

--- a/agent/scripts/tests/test_run_manager_helpers.sh
+++ b/agent/scripts/tests/test_run_manager_helpers.sh
@@ -212,6 +212,63 @@ assert_json_valid "build_webhook_json odd-kv tail is still valid JSON" "$trail_o
 assert_contains "build_webhook_json odd-kv keeps prior pair" '"key1": "v1"' "$trail_out"
 
 # ---------------------------------------------------------------------------
+# Employee event shapes (follow-up to #255)
+# ---------------------------------------------------------------------------
+echo "[#255 follow-up] employee_start / employee_complete event shapes"
+
+# employee_start: spaces in project, numeric employee_index
+emp_start="$(build_webhook_json "employee_start" "run-X" \
+    project "owner/repo with spaces" \
+    mode "auto" \
+    employee_index 2 \
+    concurrent_group_id "grp-1")"
+assert_json_valid "employee_start valid JSON" "$emp_start"
+assert_contains "employee_start event field" '"event": "employee_start"' "$emp_start"
+assert_contains "employee_start run_id field" '"run_id": "run-X"' "$emp_start"
+assert_eq "employee_start employee_index is number" \
+    "2" \
+    "$(printf '%s' "$emp_start" | python3 -c "import json,sys; v=json.load(sys.stdin)['employee_index']; print(type(v).__name__, v)" | awk '{print $2}')"
+emp_start_project="$(printf '%s' "$emp_start" | python3 -c "import json,sys; print(json.load(sys.stdin)['project'])")"
+assert_eq "employee_start project round-trips spaces" "owner/repo with spaces" "$emp_start_project"
+
+# Confirm employee_index is JSON int, not string
+emp_idx_type="$(printf '%s' "$emp_start" | python3 -c "import json,sys; v=json.load(sys.stdin)['employee_index']; print(type(v).__name__)")"
+assert_eq "employee_start employee_index is JSON int type" "int" "$emp_idx_type"
+
+# project with quotes, backslash, dollar sign, and newline — must round-trip exactly
+NASTY_PROJECT=$'"owner/repo" with \\backslash $dollar\nand newline'
+nasty_start="$(build_webhook_json "employee_start" "run-X" \
+    project "$NASTY_PROJECT" \
+    mode "auto" \
+    employee_index 0 \
+    concurrent_group_id "grp-1")"
+assert_json_valid "employee_start nasty project is valid JSON" "$nasty_start"
+nasty_project_rt="$(printf '%s' "$nasty_start" | python3 -c "import json,sys; print(json.load(sys.stdin)['project'])")"
+assert_eq "employee_start nasty project round-trips" "$NASTY_PROJECT" "$nasty_project_rt"
+
+# tokens_total edge cases: 0, large value, negative -1
+tok_zero="$(build_webhook_json "employee_complete" "run-X" \
+    project "owner/repo" exit_code 0 employee_index 0 \
+    concurrent_group_id "grp-1" \
+    tokens_input 0 tokens_output 0 tokens_total 0 turns 0)"
+assert_json_valid "employee_complete tokens_total=0 valid JSON" "$tok_zero"
+assert_contains "employee_complete tokens_total 0 is number" '"tokens_total": 0' "$tok_zero"
+
+tok_large="$(build_webhook_json "employee_complete" "run-X" \
+    project "owner/repo" exit_code 0 employee_index 0 \
+    concurrent_group_id "grp-1" \
+    tokens_input 1000000 tokens_output 234567 tokens_total 1234567890 turns 42)"
+assert_json_valid "employee_complete large tokens valid JSON" "$tok_large"
+assert_contains "employee_complete tokens_total large is number" '"tokens_total": 1234567890' "$tok_large"
+
+tok_neg="$(build_webhook_json "employee_complete" "run-X" \
+    project "owner/repo" exit_code 0 employee_index 0 \
+    concurrent_group_id "grp-1" \
+    tokens_input 0 tokens_output 0 tokens_total -1 turns 0)"
+assert_json_valid "employee_complete tokens_total=-1 valid JSON" "$tok_neg"
+assert_contains "employee_complete tokens_total -1 is number" '"tokens_total": -1' "$tok_neg"
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo


### PR DESCRIPTION
## Summary

This is the follow-up to PR #255 which hardened run-manager.sh against shell-string JSON injection via the `build_webhook_json` helper. Two `curl -d "{...}"` sites were explicitly called out as follow-up work:

- **Line ~937**: `employee_start` event — interpolated `$repo`, `$mode`, `$employee_index`, `$CONCURRENT_GROUP_ID`, and `$RUN_ID` directly into the JSON string
- **Line ~1437**: `employee_complete` event — same problem plus `$exit_code`, `$_et_in`, `$_et_out`, `$_et_total`, `$_et_turns`

Both are now replaced with `build_webhook_json`, which routes all values through `python3 json.dumps`, guaranteeing correct escaping regardless of what characters appear in repo names, mode strings, or numeric fields. Numeric fields (`employee_index`, `exit_code`, `tokens_*`, `turns`) are auto-coerced to JSON numbers by the helper's coercion logic (no quotes).

The existing `|| true` error semantics, `--max-time 3`, `>/dev/null 2>&1`, and `X-Webhook-Token` secret header are all preserved unchanged.

## Tests

14 new assertions added to `agent/scripts/tests/test_run_manager_helpers.sh`:

- `employee_start` shape: valid JSON, correct `event`/`run_id`, `employee_index` is a JSON int (not string), `project` with spaces round-trips correctly
- `employee_start` with `project` containing `"`, `\`, `$`, and `\n` — JSON parses and round-trips exactly
- `tokens_total` at 0, 1234567890, and -1 all survive as JSON numbers
- `bash -n` syntax check passes
- All 44 tests pass; 767 backend pytest tests unchanged

## Test plan

- [x] `bash -n agent/scripts/run-manager.sh` exits 0
- [x] `bash agent/scripts/tests/test_run_manager_helpers.sh` exits 0 (44/44 pass, 14 new)
- [x] `python3 -m pytest tests/ -x` from `dashboard/backend/` — 767 passed, 54 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)