### PR TITLE
ci: wire test_install.sh into CI + add README badge (#186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # NOTE: tests/test_install.sh is currently failing on main for
-      # unrelated reasons and is intentionally not run here. Wire it in
-      # via a separate PR once those failures are fixed.
       - name: Run setup_script validator test suite
         run: bash tests/test_setup_script_validation.sh
+
+      - name: Run install.sh test suite
+        run: bash tests/test_install.sh
 
   backend:
     name: backend (pytest)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Claude Agent Station
 
+[![ci](https://github.com/kenhaesler/claude-agent-station/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/kenhaesler/claude-agent-station/actions/workflows/ci.yml)
+
 Self-hosted autonomous Claude Code agent with a web dashboard.
 
 **What it does**: Runs Claude Code agent teams on a schedule to work on your GitHub repositories — implementing features, fixing bugs, and creating issues. A lead agent coordinates teammates that each tackle a single issue. A web dashboard provides real-time visibility into team activity.

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -40,7 +40,10 @@ assert_contains() {
     local haystack="$2"
     local needle="$3"
     TOTAL=$((TOTAL + 1))
-    if echo "$haystack" | grep -q "$needle"; then
+    # Why here-string: under `set -o pipefail`, `echo "$haystack" | grep -q ...`
+    # can return non-zero when grep exits on its first match and echo dies with
+    # SIGPIPE — turning a real PASS into a spurious FAIL.
+    if grep -q -- "$needle" <<<"$haystack"; then
         PASS=$((PASS + 1))
         echo -e "${GREEN}PASS${NC}: ${test_name}"
     else


### PR DESCRIPTION
## Summary
Closes the last two open items from #186:

- Wires `tests/test_install.sh` into the `shell-tests` CI job. The previous skip note ("currently failing on main for unrelated reasons") turned out to be wrong — install.sh itself was fine; the test harness was buggy.
- Adds a CI status badge to `README.md`.

### Why the test was failing
`assert_contains` used `echo "$haystack" | grep -q "$needle"` under `set -o pipefail`. `grep -q` exits on first match; `echo` then dies with SIGPIPE; pipefail returns the SIGPIPE status; the `if` branch reports a spurious FAIL even though grep matched (exit 0). Failures depended on where in the script the match occurred and pipe-buffer timing — that's why the failure list shifted between runs.

Replaced the pipeline with a here-string (`grep -q -- "$needle" <<<"$haystack"`), which has no pipe and no SIGPIPE. All 43 assertions now pass against the current `install.sh`.

## Test plan
- [x] `bash tests/test_install.sh` → 43/43 pass locally
- [ ] CI run on this PR shows the new `Run install.sh test suite` step green
- [ ] README badge renders on the PR / branch view

🤖 Generated with [Claude Code](https://claude.com/claude-code)