### PR TITLE
perf(db): add indexes to runs filter columns (#191)

### DIFF
--- a/dashboard/backend/app/database.py
+++ b/dashboard/backend/app/database.py
@@ -88,15 +88,35 @@ async def _migrate_add_columns(conn) -> None:
         ("projects", "vision_cached_body", "ALTER TABLE projects ADD COLUMN vision_cached_body TEXT"),
         ("projects", "vision_cached_at",   "ALTER TABLE projects ADD COLUMN vision_cached_at DATETIME"),
     ]
+    # `table` and `sql` below are hardcoded literals from the migrations tuple
+    # list above; PRAGMA + ALTER TABLE do not support bound parameters for
+    # identifiers, so f-strings are required.
     for table, column, sql in migrations:
         try:
-            result = await conn.execute(text(f"PRAGMA table_info({table})"))
+            result = await conn.execute(text(f"PRAGMA table_info({table})"))  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
             columns = [row[1] for row in result.fetchall()]
             if column not in columns:
-                await conn.execute(text(sql))
+                await conn.execute(text(sql))  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
                 logger.info("Migration: added %s.%s", table, column)
         except Exception as e:
             logger.debug("Migration skip %s.%s: %s", table, column, e)
+
+    # Indexes on runs columns used by list/filter/analytics queries (issue #191).
+    # SQLAlchemy's create_all creates indexes from model declarations on fresh
+    # databases, but columns added later via ALTER TABLE never get indexed
+    # unless we do it explicitly here. CREATE INDEX IF NOT EXISTS is idempotent.
+    index_migrations = [
+        "CREATE INDEX IF NOT EXISTS ix_runs_status ON runs(status)",
+        "CREATE INDEX IF NOT EXISTS ix_runs_project_id ON runs(project_id)",
+        "CREATE INDEX IF NOT EXISTS ix_runs_verdict ON runs(verdict)",
+        "CREATE INDEX IF NOT EXISTS ix_runs_started_at ON runs(started_at)",
+        "CREATE INDEX IF NOT EXISTS ix_runs_concurrent_group_id ON runs(concurrent_group_id)",
+    ]
+    for sql in index_migrations:
+        try:
+            await conn.execute(text(sql))  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        except Exception as e:
+            logger.debug("Index migration skip: %s: %s", sql, e)
 
 
 async def init_db():

--- a/dashboard/backend/app/models.py
+++ b/dashboard/backend/app/models.py
@@ -48,11 +48,11 @@ class Run(Base):
 
     id = Column(Integer, primary_key=True)
     run_id = Column(Text, nullable=False, unique=True)
-    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True)
+    project_id = Column(Integer, ForeignKey("projects.id"), nullable=True, index=True)
     mode = Column(Text, nullable=True)
     model = Column(Text, nullable=True)
-    status = Column(Text, nullable=True)  # running/success/failed
-    verdict = Column(Text, nullable=True)  # APPROVE/PR/REJECT/null
+    status = Column(Text, nullable=True, index=True)  # running/success/failed
+    verdict = Column(Text, nullable=True, index=True)  # APPROVE/PR/REJECT/null
     issue_number = Column(Integer, nullable=True)
     branch = Column(Text, nullable=True)
     cost_usd = Column(Float, nullable=True)  # Deprecated: kept for historical data
@@ -61,14 +61,14 @@ class Run(Base):
     tokens_total = Column(Integer, nullable=True)
     turns = Column(Integer, nullable=True)
     duration_ms = Column(Integer, nullable=True)
-    started_at = Column(DateTime, nullable=True)
+    started_at = Column(DateTime, nullable=True, index=True)
     finished_at = Column(DateTime, nullable=True)
     employee_report = Column(Text, nullable=True)  # JSON as text
     verdict_detail = Column(Text, nullable=True)  # JSON as text
     log_file = Column(Text, nullable=True)
     trace_id = Column(Text, nullable=True)
     employee_index = Column(Integer, nullable=True, default=0)
-    concurrent_group_id = Column(Text, nullable=True)
+    concurrent_group_id = Column(Text, nullable=True, index=True)
     # Agent Teams fields
     team_name = Column(Text, nullable=True)
     team_members = Column(Text, nullable=True)  # JSON: [{agent_id, name, status}]

--- a/dashboard/backend/tests/test_migrations.py
+++ b/dashboard/backend/tests/test_migrations.py
@@ -125,6 +125,63 @@ async def test_migration_is_idempotent(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_runs_indexes_added_to_existing_database(tmp_path):
+    """An older DB without indexes on runs filter columns should gain them after migration (issue #191)."""
+    db_path = tmp_path / "indexes_test.db"
+
+    # Create a runs table without any of the target indexes.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE runs (
+            id INTEGER PRIMARY KEY,
+            run_id TEXT NOT NULL UNIQUE,
+            project_id INTEGER,
+            status TEXT,
+            verdict TEXT,
+            started_at DATETIME,
+            concurrent_group_id TEXT
+        )
+    """)
+    conn.commit()
+
+    cursor = conn.execute("PRAGMA index_list(runs)")
+    existing = {row[1] for row in cursor.fetchall()}
+    expected = {
+        "ix_runs_status",
+        "ix_runs_project_id",
+        "ix_runs_verdict",
+        "ix_runs_started_at",
+        "ix_runs_concurrent_group_id",
+    }
+    assert expected.isdisjoint(existing)
+    conn.close()
+
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    test_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+
+    # Run migration twice to confirm idempotency.
+    async with test_engine.begin() as aconn:
+        await _migrate_add_columns(aconn)
+    async with test_engine.begin() as aconn:
+        await _migrate_add_columns(aconn)
+
+    await test_engine.dispose()
+
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.execute("PRAGMA index_list(runs)")
+    found = {row[1] for row in cursor.fetchall()}
+    assert expected.issubset(found), f"missing indexes: {expected - found}"
+
+    # EXPLAIN QUERY PLAN should report an index scan, not a full table scan,
+    # for a status filter on the runs table.
+    cursor = conn.execute("EXPLAIN QUERY PLAN SELECT * FROM runs WHERE status = 'running'")
+    plan = " ".join(str(row) for row in cursor.fetchall())
+    assert "ix_runs_status" in plan, f"expected index scan, got plan: {plan}"
+    conn.close()
+
+
+@pytest.mark.asyncio
 async def test_dag_json_read_write_after_migration(tmp_path):
     """After migration, CoordinatorTask.dag_json should be readable/writable."""
     db_path = tmp_path / "rw_test.db"


### PR DESCRIPTION
## Summary
- Adds indexes on `runs.status`, `runs.project_id`, `runs.verdict`, `runs.started_at`, and `runs.concurrent_group_id` so the filter/list/analytics queries stop full-scanning the table as history grows.
- New deployments get the indexes via SQLAlchemy `create_all`; existing deployments pick them up through idempotent `CREATE INDEX IF NOT EXISTS` statements added to `_migrate_add_columns`.
- Includes a regression test that builds an old-schema runs table, runs the migration twice, and asserts both that all five indexes exist and that `EXPLAIN QUERY PLAN` for `WHERE status = 'running'` uses `ix_runs_status` instead of a scan.

Closes #191.

## Test plan
- [x] `pytest tests/test_migrations.py` — 4 passed (including new `test_runs_indexes_added_to_existing_database`).
- [x] `pytest tests/test_runs.py tests/test_analytics.py` — 25 passed.
- [x] Full backend `pytest` — 852 passed, 54 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)