### PR TITLE
feat(agent): add Playwright and Ref MCP support

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    },
+    "ref": {
+      "url": "https://api.ref.tools/mcp"
+    }
+  }
+}

--- a/agent/agents/issue-worker.md
+++ b/agent/agents/issue-worker.md
@@ -1,7 +1,7 @@
 ---
 name: issue-worker
 description: Specialized teammate for agent teams. Works on tasks from the shared task list in an isolated git worktree.
-tools: Read, Edit, Write, Bash, Glob, Grep
+tools: Read, Edit, Write, Bash, Glob, Grep, mcp__playwright__*, mcp__ref__*
 model: claude-opus-4-7
 permissionMode: bypassPermissions
 maxTurns: 50

--- a/agent/auto_mode.py
+++ b/agent/auto_mode.py
@@ -148,6 +148,19 @@ async def policy_decide(
     if tool_name in SUBAGENT_TOOLS:
         return PermissionResultAllow()
 
+    # 3.2. MCP tools — allow at assisted+ level, refer at manual.
+    if tool_name.startswith("mcp__"):
+        if level is AutonomyLevel.MANUAL:
+            return await _defer_or_deny(
+                level=level,
+                tool_name=tool_name,
+                tool_input=tool_input,
+                run_id=run_id,
+                agent_id=agent_id,
+                reason="MCP tools require human approval at manual level",
+            )
+        return PermissionResultAllow()
+
     # 3.5. Mission Control kill-switch: operator-requested pause forces every
     #      non-readonly tool call to the permission tray, regardless of
     #      autonomy level. Checked AFTER read-only / subagent so a pause

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1214,7 +1214,16 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                             "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
                             "GITHUB_REPO": repo,
                         },
-                        allowed_tools=["Read", "Bash", "Glob", "Grep", "Edit", "Write", "Agent"],
+                        mcp_servers={
+                            "playwright": {
+                                "command": "npx",
+                                "args": ["-y", "@playwright/mcp@latest"],
+                            },
+                            "ref": {
+                                "url": "https://api.ref.tools/mcp",
+                            },
+                        },
+                        allowed_tools=["Read", "Bash", "Glob", "Grep", "Edit", "Write", "Agent", "mcp__playwright__*", "mcp__ref__*"],
                         max_turns=manager_turns,
                         model=manager_model,
                         agents=agents_dict,


### PR DESCRIPTION
## Description
This PR adds support for Playwright and Ref Model Context Protocol (MCP) servers to the Claude Agent Station. This allows agents to perform browser-based tasks and access up-to-date documentation.

### Changes
- **MCP Configuration**: Added .mcp.json to the project root with Playwright and Ref MCP configurations.
- **Orchestrator**: Updated agent/station_orchestrator.py to initialize the Lead agent with these MCP servers and pre-approve their tools.
- **Policy Engine**: Updated agent/auto_mode.py to permit mcp__* tool calls at assisted and auto autonomy levels.
- **Teammate Definition**: Updated agent/agents/issue-worker.md to include MCP tools in the teammate's available toolset.

### Verification
- Playwright system dependencies and Chromium browser were installed on the host.
- MCP servers were verified to connect via 'claude mcp list'.
- The orchestrator and worker definitions were updated to expose these capabilities to the agent team.