### PR TITLE
fix(plan-usage): align is_throttled with should_throttle threshold (#195)

### DIFF
--- a/dashboard/backend/app/routers/plan_usage.py
+++ b/dashboard/backend/app/routers/plan_usage.py
@@ -203,7 +203,10 @@ async def get_plan_usage(
         weekly_usage_percent=round(weekly_pct, 2),
         weekly_reset_at=next_reset.isoformat(),
         per_model=per_model,
-        is_throttled=should_throttle and weekly_pct >= 95.0,
+        # is_throttled mirrors should_throttle. They previously diverged because
+        # is_throttled used a hardcoded 95% threshold while should_throttle used
+        # the configurable max_usage_percent (default 85%) — see issue #195.
+        is_throttled=should_throttle,
         should_throttle=should_throttle,
         throttle_reason=throttle_reason,
     )
@@ -226,6 +229,7 @@ async def get_plan_usage_history(
 @router.post("/snapshot")
 async def record_usage_snapshot(
     plan_tier: str = Query("max_5x"),
+    max_usage_percent: float = Query(85.0, description="Threshold for throttle warning"),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Record a usage snapshot to history (called periodically or on-demand)."""
@@ -285,7 +289,7 @@ async def record_usage_snapshot(
         weekly_usage_percent=round(weekly_pct, 2),
         weekly_reset_at=next_reset.isoformat(),
         per_model_json=json.dumps(per_model_data),
-        is_throttled=weekly_pct >= 95.0,
+        is_throttled=weekly_pct >= max_usage_percent,
     )
     db.add(snapshot)
     await db.commit()

--- a/dashboard/backend/tests/test_plan_usage.py
+++ b/dashboard/backend/tests/test_plan_usage.py
@@ -133,6 +133,45 @@ async def test_get_plan_usage_per_model_breakdown(client, sample_runs):
 
 
 @pytest.mark.asyncio
+async def test_is_throttled_matches_should_throttle_above_threshold(client):
+    """Regression for issue #195: is_throttled and should_throttle must agree.
+
+    The GET endpoint previously used a hardcoded 95% threshold for is_throttled
+    while should_throttle used the configurable max_usage_percent (default 85%).
+    For weekly usage between max_usage_percent and 95%, the two booleans
+    disagreed — should_throttle=True but is_throttled=False.
+    """
+    # Pro tier weekly default limit = 180_000_000. 88% = 158_400_000 tokens.
+    target_tokens = 158_400_000
+    async with async_session() as session:
+        project = Project(repo="owner/throttle-repo", enabled=True)
+        session.add(project)
+        await session.flush()
+        session.add(
+            Run(
+                run_id="throttle-run-001",
+                project_id=project.id,
+                status="completed",
+                model="claude-sonnet-4-6",
+                tokens_input=target_tokens // 2,
+                tokens_output=target_tokens // 2,
+                tokens_total=target_tokens,
+                started_at=datetime.now(timezone.utc) - timedelta(hours=1),
+            )
+        )
+        await session.commit()
+
+    resp = await client.get("/api/plan-usage?plan_tier=pro&max_usage_percent=85")
+    assert resp.status_code == 200
+    data = resp.json()
+    # Sanity: weekly_pct landed in the previously-buggy band (85% <= pct < 95%).
+    assert 85.0 <= data["weekly_usage_percent"] < 95.0
+    assert data["should_throttle"] is True
+    assert data["is_throttled"] is True
+    assert data["is_throttled"] == data["should_throttle"]
+
+
+@pytest.mark.asyncio
 async def test_get_plan_usage_weekly_reset(client):
     """GET /api/plan-usage should include weekly_reset_at timestamp."""
     resp = await client.get("/api/plan-usage")


### PR DESCRIPTION
## Summary
- `is_throttled` previously used a hardcoded 95% threshold while `should_throttle` used the configurable `max_usage_percent` (default 85%). For weekly usage between 85% and 94.9%, the two booleans disagreed: `should_throttle=True`, `is_throttled=False`. Dashboard consumers reading `is_throttled` would see `False` even with throttle active.
- **GET /api/plan-usage**: `is_throttled` now mirrors `should_throttle` — picks up both the weekly-percent and the per-model triggers.
- **POST /api/plan-usage/snapshot**: adds `max_usage_percent` query parameter (default 85.0) and uses it instead of hardcoded `95.0`.
- New regression test places weekly usage in the previously-buggy 85–95% band and asserts both booleans agree. Verified to fail against the unfixed code.

## Scope note
Issue #195 originally asked for four new test files + the bug fix. The four test files (`test_plan_usage.py`, `test_prompts.py`, `test_system.py`, `test_config.py`) already exist in the repo, so this PR addresses only the still-relevant remaining work: the `is_throttled` logic bug and one targeted regression test.

Closes #195.

## Test plan
- [x] `pytest tests/test_plan_usage.py` — 12 passed (11 existing + 1 new regression).
- [x] Stash-and-rerun verified the new test fails against the buggy code (`assert False is True` on `is_throttled`).
- [x] Full backend `pytest` — 853 passed, 54 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)