### PR TITLE
fix(audit): attribute teammate tool calls via SDK agent_id (#262)

### DIFF
--- a/agent/audit_hook.py
+++ b/agent/audit_hook.py
@@ -332,6 +332,17 @@ def make_pre_tool_hook(
             tool_name = input_data.get("tool_name") if isinstance(input_data, dict) else getattr(input_data, "tool_name", "")
             tool_input = input_data.get("tool_input") if isinstance(input_data, dict) else getattr(input_data, "tool_input", {})
             tool_use_id = input_data.get("tool_use_id") if isinstance(input_data, dict) else getattr(input_data, "tool_use_id", None)
+            # Sub-agent attribution: the SDK populates ``agent_id`` on tool-
+            # lifecycle hook inputs when the call originated inside an Agent
+            # Teams teammate. Use it to label the audit row correctly so the
+            # timeline can distinguish lead vs. teammate work. Falls back to
+            # the configured ``actor`` for main-thread tool calls.
+            sub_agent_id = (
+                input_data.get("agent_id")
+                if isinstance(input_data, dict)
+                else getattr(input_data, "agent_id", None)
+            )
+            row_actor = f"teammate-{sub_agent_id}" if sub_agent_id else actor
             if tool_use_id:
                 # Off-load the blocking sqlite3 write so the orchestrator's
                 # event loop is not held up by WAL contention.
@@ -339,7 +350,7 @@ def make_pre_tool_hook(
                     write_audit_start,
                     idempotency_key=str(tool_use_id),
                     run_id=run_id,
-                    actor=actor,
+                    actor=row_actor,
                     tool_name=str(tool_name or ""),
                     tool_input=tool_input or {},
                     trace_id=trace_id,

--- a/dashboard/backend/tests/test_audit_hook_log.py
+++ b/dashboard/backend/tests/test_audit_hook_log.py
@@ -269,6 +269,45 @@ def test_pre_then_post_hooks_compose_end_to_end(tmp_path):
     assert r["finished_at"] is not None
 
 
+def test_pre_hook_attributes_to_teammate_when_agent_id_present(tmp_path):
+    """SDK populates agent_id on hook inputs from sub-agents — use it for actor."""
+    db = tmp_path / "test.db"
+    _init_audit_db(db)
+
+    pre = make_pre_tool_hook(run_id="run-h", actor="lead", db_path=str(db))
+    asyncio.run(pre(
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "true"},
+            "tool_use_id": "tu_team",
+            "agent_id": "issue-worker",
+        },
+        None,
+        {"signal": None},
+    ))
+
+    rows = _rows(db)
+    assert len(rows) == 1
+    assert rows[0]["actor"] == "teammate-issue-worker"
+
+
+def test_pre_hook_falls_back_to_lead_when_agent_id_absent(tmp_path):
+    """Main-thread tool calls (no agent_id) keep the configured actor."""
+    db = tmp_path / "test.db"
+    _init_audit_db(db)
+
+    pre = make_pre_tool_hook(run_id="run-h", actor="lead", db_path=str(db))
+    asyncio.run(pre(
+        {"tool_name": "Bash", "tool_input": {}, "tool_use_id": "tu_lead"},
+        None,
+        {"signal": None},
+    ))
+
+    rows = _rows(db)
+    assert len(rows) == 1
+    assert rows[0]["actor"] == "lead"
+
+
 def test_hooks_are_silent_when_tool_use_id_missing(tmp_path):
     db = tmp_path / "test.db"
     _init_audit_db(db)


### PR DESCRIPTION
Closes #262.

## Summary
- PR #261 already captures teammate tool calls in \`audit_log\` (the SDK propagates \`PreToolUse\`/\`PostToolUse\` hooks to Agent Teams sub-agents and populates \`agent_id\` on the input). The bug was that \`make_pre_tool_hook\` hard-coded \`actor=\"lead\"\` and ignored the \`agent_id\` field, so every row — including teammate calls — was labeled \"lead\".
- Read \`input_data[\"agent_id\"]\` in the pre-hook and write \`actor=\"teammate-<agent_id>\"\` when present; fall back to the configured \`actor\` for main-thread calls.
- No change to \`station_orchestrator.py\` needed — hook propagation is automatic. The post-hook also doesn't need updating because it only updates status/exit_code/tails on the existing row; \`actor\` is set at insert time.

## Why this is a small change
Initially I assumed teammate sessions would need separate \`ClaudeAgentOptions.hooks\` wiring. The SDK source (\`claude_agent_sdk/types.py:195\`, \`_SubagentContextMixin\`) clarifies this is unnecessary — sub-agent tool-lifecycle hooks interleave on the parent's hook channel, with \`agent_id\` as the attribution field. Discovery and reframing live in [issue #262](https://github.com/kenhaesler/claude-agent-station/issues/262#issuecomment-4404826130).

## Test plan
- [x] \`pytest tests/test_audit_hook_log.py\` — 14 tests pass (2 new: teammate attribution + lead fallback)
- [x] Full backend suite: 875 passed, 54 skipped — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)