### PR TITLE
fix(ui): Enabled toggle on ProjectDetail uses onchange, not onclick

### DIFF
--- a/dashboard/frontend/src/pages/ProjectDetail.svelte
+++ b/dashboard/frontend/src/pages/ProjectDetail.svelte
@@ -114,7 +114,7 @@
           </div>
           <div class="flex items-end">
             <Toggle checked={project.enabled} label="Enabled"
-              onclick={() => { project!.enabled = !project!.enabled; save('enabled', project!.enabled); }} />
+              onchange={(v) => { project!.enabled = v; save('enabled', v); }} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Fixes the Enabled toggle on the project detail page (e.g. for `next-itsm`) not staying on when clicked.

The `Toggle` component (`dashboard/frontend/src/components/forms/Toggle.svelte:6-12`) exposes its callback as `onchange?: (checked: boolean) => void`. `ProjectDetail.svelte:117` was passing `onclick` instead, which `Toggle` doesn't read. Result:

1. User clicks the toggle → Toggle's internal `toggle()` flips its local `checked` and calls `onchange?.(checked)`.
2. `onchange` is `undefined` (the parent passed `onclick`), so no save call fires and the parent's `project.enabled` is never updated.
3. On the next reactive update, `checked={project.enabled}` re-binds and snaps the toggle back to the stored (unchanged) value — making it look like the toggle refuses to stay on.

`SettingsPage.svelte:551,562` was already passing `onchange` correctly, so only `ProjectDetail` was affected. This was also the source of the existing svelte-check error:

```
ERROR "src/pages/ProjectDetail.svelte" 117:15 "Object literal may only specify known properties, and '\"onclick\"' does not exist in type '$$ComponentProps'."
```

## Test plan

- [x] `npx svelte-check` — `ProjectDetail.svelte:117` error is gone (6 errors → 5; remaining 5 are pre-existing in unrelated files).
- [x] `npm run build` — passes.
- [ ] Manual: open Projects → next-itsm → toggle Enabled off and on; reload the page and confirm state persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)