### PR TITLE
feat: vision-driven issue bootstrap

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -233,6 +233,82 @@ def fetch_eligible_issues(repo: str, limit: int, workspace: str | None = None) -
     return eligible[:limit]
 
 
+def has_open_vision_proposals(repo: str) -> bool:
+    """True if any open issue carries the `vision-suggested` label.
+
+    Used by Trigger A to skip dispatch when prior proposals are pending.
+    A `gh` failure returns False — fail-safe; we'd rather miss a dispatch
+    than spam the operator.
+    """
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", repo,
+        "--state", "open",
+        "--label", "vision-suggested",
+        "--limit", "1",
+        "--json", "number,labels",
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            logger.warning("has_open_vision_proposals: gh failed: %s", result.stderr.strip())
+            return False
+        return len(json.loads(result.stdout or "[]")) > 0
+    except Exception as exc:
+        logger.warning("has_open_vision_proposals: %s", exc)
+        return False
+
+
+def dispatch_vision_bootstrap(project_id: int) -> str:
+    """Trigger a vision-analyst run for ``project_id``.
+
+    Tries the in-container launcher first (compose-mode path) and falls
+    back to spawning the worker via subprocess (systemd-mode path or any
+    failure where the launcher is unreachable).
+
+    Returns one of:
+      - "dispatched"      — analyst was started
+      - "already-running" — launcher reported 409
+    """
+    launcher_url = os.environ.get(
+        "STATION_AGENT_LAUNCHER_URL", "http://localhost:8421",
+    ).rstrip("/")
+    token = os.environ.get("STATION_LAUNCHER_TOKEN", "")
+    headers = {"X-Launcher-Token": token} if token else {}
+
+    try:
+        resp = httpx.post(
+            f"{launcher_url}/vision-analyst",
+            params={"project_id": project_id},
+            headers=headers,
+            timeout=5.0,
+        )
+        if resp.status_code == 409:
+            logger.info("vision-analyst already running (409)")
+            return "already-running"
+        if 200 <= resp.status_code < 300:
+            return "dispatched"
+        logger.warning(
+            "launcher /vision-analyst returned %s: %s",
+            resp.status_code, resp.text[:200],
+        )
+    except httpx.RequestError as exc:
+        logger.info("launcher unreachable (%s); falling back to subprocess", exc)
+
+    # Fallback: spawn the worker directly. No cross-process lock; best
+    # effort. Reached on systemd path (no launcher), connection failure,
+    # OR an unexpected launcher status code (e.g. 401/500) — we'd
+    # rather over-deliver than silently fail.
+    subprocess.Popen(
+        ["python", "-m", "agent.vision_analyst", "--project-id", str(project_id)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return "dispatched"
+
+
 # ── Team Prompt Construction ──────────────────────────────────
 
 TEAMMATE_ROLES = ["backend", "frontend", "qa"]

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -309,6 +309,48 @@ def dispatch_vision_bootstrap(project_id: int) -> str:
     return "dispatched"
 
 
+def handle_empty_backlog(
+    config: dict,
+    repo: str,
+    project_id: int | None,
+    workspace: str,
+    run_id: str,
+) -> str:
+    """Decide what to do when a project's backlog is empty.
+
+    Returns the skip_reason string. Side-effects:
+      - posts a `finished` webhook for the regular run with skip_reason
+      - dispatches the vision_analyst when conditions match (Trigger A)
+    """
+    has_vision = os.path.isfile(os.path.join(workspace, "docs", "vision.md"))
+    proposals_pending = has_vision and has_open_vision_proposals(repo)
+
+    if not has_vision:
+        skip_reason = "no-eligible-issues-no-vision"
+    elif proposals_pending:
+        skip_reason = "no-eligible-issues-proposals-pending"
+    elif project_id is None:
+        # Can't dispatch without a project_id (manager-config drift).
+        skip_reason = "no-eligible-issues-no-vision"
+    else:
+        outcome = dispatch_vision_bootstrap(project_id)
+        skip_reason = (
+            "no-eligible-issues-bootstrap-dispatched"
+            if outcome == "dispatched"
+            else "no-eligible-issues-bootstrap-already-running"
+        )
+
+    post_webhook(config, "finished", {
+        "run_id": f"run-{run_id}",
+        "project": repo,
+        "mode": "agent-teams",
+        "status": "completed",
+        "skip_reason": skip_reason,
+    })
+    logger.info("Empty backlog for %s: %s", repo, skip_reason)
+    return skip_reason
+
+
 # ── Team Prompt Construction ──────────────────────────────────
 
 TEAMMATE_ROLES = ["backend", "frontend", "qa"]
@@ -1006,7 +1048,13 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
         # Fetch and filter issues
         issues = fetch_eligible_issues(repo, max_per_project, workspace)
         if not issues:
-            logger.info("No eligible issues for %s, skipping", repo)
+            handle_empty_backlog(
+                config=config,
+                repo=repo,
+                project_id=project.get("id"),
+                workspace=workspace,
+                run_id=run_id,
+            )
             continue
 
         # Hook 1: vision-aware prioritisation

--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -225,9 +225,10 @@ def propose_gaps(workspace: str, vision: dict, repo: str, model: str) -> list[di
     return proposals[:MAX_PROPOSALS]
 
 
-def create_proposed_issues(repo: str, proposals: list[dict]) -> list[int]:
-    """Create issues via `gh`. Returns list of created issue numbers."""
-    created = []
+def create_proposed_issues(repo: str, proposals: list[dict]) -> list[tuple[int, dict]]:
+    """Create issues via `gh`. Returns list of (issue_number, proposal) tuples
+    for the proposals that actually succeeded."""
+    created: list[tuple[int, dict]] = []
     for p in proposals:
         labels = ["vision-suggested"]
         priority = (p.get("priority") or "low").lower()
@@ -246,7 +247,7 @@ def create_proposed_issues(repo: str, proposals: list[dict]) -> list[int]:
                 continue
             url = result.stdout.strip()
             num = int(url.rstrip("/").rsplit("/", 1)[1])
-            created.append(num)
+            created.append((num, p))
             logger.info("Proposed issue #%d: %s", num, p["title"])
         except Exception as e:
             logger.warning("gh issue create failed: %s", e)
@@ -320,21 +321,22 @@ async def run_for_project(project_id: int) -> dict:
         _finish("success", vision_bootstrap_count=0, vision_bootstrap_proposals=[])
         return {"ok": True, "proposals": [], "created": []}
 
-    created = create_proposed_issues(repo, proposals)
+    created_pairs = create_proposed_issues(repo, proposals)
     proposal_records = [
         {
             "number": num,
             "title": p.get("title", ""),
             "url": f"https://github.com/{repo}/issues/{num}",
         }
-        for num, p in zip(created, proposals)
+        for num, p in created_pairs
     ]
+    created_numbers = [num for num, _ in created_pairs]
     _finish(
         "success",
-        vision_bootstrap_count=len(created),
+        vision_bootstrap_count=len(created_pairs),
         vision_bootstrap_proposals=proposal_records,
     )
-    return {"ok": True, "proposals": proposals, "created": created}
+    return {"ok": True, "proposals": proposals, "created": created_numbers}
 
 
 def _main():

--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -14,7 +14,12 @@ import logging
 import os
 import subprocess
 import sys
+import uuid
 from typing import Any
+
+import httpx
+
+from agent.vision import load_vision
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -25,6 +30,33 @@ DISCLAIMER = (
     "Review and accept by removing the `vision-suggested` label, "
     "or close to reject.*\n\n---\n\n"
 )
+
+
+def _webhook_url() -> str | None:
+    return os.environ.get("STATION_WEBHOOK_URL") or None
+
+
+def _webhook_secret() -> str | None:
+    return os.environ.get("STATION_WEBHOOK_SECRET") or None
+
+
+def _post_webhook(payload: dict) -> None:
+    """Best-effort POST to STATION_WEBHOOK_URL. Failures are logged, not raised."""
+    url = _webhook_url()
+    if not url:
+        logger.info("vision_analyst: STATION_WEBHOOK_URL unset, skipping webhook")
+        return
+    headers = {}
+    secret = _webhook_secret()
+    if secret:
+        headers["X-Webhook-Token"] = secret
+    try:
+        resp = httpx.post(url, json=payload, headers=headers, timeout=5.0)
+        if resp.status_code >= 400:
+            logger.warning("vision_analyst webhook %s -> %s: %s",
+                           payload.get("event"), resp.status_code, resp.text[:200])
+    except httpx.HTTPError as exc:
+        logger.warning("vision_analyst webhook POST failed: %s", exc)
 
 
 def _gather_repo_state(workspace: str, repo: str) -> dict:
@@ -236,34 +268,72 @@ def _ensure_workspace(workspace: str, repo: str) -> bool:
 
 
 async def run_for_project(project_id: int) -> dict:
-    """Entry point: load project from DB, run analyst, return summary."""
+    """Entry point: load project from DB, run analyst, return summary.
+
+    Self-registers as a `vision-bootstrap` Run via webhooks so the dashboard
+    sees the activity in Mission Control + Runs list.
+    """
     from app.database import async_session, init_db
     from app.models import Project
-    from agent.vision import load_vision
 
     await init_db()
     async with async_session() as db:
         project = await db.get(Project, project_id)
         if not project:
             return {"ok": False, "error": "project not found"}
+        repo = project.repo
 
     workspaces_dir = os.environ.get("STATION_WORKSPACES", "/var/lib/claude-agent-station/workspaces")
-    name = project.repo.split("/")[-1]
+    name = repo.split("/")[-1]
     workspace = os.path.join(workspaces_dir, name)
 
-    if not _ensure_workspace(workspace, project.repo):
-        return {"ok": False, "error": f"could not clone {project.repo}"}
+    run_id = f"run-vb-{uuid.uuid4().hex[:12]}"
+    _post_webhook({
+        "event": "started",
+        "run_id": run_id,
+        "project": repo,
+        "mode": "vision-bootstrap",
+    })
+
+    def _finish(status: str, **extra) -> None:
+        _post_webhook({
+            "event": "finished",
+            "run_id": run_id,
+            "project": repo,
+            "mode": "vision-bootstrap",
+            "status": status,
+            **extra,
+        })
+
+    if not _ensure_workspace(workspace, repo):
+        _finish("error")
+        return {"ok": False, "error": f"could not clone {repo}"}
 
     vision = load_vision(workspace)
     if vision is None:
+        _finish("error")
         return {"ok": False, "error": "no vision file at docs/vision.md"}
 
     model = os.environ.get("STATION_VISION_ANALYST_MODEL", "claude-sonnet-4-6")
-    proposals = propose_gaps(workspace, vision, project.repo, model)
+    proposals = propose_gaps(workspace, vision, repo, model)
     if not proposals:
+        _finish("success", vision_bootstrap_count=0, vision_bootstrap_proposals=[])
         return {"ok": True, "proposals": [], "created": []}
 
-    created = create_proposed_issues(project.repo, proposals)
+    created = create_proposed_issues(repo, proposals)
+    proposal_records = [
+        {
+            "number": num,
+            "title": p.get("title", ""),
+            "url": f"https://github.com/{repo}/issues/{num}",
+        }
+        for num, p in zip(created, proposals)
+    ]
+    _finish(
+        "success",
+        vision_bootstrap_count=len(created),
+        vision_bootstrap_proposals=proposal_records,
+    )
     return {"ok": True, "proposals": proposals, "created": created}
 
 

--- a/dashboard/backend/app/database.py
+++ b/dashboard/backend/app/database.py
@@ -87,6 +87,11 @@ async def _migrate_add_columns(conn) -> None:
         ("projects", "vision_cached_sha",  "ALTER TABLE projects ADD COLUMN vision_cached_sha TEXT"),
         ("projects", "vision_cached_body", "ALTER TABLE projects ADD COLUMN vision_cached_body TEXT"),
         ("projects", "vision_cached_at",   "ALTER TABLE projects ADD COLUMN vision_cached_at DATETIME"),
+        # Vision-bootstrap columns (spec 2026-05-08-vision-issue-bootstrap-design.md)
+        ("runs", "skip_reason", "ALTER TABLE runs ADD COLUMN skip_reason TEXT"),
+        ("runs", "vision_bootstrap_count", "ALTER TABLE runs ADD COLUMN vision_bootstrap_count INTEGER"),
+        ("runs", "vision_bootstrap_proposals", "ALTER TABLE runs ADD COLUMN vision_bootstrap_proposals TEXT"),
+        ("projects", "last_vision_analyzed_sha", "ALTER TABLE projects ADD COLUMN last_vision_analyzed_sha TEXT"),
     ]
     # `table` and `sql` below are hardcoded literals from the migrations tuple
     # list above; PRAGMA + ALTER TABLE do not support bound parameters for

--- a/dashboard/backend/app/models.py
+++ b/dashboard/backend/app/models.py
@@ -33,6 +33,7 @@ class Project(Base):
     vision_cached_sha = Column(Text, nullable=True, default=None)
     vision_cached_body = Column(Text, nullable=True, default=None)
     vision_cached_at = Column(DateTime, nullable=True, default=None)
+    last_vision_analyzed_sha = Column(Text, nullable=True, default=None)
     created_at = Column(DateTime, default=_utcnow)
     updated_at = Column(DateTime, default=_utcnow, onupdate=_utcnow)
 
@@ -75,6 +76,10 @@ class Run(Base):
     # ADR-0001: autonomy snapshot at trigger time; per-run budget override
     autonomy_level = Column(Text, nullable=True, default="assisted")
     max_budget_usd = Column(Float, nullable=True, default=None)
+    # Vision-bootstrap (spec 2026-05-08-vision-issue-bootstrap-design.md)
+    skip_reason = Column(Text, nullable=True)
+    vision_bootstrap_count = Column(Integer, nullable=True)
+    vision_bootstrap_proposals = Column(Text, nullable=True)  # JSON list
 
 
 class ConfigEntry(Base):

--- a/dashboard/backend/app/routers/vision.py
+++ b/dashboard/backend/app/routers/vision.py
@@ -324,12 +324,15 @@ async def vision_proposals(project_id: int, db: AsyncSession = Depends(get_db)):
     if cached and (time.time() - cached[0]) < _PROPOSALS_TTL_S:
         return VisionProposalsRead(**cached[1])
 
-    open_count = _count_issues(project.repo, state="open", label="vision-suggested")
+    import asyncio as _asyncio
+    open_count = await _asyncio.to_thread(
+        _count_issues, project.repo, state="open", label="vision-suggested"
+    )
     # Accepted = closed within last 7 days that previously had vision-suggested.
     # The label may have been removed when the issue was accepted, so this is
     # an approximation — close enough for an info strip.
-    accepted = _count_issues(
-        project.repo, state="closed", label="vision-suggested", days_back=7,
+    accepted = await _asyncio.to_thread(
+        _count_issues, project.repo, state="closed", label="vision-suggested", days_back=7,
     )
 
     payload = {"open": open_count, "accepted_recent": accepted}

--- a/dashboard/backend/app/routers/vision.py
+++ b/dashboard/backend/app/routers/vision.py
@@ -116,6 +116,7 @@ async def commit_vision(
     # fire the analyst when the vision SHA actually changed. We set
     # last_vision_analyzed_sha at *dispatch* time (not on completion) so a
     # failed analyst doesn't loop on identical re-commits.
+    dispatched: bool = False
     if fresh.sha != project.last_vision_analyzed_sha:
         try:
             result = await service_control.start_vision_analyst(project_id)
@@ -127,6 +128,7 @@ async def commit_vision(
             else:
                 # 200 or 409 — both mean "an analyst run will happen"
                 project.last_vision_analyzed_sha = fresh.sha
+                dispatched = True
         except Exception as exc:
             logger.warning("vision commit B-trigger dispatch exception: %s", exc)
 
@@ -136,7 +138,7 @@ async def commit_vision(
         await vc_service.mark_approved(db, active.id, assembled=body.vision_doc.model_dump())
 
     await db.commit()
-    return VisionCommitOut(sha=new_sha, html_url=fresh.html_url)
+    return VisionCommitOut(sha=new_sha, html_url=fresh.html_url, analyst_dispatched=dispatched)
 
 
 # ---------------------------------------------------------------------------

--- a/dashboard/backend/app/routers/vision.py
+++ b/dashboard/backend/app/routers/vision.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import subprocess
+import time
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
 
@@ -192,9 +195,8 @@ async def chat_turn(
         system_prompt = _load_prompt("vision_create.md")
 
     # Pick the model — read the station config JSON directly
-    import asyncio as _asyncio
     from app.services.config_sync import _read_config_json
-    config = await _asyncio.to_thread(_read_config_json)
+    config = await asyncio.to_thread(_read_config_json)
     model = (config.get("models") or {}).get("planner") or "claude-sonnet-4-6"
 
     async def event_stream():
@@ -288,9 +290,6 @@ _PROPOSALS_TTL_S = 60
 
 def _count_issues(repo: str, *, state: str, label: str, days_back: int | None = None) -> int:
     """Run `gh issue list` and count results. Returns 0 on any failure."""
-    import subprocess
-    import datetime as _dt
-
     cmd = [
         "gh", "issue", "list",
         "--repo", repo,
@@ -302,7 +301,7 @@ def _count_issues(repo: str, *, state: str, label: str, days_back: int | None = 
     if days_back is not None:
         # Use gh's --search; resolve the date in Python to avoid shell expansion
         # surprises.
-        cutoff = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=days_back)).strftime("%Y-%m-%d")
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days_back)).strftime("%Y-%m-%d")
         cmd += ["--search", f"closed:>={cutoff}"]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
@@ -316,8 +315,6 @@ def _count_issues(repo: str, *, state: str, label: str, days_back: int | None = 
 @router.get("/{project_id}/vision/proposals", response_model=VisionProposalsRead)
 async def vision_proposals(project_id: int, db: AsyncSession = Depends(get_db)):
     """Return open + recently-accepted proposal counts for the Vision tab."""
-    import time
-
     project = await db.get(Project, project_id)
     if not project:
         raise HTTPException(status_code=404, detail="project not found")
@@ -326,14 +323,13 @@ async def vision_proposals(project_id: int, db: AsyncSession = Depends(get_db)):
     if cached and (time.time() - cached[0]) < _PROPOSALS_TTL_S:
         return VisionProposalsRead(**cached[1])
 
-    import asyncio as _asyncio
-    open_count = await _asyncio.to_thread(
+    open_count = await asyncio.to_thread(
         _count_issues, project.repo, state="open", label="vision-suggested"
     )
     # Accepted = closed within last 7 days that previously had vision-suggested.
     # The label may have been removed when the issue was accepted, so this is
     # an approximation — close enough for an info strip.
-    accepted = await _asyncio.to_thread(
+    accepted = await asyncio.to_thread(
         _count_issues, project.repo, state="closed", label="vision-suggested", days_back=7,
     )
 

--- a/dashboard/backend/app/routers/vision.py
+++ b/dashboard/backend/app/routers/vision.py
@@ -112,6 +112,24 @@ async def commit_vision(
     project.vision_cached_body = fresh.body
     project.vision_cached_at = now
 
+    # Trigger B (spec 2026-05-08-vision-issue-bootstrap-design.md):
+    # fire the analyst when the vision SHA actually changed. We set
+    # last_vision_analyzed_sha at *dispatch* time (not on completion) so a
+    # failed analyst doesn't loop on identical re-commits.
+    if fresh.sha != project.last_vision_analyzed_sha:
+        try:
+            result = await service_control.start_vision_analyst(project_id)
+            if not result.get("success") and result.get("status_code") != 409:
+                logger.warning(
+                    "vision commit B-trigger dispatch failed: %s",
+                    result.get("error") or result.get("stderr"),
+                )
+            else:
+                # 200 or 409 — both mean "an analyst run will happen"
+                project.last_vision_analyzed_sha = fresh.sha
+        except Exception as exc:
+            logger.warning("vision commit B-trigger dispatch exception: %s", exc)
+
     # Mark any active chat session as approved with the assembled doc
     active = await vc_service.get_active_session(db, project_id)
     if active:

--- a/dashboard/backend/app/routers/vision.py
+++ b/dashboard/backend/app/routers/vision.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_db
 from app.models import Project, VisionChatSession
-from app.schemas import VisionRead, VisionCommitIn, VisionCommitOut, VisionStaleSha, VisionChatTurnIn, VisionChatSessionOut
+from app.schemas import VisionRead, VisionCommitIn, VisionCommitOut, VisionStaleSha, VisionChatTurnIn, VisionChatSessionOut, VisionProposalsRead
 from app.services import github_contents
 from app.services.vision_render import render_vision_doc
 from app.services import vision_chat as vc_service
@@ -271,3 +271,67 @@ async def find_gaps(project_id: int, db: AsyncSession = Depends(get_db)):
             detail=result.get("error") or result.get("stderr") or "failed to start vision-analyst",
         )
     return {"status": "triggered", **{k: v for k, v in result.items() if k not in {"success", "status_code"}}}
+
+
+# ---------------------------------------------------------------------------
+# Vision proposals: open + recently-accepted vision-suggested issues
+# ---------------------------------------------------------------------------
+
+# Module-level cache: {project_id: (timestamp, payload)}.
+# 60-second TTL is enough to absorb dashboard re-renders without
+# overwhelming the rate-limited gh CLI.
+_PROPOSALS_CACHE: dict[int, tuple[float, dict]] = {}
+_PROPOSALS_TTL_S = 60
+
+
+def _count_issues(repo: str, *, state: str, label: str, days_back: int | None = None) -> int:
+    """Run `gh issue list` and count results. Returns 0 on any failure."""
+    import subprocess
+    import datetime as _dt
+
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", repo,
+        "--state", state,
+        "--label", label,
+        "--limit", "100",
+        "--json", "number",
+    ]
+    if days_back is not None:
+        # Use gh's --search; resolve the date in Python to avoid shell expansion
+        # surprises.
+        cutoff = (_dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=days_back)).strftime("%Y-%m-%d")
+        cmd += ["--search", f"closed:>={cutoff}"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            return 0
+        return len(json.loads(result.stdout or "[]"))
+    except Exception:
+        return 0
+
+
+@router.get("/{project_id}/vision/proposals", response_model=VisionProposalsRead)
+async def vision_proposals(project_id: int, db: AsyncSession = Depends(get_db)):
+    """Return open + recently-accepted proposal counts for the Vision tab."""
+    import time
+
+    project = await db.get(Project, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    cached = _PROPOSALS_CACHE.get(project_id)
+    if cached and (time.time() - cached[0]) < _PROPOSALS_TTL_S:
+        return VisionProposalsRead(**cached[1])
+
+    open_count = _count_issues(project.repo, state="open", label="vision-suggested")
+    # Accepted = closed within last 7 days that previously had vision-suggested.
+    # The label may have been removed when the issue was accepted, so this is
+    # an approximation — close enough for an info strip.
+    accepted = _count_issues(
+        project.repo, state="closed", label="vision-suggested", days_back=7,
+    )
+
+    payload = {"open": open_count, "accepted_recent": accepted}
+    _PROPOSALS_CACHE[project_id] = (time.time(), payload)
+    return VisionProposalsRead(**payload)

--- a/dashboard/backend/app/routers/webhook.py
+++ b/dashboard/backend/app/routers/webhook.py
@@ -170,6 +170,9 @@ async def receive_run_event(
             "turns": event.turns,
             "narration": event.narration,
             "narration_kind": event.narration_kind,
+            "vision_bootstrap_count": event.vision_bootstrap_count,
+            "vision_bootstrap_proposals": event.vision_bootstrap_proposals,
+            "skip_reason": event.skip_reason,
         },
     })
 

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -853,3 +853,9 @@ class VisionChatTurnIn(BaseModel):
     """Body for POST /api/projects/{id}/vision/chat (turn)."""
     session_id: str | None = None  # None on first turn
     message: str
+
+
+class VisionProposalsRead(BaseModel):
+    """Response for GET /api/projects/{id}/vision/proposals."""
+    open: int
+    accepted_recent: int

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 from typing import Any
 
@@ -87,6 +88,18 @@ class RunOut(BaseModel):
     # ADR-0001
     autonomy_level: str | None = None
     max_budget_usd: float | None = None
+    # Vision-bootstrap fields — spec 2026-05-08-vision-issue-bootstrap-design.md
+    vision_bootstrap_count: int | None = None
+    vision_bootstrap_proposals: list[dict] | None = None
+    skip_reason: str | None = None
+
+    @field_validator("vision_bootstrap_proposals", mode="before")
+    @classmethod
+    def _deserialize_proposals(cls, v: object) -> object:
+        """Accept raw JSON string from the DB column or a parsed list."""
+        if isinstance(v, str):
+            return json.loads(v)
+        return v
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -328,6 +341,10 @@ class WebhookRunEvent(BaseModel):
     # has to guess what's happening.
     narration: str | None = None
     narration_kind: str | None = None  # "directive" | "step" | "system"
+    # Vision-bootstrap fields — spec 2026-05-08-vision-issue-bootstrap-design.md
+    vision_bootstrap_count: int | None = None
+    vision_bootstrap_proposals: list[dict] | None = None
+    skip_reason: str | None = None
 
 
 # --- Coordinator ---
@@ -704,9 +721,8 @@ class PermissionRequestOut(BaseModel):
     def _parse_json_input(cls, v: Any) -> Any:
         """tool_input is stored as a JSON string; unwrap for the API."""
         if isinstance(v, str):
-            import json as _json
             try:
-                return _json.loads(v)
+                return json.loads(v)
             except Exception:
                 return {"raw": v}
         return v or {}

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -827,6 +827,7 @@ class VisionCommitOut(BaseModel):
     """Response for POST /api/projects/{id}/vision."""
     sha: str
     html_url: str
+    analyst_dispatched: bool = False  # True when the SHA-gated dispatch fired (or 409'd)
 
 
 class VisionStaleSha(BaseModel):

--- a/dashboard/backend/app/services/run_lifecycle.py
+++ b/dashboard/backend/app/services/run_lifecycle.py
@@ -182,6 +182,17 @@ async def handle_finished(
     run.duration_ms = event.duration_ms
     run.finished_at = datetime.now(timezone.utc)
     run.model = event.model or run.model
+    if event.mode:
+        run.mode = event.mode
+
+    # Vision-bootstrap: only set when the event carries them so we don't
+    # overwrite a regular run's NULLs with NULL-from-event.
+    if event.vision_bootstrap_count is not None:
+        run.vision_bootstrap_count = event.vision_bootstrap_count
+    if event.vision_bootstrap_proposals is not None:
+        run.vision_bootstrap_proposals = json.dumps(event.vision_bootstrap_proposals)
+    if event.skip_reason is not None:
+        run.skip_reason = event.skip_reason
 
     if not run.employee_report and event.project:
         repo_short = _safe_repo_short(event.project)

--- a/dashboard/backend/tests/test_migrations.py
+++ b/dashboard/backend/tests/test_migrations.py
@@ -230,3 +230,50 @@ async def test_dag_json_read_write_after_migration(tmp_path):
         assert row[0] == '{"nodes": []}'
 
     await test_engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_vision_bootstrap_columns_present(tmp_path):
+    """The four vision-bootstrap columns must exist after migration."""
+    db_path = tmp_path / "vision_bootstrap_test.db"
+
+    # Create minimal runs and projects tables without the vision-bootstrap columns.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE runs (
+            id INTEGER PRIMARY KEY,
+            run_id TEXT NOT NULL,
+            project_id INTEGER,
+            status TEXT,
+            verdict TEXT,
+            started_at DATETIME
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE projects (
+            id INTEGER PRIMARY KEY,
+            repo TEXT NOT NULL,
+            name TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    test_engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}", echo=False)
+
+    async with test_engine.begin() as aconn:
+        await _migrate_add_columns(aconn)
+
+    await test_engine.dispose()
+
+    conn = sqlite3.connect(str(db_path))
+    runs_cols = {row[1] for row in conn.execute("PRAGMA table_info(runs)").fetchall()}
+    projects_cols = {row[1] for row in conn.execute("PRAGMA table_info(projects)").fetchall()}
+    conn.close()
+
+    assert "skip_reason" in runs_cols
+    assert "vision_bootstrap_count" in runs_cols
+    assert "vision_bootstrap_proposals" in runs_cols
+    assert "last_vision_analyzed_sha" in projects_cols

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -364,3 +364,76 @@ def test_dispatch_vision_bootstrap_falls_back_on_unexpected_status(monkeypatch):
     monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://launcher:8421")
     assert dispatch_vision_bootstrap(42) == "dispatched"
     assert spawned == [["python", "-m", "agent.vision_analyst", "--project-id", "42"]]
+
+
+# --- Task 6: handle_empty_backlog -------------------------------------------
+
+
+def test_handle_empty_backlog_dispatches_when_vision_and_no_proposals(monkeypatch, tmp_path):
+    """Trigger A: dispatches and reports skip_reason=bootstrap-dispatched."""
+    from agent import station_orchestrator as so
+
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    (ws / "docs").mkdir()
+    (ws / "docs" / "vision.md").write_text("## Problem\np\n## Users\nu\n## End-state\ne\n## Non-goals\nn\n## Principles\npr\n## Horizons\nh\n## Anti-patterns\na\n")
+
+    monkeypatch.setattr(so, "has_open_vision_proposals", lambda r: False)
+    dispatched = []
+    monkeypatch.setattr(so, "dispatch_vision_bootstrap", lambda pid: dispatched.append(pid) or "dispatched")
+    posted = []
+    monkeypatch.setattr(so, "post_webhook", lambda cfg, ev, data: posted.append((ev, data)))
+
+    skip_reason = so.handle_empty_backlog(
+        config={}, repo="x/y", project_id=42, workspace=str(ws), run_id="r-1",
+    )
+    assert skip_reason == "no-eligible-issues-bootstrap-dispatched"
+    assert dispatched == [42]
+    assert any(ev == "finished" and d.get("skip_reason") == skip_reason for ev, d in posted)
+
+
+def test_handle_empty_backlog_no_vision(monkeypatch, tmp_path):
+    from agent import station_orchestrator as so
+    ws = tmp_path / "repo"
+    ws.mkdir()  # no docs/vision.md
+    monkeypatch.setattr(so, "has_open_vision_proposals", lambda r: False)
+    dispatched = []
+    monkeypatch.setattr(so, "dispatch_vision_bootstrap", lambda pid: dispatched.append(pid) or "dispatched")
+    monkeypatch.setattr(so, "post_webhook", lambda *a, **k: None)
+    skip_reason = so.handle_empty_backlog(
+        config={}, repo="x/y", project_id=42, workspace=str(ws), run_id="r-1",
+    )
+    assert skip_reason == "no-eligible-issues-no-vision"
+    assert dispatched == []
+
+
+def test_handle_empty_backlog_proposals_pending(monkeypatch, tmp_path):
+    from agent import station_orchestrator as so
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    (ws / "docs").mkdir()
+    (ws / "docs" / "vision.md").write_text("## Problem\np\n")
+    monkeypatch.setattr(so, "has_open_vision_proposals", lambda r: True)
+    dispatched = []
+    monkeypatch.setattr(so, "dispatch_vision_bootstrap", lambda pid: dispatched.append(pid) or "dispatched")
+    monkeypatch.setattr(so, "post_webhook", lambda *a, **k: None)
+    skip_reason = so.handle_empty_backlog(
+        config={}, repo="x/y", project_id=42, workspace=str(ws), run_id="r-1",
+    )
+    assert skip_reason == "no-eligible-issues-proposals-pending"
+    assert dispatched == []
+
+
+def test_handle_empty_backlog_already_running(monkeypatch, tmp_path):
+    from agent import station_orchestrator as so
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    (ws / "docs").mkdir()
+    (ws / "docs" / "vision.md").write_text("## Problem\np\n")
+    monkeypatch.setattr(so, "has_open_vision_proposals", lambda r: False)
+    monkeypatch.setattr(so, "dispatch_vision_bootstrap", lambda pid: "already-running")
+    monkeypatch.setattr(so, "post_webhook", lambda *a, **k: None)
+    skip_reason = so.handle_empty_backlog(
+        config={}, repo="x/y", project_id=42, workspace=str(ws), run_id="r-1",
+    )
+    assert skip_reason == "no-eligible-issues-bootstrap-already-running"

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -260,3 +260,107 @@ async def test_control_poll_loop_drains_messages_continuously(tmp_path, monkeypa
             except (asyncio.CancelledError, Exception):
                 pass
         conn.close()
+
+
+# --- Task 4: has_open_vision_proposals -----------------------------------
+
+
+def test_has_open_vision_proposals_true_when_label_present(monkeypatch):
+    from agent.station_orchestrator import has_open_vision_proposals
+
+    fake_stdout = '[{"number": 1, "labels": [{"name": "vision-suggested"}]}]'
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: type("R", (), {"returncode": 0, "stdout": fake_stdout, "stderr": ""}),
+    )
+    assert has_open_vision_proposals("x/y") is True
+
+
+def test_has_open_vision_proposals_false_when_no_matches(monkeypatch):
+    from agent.station_orchestrator import has_open_vision_proposals
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""}),
+    )
+    assert has_open_vision_proposals("x/y") is False
+
+
+def test_has_open_vision_proposals_false_on_gh_failure(monkeypatch):
+    from agent.station_orchestrator import has_open_vision_proposals
+
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: type("R", (), {"returncode": 1, "stdout": "", "stderr": "boom"}),
+    )
+    assert has_open_vision_proposals("x/y") is False
+
+
+# --- Task 5: dispatch_vision_bootstrap -----------------------------------
+
+
+def test_dispatch_vision_bootstrap_returns_dispatched_on_200(monkeypatch):
+    import httpx
+
+    from agent.station_orchestrator import dispatch_vision_bootstrap
+
+    class R:
+        status_code = 200
+        text = ""
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: R())
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://launcher:8421")
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "tok")
+    assert dispatch_vision_bootstrap(42) == "dispatched"
+
+
+def test_dispatch_vision_bootstrap_returns_already_running_on_409(monkeypatch):
+    import httpx
+
+    from agent.station_orchestrator import dispatch_vision_bootstrap
+
+    class R:
+        status_code = 409
+        text = "vision-analyst already running"
+
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: R())
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://launcher:8421")
+    assert dispatch_vision_bootstrap(42) == "already-running"
+
+
+def test_dispatch_vision_bootstrap_falls_back_to_subprocess(monkeypatch):
+    """When launcher is unreachable, spawn directly via subprocess."""
+    import httpx
+
+    from agent.station_orchestrator import dispatch_vision_bootstrap
+
+    def boom(*a, **k):
+        raise httpx.RequestError("connection refused")
+
+    monkeypatch.setattr(httpx, "post", boom)
+    spawned = []
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda cmd, *a, **k: spawned.append(cmd) or type("P", (), {"pid": 1234})(),
+    )
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://launcher:8421")
+    assert dispatch_vision_bootstrap(42) == "dispatched"
+    assert spawned == [["python", "-m", "agent.vision_analyst", "--project-id", "42"]]
+
+
+def test_dispatch_vision_bootstrap_falls_back_on_unexpected_status(monkeypatch):
+    """Unexpected non-2xx, non-409 -> subprocess fallback (graceful degradation)."""
+    import httpx
+    from agent.station_orchestrator import dispatch_vision_bootstrap
+    class R:
+        status_code = 500
+        text = "internal server error"
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: R())
+    spawned = []
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda cmd, *a, **k: spawned.append(cmd) or type("P", (), {"pid": 1234})(),
+    )
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://launcher:8421")
+    assert dispatch_vision_bootstrap(42) == "dispatched"
+    assert spawned == [["python", "-m", "agent.vision_analyst", "--project-id", "42"]]

--- a/dashboard/backend/tests/test_run_lifecycle.py
+++ b/dashboard/backend/tests/test_run_lifecycle.py
@@ -1,0 +1,47 @@
+"""Tests for run_lifecycle handle_finished with vision-bootstrap fields."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import pytest_asyncio
+
+from app.database import Base, async_session, engine
+from app.services.run_lifecycle import handle_finished
+from app.schemas import WebhookRunEvent
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_persists_vision_bootstrap_fields(setup_db):
+    event = WebhookRunEvent(
+        event="finished",
+        run_id="run-vb-test-1",
+        project="laboef1900/next-itsm",
+        mode="vision-bootstrap",
+        status="success",
+        vision_bootstrap_count=3,
+        vision_bootstrap_proposals=[
+            {"number": 101, "title": "Add metrics dashboard", "url": "https://github.com/x/y/issues/101"},
+            {"number": 102, "title": "Document API", "url": "https://github.com/x/y/issues/102"},
+            {"number": 103, "title": "Add CI", "url": "https://github.com/x/y/issues/103"},
+        ],
+    )
+    async with async_session() as db:
+        run = await handle_finished(db, event, project_id=None, run=None)
+        await db.commit()
+        await db.refresh(run)
+        assert run.mode == "vision-bootstrap"
+        assert run.vision_bootstrap_count == 3
+        proposals = json.loads(run.vision_bootstrap_proposals)
+        assert len(proposals) == 3
+        assert proposals[0]["number"] == 101

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -58,7 +58,7 @@ async def test_run_for_project_posts_started_and_finished_webhooks(monkeypatch, 
     monkeypatch.setattr(va, "propose_gaps", lambda w, v, r, m: [
         {"title": "T1", "body": "B1", "priority": "low"},
     ])
-    monkeypatch.setattr(va, "create_proposed_issues", lambda r, p: [101])
+    monkeypatch.setattr(va, "create_proposed_issues", lambda r, p: [(101, p[0])])
     monkeypatch.setenv("STATION_WEBHOOK_URL", "http://test/api/webhook/run-event")
     monkeypatch.setenv("STATION_WORKSPACES", str(tmp_path))
 
@@ -84,3 +84,41 @@ async def test_run_for_project_posts_started_and_finished_webhooks(monkeypatch, 
     assert finished["status"] == "success"
     assert finished["vision_bootstrap_count"] == 1
     assert finished["vision_bootstrap_proposals"][0]["number"] == 101
+
+
+def test_create_proposed_issues_pairs_failures_correctly(monkeypatch):
+    """When proposal A fails and B succeeds, the (number, proposal) tuple for B
+    correctly carries B's title — not A's."""
+    from agent import vision_analyst as va
+
+    proposals = [
+        {"title": "Proposal A (will fail)", "body": "x", "priority": "low"},
+        {"title": "Proposal B (will succeed)", "body": "y", "priority": "low"},
+        {"title": "Proposal C (will succeed)", "body": "z", "priority": "low"},
+    ]
+
+    call_count = [0]
+
+    def fake_run(cmd, *a, **kw):
+        call_count[0] += 1
+        # First call (Proposal A) fails
+        if call_count[0] == 1:
+            return type("R", (), {"returncode": 1, "stdout": "", "stderr": "gh boom"})()
+        # Subsequent calls succeed; URL ends with the issue number
+        n = 100 + call_count[0]
+        return type("R", (), {
+            "returncode": 0,
+            "stdout": f"https://github.com/x/y/issues/{n}\n",
+            "stderr": "",
+        })()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+
+    pairs = va.create_proposed_issues("x/y", proposals)
+    assert len(pairs) == 2
+    # First pair: issue 102 should be Proposal B (NOT A)
+    assert pairs[0][0] == 102
+    assert pairs[0][1]["title"] == "Proposal B (will succeed)"
+    # Second pair: issue 103 should be Proposal C
+    assert pairs[1][0] == 103
+    assert pairs[1][1]["title"] == "Proposal C (will succeed)"

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -33,3 +33,54 @@ def test_format_proposal_body_includes_disclaimer():
     assert "Proposed by Claude Station" in body
     assert "vision-suggested" in body
     assert "The feature explanation." in body
+
+
+async def test_run_for_project_posts_started_and_finished_webhooks(monkeypatch, tmp_path):
+    """run_for_project must POST started + finished events with mode=vision-bootstrap."""
+    from agent import vision_analyst as va
+
+    posted = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        posted.append({"url": url, "json": json})
+        class R:
+            status_code = 200
+            def raise_for_status(self): pass
+        return R()
+
+    monkeypatch.setattr(va.httpx, "post", fake_post, raising=False)
+    monkeypatch.setattr(va, "_ensure_workspace", lambda w, r: True)
+    monkeypatch.setattr(va, "load_vision", lambda w: {
+        "problem": "p", "users": "u", "end_state": "e",
+        "non_goals": "n", "principles": "pr", "horizons": "h",
+        "anti_patterns": "a",
+    })
+    monkeypatch.setattr(va, "propose_gaps", lambda w, v, r, m: [
+        {"title": "T1", "body": "B1", "priority": "low"},
+    ])
+    monkeypatch.setattr(va, "create_proposed_issues", lambda r, p: [101])
+    monkeypatch.setenv("STATION_WEBHOOK_URL", "http://test/api/webhook/run-event")
+    monkeypatch.setenv("STATION_WORKSPACES", str(tmp_path))
+
+    # Project with id=1
+    from app.database import async_session, init_db
+    from app.models import Project
+    await init_db()
+    async with async_session() as db:
+        db.add(Project(id=1, repo="x/y", branch="main"))
+        await db.commit()
+
+    result = await va.run_for_project(1)
+    assert result["ok"] is True
+
+    assert len(posted) == 2
+    started = posted[0]["json"]
+    finished = posted[1]["json"]
+    assert started["event"] == "started"
+    assert started["mode"] == "vision-bootstrap"
+    assert started["run_id"].startswith("run-vb-")
+    assert finished["event"] == "finished"
+    assert finished["mode"] == "vision-bootstrap"
+    assert finished["status"] == "success"
+    assert finished["vision_bootstrap_count"] == 1
+    assert finished["vision_bootstrap_proposals"][0]["number"] == 101

--- a/dashboard/backend/tests/test_vision_router.py
+++ b/dashboard/backend/tests/test_vision_router.py
@@ -220,3 +220,101 @@ async def test_find_gaps_calls_service_control(project):
             r = await c.post(f"/api/projects/{project.id}/vision/find-gaps")
     assert r.status_code == 200
     assert r.json()["status"] == "triggered"
+
+
+# ---------------------------------------------------------------------------
+# Trigger B — auto-fire analyst on vision commit
+# ---------------------------------------------------------------------------
+
+def _commit_body():
+    return {
+        "vision_doc": {
+            "problem": "P", "users": "U", "end_state": "E", "non_goals": "N",
+            "principles": "Pr", "horizons": "H", "anti_patterns": "A",
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_commit_vision_fires_analyst_when_sha_changes(project):
+    """Two commits with different fresh.sha values → start_vision_analyst called twice."""
+    async with async_session() as db:
+        proj = await db.get(Project, project.id)
+        proj.vision_cached_sha = "old-sha"
+        await db.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        analyst_mock = AsyncMock(return_value={"success": True, "status_code": 200, "pid": 1})
+        with patch("app.services.github_contents.write_file", new=AsyncMock(return_value="sha-1")), \
+             patch("app.services.github_contents.read_file",
+                   new=AsyncMock(return_value=ContentsResult(sha="sha-1", body="# v1", html_url="http://x"))), \
+             patch("app.services.service_control.start_vision_analyst", new=analyst_mock):
+            r1 = await c.post(f"/api/projects/{project.id}/vision", json=_commit_body())
+        assert r1.status_code == 200
+
+        # Second commit with a different SHA
+        analyst_mock2 = AsyncMock(return_value={"success": True, "status_code": 200, "pid": 2})
+        with patch("app.services.github_contents.write_file", new=AsyncMock(return_value="sha-2")), \
+             patch("app.services.github_contents.read_file",
+                   new=AsyncMock(return_value=ContentsResult(sha="sha-2", body="# v2", html_url="http://x"))), \
+             patch("app.services.service_control.start_vision_analyst", new=analyst_mock2):
+            r2 = await c.post(f"/api/projects/{project.id}/vision", json=_commit_body())
+        assert r2.status_code == 200
+
+    analyst_mock.assert_called_once()
+    analyst_mock2.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_commit_vision_skips_analyst_when_sha_unchanged(project):
+    """Second commit returns the same fresh.sha → analyst called only once total."""
+    async with async_session() as db:
+        proj = await db.get(Project, project.id)
+        proj.vision_cached_sha = "old-sha"
+        await db.commit()
+
+    transport = ASGITransport(app=app)
+    analyst_mock = AsyncMock(return_value={"success": True, "status_code": 200, "pid": 1})
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        # First commit — new SHA → analyst fires
+        with patch("app.services.github_contents.write_file", new=AsyncMock(return_value="same-sha")), \
+             patch("app.services.github_contents.read_file",
+                   new=AsyncMock(return_value=ContentsResult(sha="same-sha", body="# v1", html_url="http://x"))), \
+             patch("app.services.service_control.start_vision_analyst", new=analyst_mock):
+            r1 = await c.post(f"/api/projects/{project.id}/vision", json=_commit_body())
+        assert r1.status_code == 200
+
+        # Second commit — same SHA returned → analyst must NOT fire again
+        with patch("app.services.github_contents.write_file", new=AsyncMock(return_value="same-sha")), \
+             patch("app.services.github_contents.read_file",
+                   new=AsyncMock(return_value=ContentsResult(sha="same-sha", body="# v1", html_url="http://x"))), \
+             patch("app.services.service_control.start_vision_analyst", new=analyst_mock):
+            r2 = await c.post(f"/api/projects/{project.id}/vision", json=_commit_body())
+        assert r2.status_code == 200
+
+    analyst_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_commit_vision_treats_409_as_success(project):
+    """409 from launcher is treated as success: commit returns 200 and SHA is advanced."""
+    async with async_session() as db:
+        proj = await db.get(Project, project.id)
+        proj.vision_cached_sha = "old-sha"
+        await db.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        with patch("app.services.github_contents.write_file", new=AsyncMock(return_value="new-sha")), \
+             patch("app.services.github_contents.read_file",
+                   new=AsyncMock(return_value=ContentsResult(sha="new-sha", body="# v", html_url="http://x"))), \
+             patch("app.services.service_control.start_vision_analyst",
+                   new=AsyncMock(return_value={"success": False, "status_code": 409, "error": "already running"})):
+            r = await c.post(f"/api/projects/{project.id}/vision", json=_commit_body())
+    assert r.status_code == 200
+
+    # SHA must have been advanced so identical re-commits don't refire
+    async with async_session() as db:
+        proj = await db.get(Project, project.id)
+        assert proj.last_vision_analyzed_sha == "new-sha"

--- a/dashboard/backend/tests/test_vision_router.py
+++ b/dashboard/backend/tests/test_vision_router.py
@@ -318,3 +318,38 @@ async def test_commit_vision_treats_409_as_success(project):
     async with async_session() as db:
         proj = await db.get(Project, project.id)
         assert proj.last_vision_analyzed_sha == "new-sha"
+
+
+@pytest.mark.asyncio
+async def test_vision_proposals_endpoint_returns_counts(project, monkeypatch):
+    """GET /api/projects/{id}/vision/proposals returns open + accepted_recent."""
+    import subprocess
+    from app.routers import vision as vision_router
+
+    # Clear the module-level cache so we don't get a stale hit
+    vision_router._PROPOSALS_CACHE.clear()
+
+    open_payload = '[{"number": 1}, {"number": 2}, {"number": 3}]'
+    closed_payload = '[{"number": 99}]'
+
+    def fake_run(cmd, *a, **k):
+        # Distinguish open vs closed by inspecting the --state flag
+        try:
+            state = cmd[cmd.index("--state") + 1]
+        except (ValueError, IndexError):
+            state = ""
+        if state == "open":
+            return type("R", (), {"returncode": 0, "stdout": open_payload, "stderr": ""})()
+        if state == "closed":
+            return type("R", (), {"returncode": 0, "stdout": closed_payload, "stderr": ""})()
+        return type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""})()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        resp = await c.get(f"/api/projects/{project.id}/vision/proposals")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["open"] == 3
+    assert body["accepted_recent"] == 1

--- a/dashboard/backend/tests/test_vision_router.py
+++ b/dashboard/backend/tests/test_vision_router.py
@@ -264,6 +264,8 @@ async def test_commit_vision_fires_analyst_when_sha_changes(project):
 
     analyst_mock.assert_called_once()
     analyst_mock2.assert_called_once()
+    assert r1.json()["analyst_dispatched"] is True
+    assert r2.json()["analyst_dispatched"] is True
 
 
 @pytest.mark.asyncio
@@ -294,6 +296,8 @@ async def test_commit_vision_skips_analyst_when_sha_unchanged(project):
         assert r2.status_code == 200
 
     analyst_mock.assert_called_once()
+    assert r1.json()["analyst_dispatched"] is True
+    assert r2.json()["analyst_dispatched"] is False
 
 
 @pytest.mark.asyncio
@@ -313,6 +317,8 @@ async def test_commit_vision_treats_409_as_success(project):
                    new=AsyncMock(return_value={"success": False, "status_code": 409, "error": "already running"})):
             r = await c.post(f"/api/projects/{project.id}/vision", json=_commit_body())
     assert r.status_code == 200
+
+    assert r.json()["analyst_dispatched"] is True
 
     # SHA must have been advanced so identical re-commits don't refire
     async with async_session() as db:

--- a/dashboard/backend/tests/test_webhook.py
+++ b/dashboard/backend/tests/test_webhook.py
@@ -658,6 +658,93 @@ def test_normalize_event_name():
     assert _normalize_event_name("unknown_event") == "unknown_event"
 
 
+# ---------------------------------------------------------------------------
+# SSE broadcast: vision-bootstrap fields propagated to event bus
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@patch("app.services.run_lifecycle.parse_employee_report", return_value=None)
+async def test_run_event_publishes_vision_bootstrap_fields_to_sse(
+    mock_report, project_client: AsyncClient
+):
+    """Webhook 'finished' for vision-bootstrap should propagate vision_bootstrap_count,
+    vision_bootstrap_proposals, and skip_reason to the SSE event bus payload."""
+    published: list[dict] = []
+
+    async def capture_publish(payload: dict) -> None:
+        published.append(payload)
+
+    with patch("app.routers.webhook.event_bus_publish", side_effect=capture_publish):
+        resp = await project_client.post("/api/webhook/run-event", json={
+            "run_id": "run-vb-sse-001",
+            "event": "run_complete",
+            "project": "owner/test-repo",
+            "mode": "vision-bootstrap",
+            "status": "success",
+            "vision_bootstrap_count": 3,
+            "vision_bootstrap_proposals": [
+                {"title": "Add logging", "body": "We need logs."},
+                {"title": "Add tests", "body": "Coverage gap."},
+                {"title": "Add docs", "body": "Docs are missing."},
+            ],
+            "skip_reason": None,
+        })
+    assert resp.status_code == 200
+
+    # At least one published event should carry the vision-bootstrap fields
+    assert len(published) >= 1, "event_bus_publish was never called"
+    data_blocks = [p.get("data", {}) for p in published]
+    matching = [
+        d for d in data_blocks
+        if d.get("vision_bootstrap_count") is not None
+        or d.get("vision_bootstrap_proposals") is not None
+    ]
+    assert matching, (
+        "None of the published SSE events carried vision_bootstrap_count or "
+        "vision_bootstrap_proposals. "
+        f"Published data blocks: {data_blocks}"
+    )
+    sse_data = matching[0]
+    assert sse_data["vision_bootstrap_count"] == 3
+    assert isinstance(sse_data["vision_bootstrap_proposals"], list)
+    assert len(sse_data["vision_bootstrap_proposals"]) == 3
+    assert sse_data["vision_bootstrap_proposals"][0]["title"] == "Add logging"
+
+
+@pytest.mark.asyncio
+@patch("app.services.run_lifecycle.parse_employee_report", return_value=None)
+async def test_run_event_publishes_skip_reason_to_sse(
+    mock_report, project_client: AsyncClient
+):
+    """Webhook 'finished' for vision-bootstrap with skip_reason should propagate
+    the skip_reason field in the SSE payload."""
+    published: list[dict] = []
+
+    async def capture_publish(payload: dict) -> None:
+        published.append(payload)
+
+    with patch("app.routers.webhook.event_bus_publish", side_effect=capture_publish):
+        resp = await project_client.post("/api/webhook/run-event", json={
+            "run_id": "run-vb-sse-002",
+            "event": "run_complete",
+            "project": "owner/test-repo",
+            "mode": "vision-bootstrap",
+            "status": "success",
+            "vision_bootstrap_count": 0,
+            "vision_bootstrap_proposals": [],
+            "skip_reason": "no_vision_document",
+        })
+    assert resp.status_code == 200
+
+    data_blocks = [p.get("data", {}) for p in published]
+    matching = [d for d in data_blocks if d.get("skip_reason") is not None]
+    assert matching, (
+        "No published SSE event carried skip_reason. "
+        f"Published data blocks: {data_blocks}"
+    )
+    assert matching[0]["skip_reason"] == "no_vision_document"
+
+
 def test_build_notification_message():
     """Test the _build_notification_message function."""
     from app.services.run_lifecycle import build_notification_message as _build_notification_message

--- a/dashboard/frontend/src/app.css
+++ b/dashboard/frontend/src/app.css
@@ -369,6 +369,8 @@ code, .font-mono {
 .badge-triage { background: rgba(176,96,48,0.08); color: #B06030; }
 .badge-review { background: rgba(99,102,180,0.10); color: rgba(80,82,150,1); }
 .badge-fix { background: rgba(46,125,50,0.10); color: #2E7D32; }
+.badge-vision-bootstrap { background: rgba(176,96,48,0.12); color: #B06030; }
+.badge-agent-teams { background: rgba(99,102,180,0.10); color: rgba(80,82,150,1); }
 
 /* --- Card — warm neumorphic --- */
 .card {

--- a/dashboard/frontend/src/components/vision/VisionChat.svelte
+++ b/dashboard/frontend/src/components/vision/VisionChat.svelte
@@ -6,7 +6,7 @@
     visionChatTurnUrl, getVisionChatSession, cancelVisionChat,
     commitVision, getStoredApiKey,
   } from '../../lib/api';
-  import { toastError, toastSuccess } from '../../lib/toast.svelte';
+  import { toastError, toastSuccess, addToast } from '../../lib/toast.svelte';
   import type { VisionDoc, VisionSseEvent } from '../../lib/types';
   import CoverageChecklist from './CoverageChecklist.svelte';
 
@@ -108,6 +108,7 @@
     try {
       await commitVision(projectId, assembledDoc);
       toastSuccess('Vision saved to GitHub');
+      addToast('info', 'Vision analyst running — proposals will appear in a few minutes.');
       onApproved();
     } catch (e: any) {
       toastError(e.message);

--- a/dashboard/frontend/src/components/vision/VisionChat.svelte
+++ b/dashboard/frontend/src/components/vision/VisionChat.svelte
@@ -106,9 +106,11 @@
   async function approveAndCommit() {
     if (!assembledDoc) return;
     try {
-      await commitVision(projectId, assembledDoc);
+      const result = await commitVision(projectId, assembledDoc);
       toastSuccess('Vision saved to GitHub');
-      addToast('info', 'Vision analyst running — proposals will appear in a few minutes.');
+      if (result.analyst_dispatched) {
+        addToast('info', 'Vision analyst running — proposals will appear in a few minutes.');
+      }
       onApproved();
     } catch (e: any) {
       toastError(e.message);

--- a/dashboard/frontend/src/components/vision/VisionTab.svelte
+++ b/dashboard/frontend/src/components/vision/VisionTab.svelte
@@ -1,7 +1,7 @@
 <!-- dashboard/frontend/src/components/vision/VisionTab.svelte -->
 <script lang="ts">
-  import { getVision, findVisionGaps } from '../../lib/api';
-  import type { VisionRead, Project } from '../../lib/types';
+  import { getVision, findVisionGaps, getVisionProposals } from '../../lib/api';
+  import type { VisionRead, Project, VisionProposals } from '../../lib/types';
   import VisionChat from './VisionChat.svelte';
   import { toastSuccess, toastError } from '../../lib/toast.svelte';
 
@@ -11,8 +11,18 @@
   let loading = $state(true);
   let mode = $state<'view' | 'chat'>('view');
   let findingGaps = $state(false);
+  let proposals = $state<VisionProposals | null>(null);
 
   $effect(() => { load(); });
+
+  $effect(() => {
+    if (!project?.id) return;
+    let cancelled = false;
+    getVisionProposals(project.id)
+      .then(p => { if (!cancelled) proposals = p; })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  });
 
   async function load() {
     loading = true;
@@ -43,10 +53,37 @@
     }
   }
 
+  function rerunAnalyst() {
+    fetch(`/api/projects/${project.id}/vision/find-gaps`, { method: 'POST' })
+      .then(r => { if (!r.ok) console.warn('vision-analyst rerun failed', r.status); });
+  }
+
   const githubBaseUrl = $derived(
     `https://github.com/${project.repo}/blob/${project.branch || 'main'}/docs/vision.md`,
   );
+
+  const githubProposalsUrl = $derived(
+    `https://github.com/${project.repo}/issues?q=is:open+label:vision-suggested`,
+  );
 </script>
+
+<!-- Vision analyst info strip -->
+<div class="card p-3 mb-3 flex gap-3 items-center flex-wrap">
+  <strong class="text-sm">Vision analyst</strong>
+  <span class="text-xs text-tertiary">
+    {#if proposals}
+      {proposals.open} proposal{proposals.open === 1 ? '' : 's'} open
+      · {proposals.accepted_recent} accepted last week
+    {:else}
+      Loading…
+    {/if}
+  </span>
+  <span class="flex-1"></span>
+  <button type="button" class="btn btn-ghost btn-sm text-xs" onclick={rerunAnalyst}>Re-run analyst</button>
+  <a class="btn btn-ghost btn-sm text-xs"
+     href={githubProposalsUrl}
+     target="_blank" rel="noopener">View on GitHub →</a>
+</div>
 
 {#if loading}
   <div class="text-sm text-tertiary">Loading…</div>

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -454,6 +454,29 @@ function handleSSEEvent(data: any) {
         content: `Verdict: ${data.verdict ?? data.action ?? 'UNKNOWN'}`,
       });
       break;
+    case 'finished': {
+      // The vision_analyst worker emits event="finished" when the vision-bootstrap
+      // run completes. Only act on this for vision-bootstrap mode — all other
+      // terminal events use run_complete / orchestrator_complete below.
+      const vbRunMode = data.mode ?? data.data?.mode;
+      if (vbRunMode !== 'vision-bootstrap') break;
+      agentPresence.phase = 'idle';
+      addConversationEntry({
+        agentName: 'Manager',
+        agentColor,
+        type: 'phase',
+        content: 'Run completed',
+      });
+      const vbCount = (data.vision_bootstrap_count ?? data.data?.vision_bootstrap_count) ?? 0;
+      addToast(
+        'success',
+        vbCount === 0
+          ? 'Vision analyzed — no gaps found.'
+          : `${vbCount} issue${vbCount === 1 ? '' : 's'} created from vision.`,
+      );
+      refreshActiveRuns();
+      break;
+    }
     case 'run_complete':
     case 'orchestrator_complete':
     case 'orchestrator_error': {

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -351,6 +351,16 @@ function connectSSE() {
   sse.connect();
 }
 
+function visionBootstrapCompletionToast(data: any): void {
+  const n = (data.vision_bootstrap_count ?? data.data?.vision_bootstrap_count) ?? 0;
+  addToast(
+    'success',
+    n === 0
+      ? 'Vision analyzed — no gaps found.'
+      : `${n} issue${n === 1 ? '' : 's'} created from vision.`,
+  );
+}
+
 function handleSSEEvent(data: any) {
   const eventType = data.event ?? data.type;
   const agentColor = getRoleColors().manager;
@@ -467,13 +477,7 @@ function handleSSEEvent(data: any) {
         type: 'phase',
         content: 'Run completed',
       });
-      const vbCount = (data.vision_bootstrap_count ?? data.data?.vision_bootstrap_count) ?? 0;
-      addToast(
-        'success',
-        vbCount === 0
-          ? 'Vision analyzed — no gaps found.'
-          : `${vbCount} issue${vbCount === 1 ? '' : 's'} created from vision.`,
-      );
+      visionBootstrapCompletionToast(data);
       refreshActiveRuns();
       break;
     }
@@ -502,13 +506,7 @@ function handleSSEEvent(data: any) {
       if (runMode === 'vision-bootstrap' && !interrupted &&
           (runStatus === 'success' || runStatus === 'completed') &&
           eventType !== 'orchestrator_error') {
-        const n = (data.vision_bootstrap_count ?? data.data?.vision_bootstrap_count) ?? 0;
-        addToast(
-          'success',
-          n === 0
-            ? 'Vision analyzed — no gaps found.'
-            : `${n} issue${n === 1 ? '' : 's'} created from vision.`,
-        );
+        visionBootstrapCompletionToast(data);
       }
       refreshActiveRuns();
       break;

--- a/dashboard/frontend/src/lib/agent-presence.svelte.ts
+++ b/dashboard/frontend/src/lib/agent-presence.svelte.ts
@@ -11,6 +11,7 @@ import { getActiveEmployees, getLatestRun, listPlans, listRuns, getStoredApiKey 
 import type { ActiveEmployee, Run } from './types';
 import { AgentEventStream } from './event-stream';
 import { handleStreamEvent as permissionTrayHandleEvent } from './permission-tray.svelte';
+import { addToast } from './toast.svelte';
 
 // --- Agent Identity ---
 
@@ -472,6 +473,20 @@ function handleSSEEvent(data: any) {
           : (eventType === 'orchestrator_error' ? 'Run failed' : 'Run completed'),
         isError: interrupted || eventType === 'orchestrator_error',
       });
+      // Vision-bootstrap completion toast
+      const runMode = data.mode ?? data.data?.mode;
+      const runStatus = data.status ?? data.data?.status;
+      if (runMode === 'vision-bootstrap' && !interrupted &&
+          (runStatus === 'success' || runStatus === 'completed') &&
+          eventType !== 'orchestrator_error') {
+        const n = (data.vision_bootstrap_count ?? data.data?.vision_bootstrap_count) ?? 0;
+        addToast(
+          'success',
+          n === 0
+            ? 'Vision analyzed — no gaps found.'
+            : `${n} issue${n === 1 ? '' : 's'} created from vision.`,
+        );
+      }
       refreshActiveRuns();
       break;
     }

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -548,3 +548,6 @@ export const visionChatTurnUrl = (projectId: number) =>
 
 export const findVisionGaps = (projectId: number) =>
   request<{ status: string; pid?: number; log?: string }>(`/api/projects/${projectId}/vision/find-gaps`, { method: 'POST' });
+
+export const getVisionProposals = (projectId: number): Promise<VisionProposals> =>
+  request<VisionProposals>(`/api/projects/${projectId}/vision/proposals`);

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -13,7 +13,7 @@ import type {
   AnalyticsResponse, DiffResult, PlanUsage,
   PromptInfo, StationConfig, TokenUsage,
   AgentEvent, Notification,
-  VisionRead, VisionDoc, VisionCommitOut, VisionChatSession,
+  VisionRead, VisionDoc, VisionCommitOut, VisionChatSession, VisionProposals,
 } from './types';
 
 import { toastError } from './toast.svelte';

--- a/dashboard/frontend/src/lib/format.test.ts
+++ b/dashboard/frontend/src/lib/format.test.ts
@@ -125,7 +125,25 @@ describe('timeAgo', () => {
   });
 });
 
-import { formatRunMode } from './format';
+import { formatRunMode, formatSkipReason } from './format';
+
+describe('formatSkipReason', () => {
+  it('maps the four canned reasons', () => {
+    expect(formatSkipReason('no-eligible-issues-no-vision')).toContain('Vision tab');
+    expect(formatSkipReason('no-eligible-issues-bootstrap-dispatched')).toContain('dispatched');
+    expect(formatSkipReason('no-eligible-issues-bootstrap-already-running')).toContain('already running');
+    expect(formatSkipReason('no-eligible-issues-proposals-pending')).toContain('await');
+  });
+
+  it('returns empty for null/undefined', () => {
+    expect(formatSkipReason(null)).toBe('');
+    expect(formatSkipReason(undefined)).toBe('');
+  });
+
+  it('falls back to raw value for unknown reasons', () => {
+    expect(formatSkipReason('weird-thing')).toBe('weird-thing');
+  });
+});
 
 describe('formatRunMode', () => {
   it('returns vision-bootstrap descriptor', () => {

--- a/dashboard/frontend/src/lib/format.test.ts
+++ b/dashboard/frontend/src/lib/format.test.ts
@@ -7,6 +7,7 @@ import {
   shortRepo,
   shortRunId,
   formatPercent,
+  formatRunMode,
 } from './format';
 
 describe('formatTokens', () => {
@@ -121,5 +122,28 @@ describe('timeAgo', () => {
     vi.setSystemTime(now);
     const future = new Date(now.getTime() + 60_000).toISOString();
     expect(timeAgo(future)).toBe('just now');
+  });
+});
+
+import { formatRunMode } from './format';
+
+describe('formatRunMode', () => {
+  it('returns vision-bootstrap descriptor', () => {
+    const m = formatRunMode('vision-bootstrap');
+    expect(m.label).toBe('Vision bootstrap');
+    expect(m.icon).toBe('✨');
+    expect(m.accent).toBe('violet');
+  });
+
+  it('returns agent-teams descriptor', () => {
+    const m = formatRunMode('agent-teams');
+    expect(m.label).toBe('Agent Teams');
+    expect(m.accent).toBe('default');
+  });
+
+  it('falls back for unknown modes', () => {
+    const m = formatRunMode(null);
+    expect(m.label).toBe('Run');
+    expect(m.accent).toBe('default');
   });
 });

--- a/dashboard/frontend/src/lib/format.ts
+++ b/dashboard/frontend/src/lib/format.ts
@@ -98,3 +98,21 @@ export function formatRunMode(mode: string | null | undefined): RunModeDescripto
       return { label: 'Run', icon: '◆', accent: 'default' };
   }
 }
+
+/** Human-readable hint for a Run.skip_reason value. Returns the raw value
+ *  if no canned text matches. */
+export function formatSkipReason(reason: string | null | undefined): string {
+  if (!reason) return '';
+  switch (reason) {
+    case 'no-eligible-issues-no-vision':
+      return 'No vision yet — define one in the Vision tab.';
+    case 'no-eligible-issues-bootstrap-dispatched':
+      return 'Vision analyst dispatched.';
+    case 'no-eligible-issues-bootstrap-already-running':
+      return 'Vision analyst is already running.';
+    case 'no-eligible-issues-proposals-pending':
+      return 'Vision-suggested issues await your acceptance.';
+    default:
+      return reason;
+  }
+}

--- a/dashboard/frontend/src/lib/format.ts
+++ b/dashboard/frontend/src/lib/format.ts
@@ -80,3 +80,21 @@ export function formatCost(usd: number | null): string {
   if (usd < 0.01) return `$${usd.toFixed(4)}`;
   return `$${usd.toFixed(2)}`;
 }
+
+export interface RunModeDescriptor {
+  label: string;
+  icon: string;
+  accent: 'default' | 'violet';
+}
+
+/** Map a Run.mode value to its UI descriptor. */
+export function formatRunMode(mode: string | null | undefined): RunModeDescriptor {
+  switch (mode) {
+    case 'vision-bootstrap':
+      return { label: 'Vision bootstrap', icon: '✨', accent: 'violet' };
+    case 'agent-teams':
+      return { label: 'Agent Teams', icon: '◆', accent: 'default' };
+    default:
+      return { label: 'Run', icon: '◆', accent: 'default' };
+  }
+}

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -445,6 +445,7 @@ export interface VisionRead {
 export interface VisionCommitOut {
   sha: string;
   html_url: string;
+  analyst_dispatched?: boolean;
 }
 
 export interface VisionStaleSha {

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -71,6 +71,9 @@ export interface Run {
   team_members: string | null;
   autonomy_level: AutonomyLevel | null;
   max_budget_usd: number | null;
+  skip_reason?: string | null;
+  vision_bootstrap_count?: number | null;
+  vision_bootstrap_proposals?: { number: number; title: string; url: string }[] | null;
 }
 
 export interface RunList {
@@ -469,3 +472,8 @@ export type VisionSseEvent =
   | { type: 'vision_ready'; vision_doc: VisionDoc }
   | { type: 'error'; code: string; message: string }
   | { type: 'done' };
+
+export interface VisionProposals {
+  open: number;
+  accepted_recent: number;
+}

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getRunFullContext, getRunDiff, getCoordinatorMessages } from '../lib/api';
-  import { formatTokens, formatDuration, timeAgo, formatRunMode } from '../lib/format';
+  import { formatTokens, formatDuration, timeAgo, formatRunMode, formatSkipReason } from '../lib/format';
   import { getAgentName, getAgentColor } from '../lib/agent-presence.svelte';
   import type { RunFullContext, DiffResult, CoordinatorMessage } from '../lib/types';
   import { navigate } from '../lib/router.svelte';
@@ -118,6 +118,11 @@
           {#if run.mode}
             {@const m = formatRunMode(run.mode)}
             <span class="badge badge-{run.mode}">{m.icon} {m.label}</span>
+          {/if}
+          {#if run.skip_reason}
+            <div class="text-sm" style="color: var(--color-text-secondary, #6b6b6b); margin-top: 0.25rem;">
+              {formatSkipReason(run.skip_reason)}
+            </div>
           {/if}
           {#if run.model}
             <span>{run.model}</span>

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getRunFullContext, getRunDiff, getCoordinatorMessages } from '../lib/api';
-  import { formatTokens, formatDuration, timeAgo } from '../lib/format';
+  import { formatTokens, formatDuration, timeAgo, formatRunMode } from '../lib/format';
   import { getAgentName, getAgentColor } from '../lib/agent-presence.svelte';
   import type { RunFullContext, DiffResult, CoordinatorMessage } from '../lib/types';
   import { navigate } from '../lib/router.svelte';
@@ -116,7 +116,8 @@
             <span>#{run.issue_number}</span>
           {/if}
           {#if run.mode}
-            <span class="badge badge-{run.mode}">{run.mode}</span>
+            {@const m = formatRunMode(run.mode)}
+            <span class="badge badge-{run.mode}">{m.icon} {m.label}</span>
           {/if}
           {#if run.model}
             <span>{run.model}</span>

--- a/dashboard/frontend/src/pages/RunsPage.svelte
+++ b/dashboard/frontend/src/pages/RunsPage.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { listRuns } from '../lib/api';
   import { navigate } from '../lib/router.svelte';
-  import { formatTokens, formatDuration, timeAgo } from '../lib/format';
+  import { formatTokens, formatDuration, timeAgo, formatRunMode, formatSkipReason } from '../lib/format';
   import type { Run } from '../lib/types';
   import SkeletonLoader from '../components/data-display/SkeletonLoader.svelte';
   import EmptyState from '../components/data-display/EmptyState.svelte';
@@ -46,10 +46,6 @@
     return verdict ? map[verdict] ?? '' : '';
   }
 
-  function getModeBadge(mode: string | null): string {
-    return mode ? `badge-${mode}` : '';
-  }
-
   function getStatusDot(run: Run): string {
     // Any active sub-state of a live run should render green, not offline.
     if (
@@ -65,6 +61,7 @@
   }
 
   function getRowTint(run: Run): string {
+    if (run.mode === 'vision-bootstrap') return 'background: rgba(176,96,48,0.04); border-left: 2px solid var(--color-violet);';
     if (run.verdict === 'APPROVE' || run.verdict === 'PR') return 'background: rgba(46,125,50,0.03);';
     if (run.verdict === 'REJECT') return 'background: rgba(208,96,80,0.03);';
     if (run.status === 'started') return 'background: rgba(46,125,50,0.02);';
@@ -139,9 +136,11 @@
           {/each}
         {:else}
           {#each runs as run, i (run.id)}
+            {@const m = formatRunMode(run.mode)}
+            {@const skipHint = formatSkipReason(run.skip_reason)}
             <tr
               class="hover:bg-surface-1/50 cursor-pointer transition-colors animate-slide-up stagger-{Math.min(i + 1, 6)}"
-              style="{getRowTint(run)} border-bottom: 1px solid rgba(240,220,200,0.10);"
+              style="{getRowTint(run)} border-bottom: {skipHint ? 'none' : '1px solid rgba(240,220,200,0.10)'};"
               onclick={() => navigate(`/runs/${run.run_id}`)}
               role="button"
               tabindex="0"
@@ -153,7 +152,9 @@
                 {#if run.issue_number}<span class="text-xs text-primary">#{run.issue_number}</span>
                 {:else}<span class="text-xs text-ghost">-</span>{/if}
               </td>
-              <td class="p-3">{#if run.mode}<span class="badge {getModeBadge(run.mode)}">{run.mode}</span>{:else}<span class="text-xs text-ghost">-</span>{/if}</td>
+              <td class="p-3">
+                <span class="badge badge-{run.mode ?? 'default'}">{m.icon} {m.label}</span>
+              </td>
               <td class="p-3"><span class="text-xs font-mono text-tertiary">{run.model?.split('-').pop() ?? '-'}</span></td>
               <td class="p-3"><AutonomyBadge level={run.autonomy_level} size="xs" /></td>
               <td class="p-3">
@@ -165,6 +166,21 @@
               <td class="p-3 text-right"><span class="font-mono text-xs text-secondary">{run.duration_ms ? formatDuration(run.duration_ms) : '-'}</span></td>
               <td class="p-3 text-right"><span class="font-mono text-xs text-tertiary">{timeAgo(run.started_at)}</span></td>
             </tr>
+            {#if skipHint}
+              <tr
+                style="{getRowTint(run)} border-bottom: 1px solid rgba(240,220,200,0.10);"
+                onclick={() => navigate(`/runs/${run.run_id}`)}
+                role="button"
+                tabindex="-1"
+                onkeydown={(e) => e.key === 'Enter' && navigate(`/runs/${run.run_id}`)}
+                class="cursor-pointer"
+              >
+                <td></td>
+                <td colspan="9" class="pb-2 pt-0 px-3">
+                  <span class="text-xs font-mono" style="color: var(--color-violet);">{skipHint}</span>
+                </td>
+              </tr>
+            {/if}
           {/each}
         {/if}
         {#if !loading && runs.length === 0}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -281,6 +281,18 @@ See [`configuration.md`](configuration.md#environment-variables) for the full ta
 
 ---
 
+## Run Modes
+
+The orchestrator dispatches runs in different modes, each with distinct behavior and responsibilities:
+
+- **`agent-teams`** — full autonomous workflow: lead decomposes eligible issues into tasks, spawns three teammates in isolated worktrees, manager reviews each implementation, verdicts issued (APPROVE/PR/REJECT).
+- **`vision-bootstrap`** — single-shot run that dispatches `agent/vision_analyst.py` to propose new issues from `docs/vision.md`. Triggered automatically (orchestrator empty backlog, or vision commit with content-hash change) or manually from the Vision tab. Never spawns teammates, never opens PRs.
+- **`fix`** — single-issue repair mode for regressions and urgent bugs.
+- **`triage`** — issue classification and labeling without implementation.
+- **`review`** — security or code review mode for pull requests.
+
+---
+
 ## Deployment Model
 
 ### Hardlink Deployment

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,7 @@ Defaults per role (from `agent/config/default-config.json`):
 | Analyst | `claude-sonnet-4-6` | `models.analyst` |
 | Planner | `claude-sonnet-4-6` | `models.planner` |
 | Router | `claude-haiku-4-5-20251001` | `models.router` |
+| Vision analyst | `claude-sonnet-4-6` | env: `STATION_VISION_ANALYST_MODEL` |
 
 To change a model, set the corresponding key via the dashboard Config page or `PATCH /api/config`. The orchestrator picks up the change on the next run.
 
@@ -123,3 +124,12 @@ Example JSON for the `POST /api/projects` request body:
   "setup_script": "pip install -r requirements.txt"
 }
 ```
+
+### Vision-driven issue bootstrap
+
+When a project has `docs/vision.md`, two automatic triggers fire the vision analyst:
+
+- **Trigger A (orchestrator):** triggered runs that find no eligible issues dispatch the analyst when no `vision-suggested` issues are already open. The triggering run terminates with `Run.skip_reason = no-eligible-issues-bootstrap-dispatched`.
+- **Trigger B (vision commit):** committing a new vision via the dashboard fires the analyst when the document SHA changes. Idempotent on identical re-commits via `Project.last_vision_analyzed_sha`.
+
+Both produce `Run.mode = vision-bootstrap` rows that surface in the Runs list and Mission Control. Issues land with the `vision-suggested` label; remove the label to accept (the orchestrator's `SKIP_LABELS` blocks autonomous implementation until then).

--- a/docs/superpowers/plans/2026-05-08-vision-issue-bootstrap.md
+++ b/docs/superpowers/plans/2026-05-08-vision-issue-bootstrap.md
@@ -1,0 +1,1681 @@
+# Vision-driven Issue Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-fire `vision_analyst` from two trigger points (orchestrator on empty backlog; vision commit with content-hash change) and surface the activity as a distinct `vision-bootstrap` run type in the dashboard.
+
+**Architecture:** No new worker. Reuse `agent/vision_analyst.py`, `agent/launcher.py:/vision-analyst`, and `service_control.start_vision_analyst`. Add a `vision-bootstrap` value for `Run.mode`, four nullable DB columns, two trigger sites, one new endpoint, and four UI surfaces. Vision-analyst worker self-registers as a `Run` row by calling the existing `/api/webhook/run-event` endpoint.
+
+**Tech Stack:** Python 3.11+ / FastAPI / SQLite / SQLAlchemy / pytest / pytest-asyncio / httpx (orchestrator → launcher); Svelte 5 / TypeScript / Vitest (frontend).
+
+**Spec:** `docs/superpowers/specs/2026-05-08-vision-issue-bootstrap-design.md`
+
+**Branch:** `feature/vision-bootstrap` (already created; spec already committed).
+
+---
+
+## File map
+
+### Backend
+
+| File | Change |
+|---|---|
+| `dashboard/backend/app/database.py` | Append 4 ALTER TABLE entries to `migrations` list |
+| `dashboard/backend/app/models.py` | Add 4 columns: `Run.skip_reason`, `Run.vision_bootstrap_count`, `Run.vision_bootstrap_proposals`, `Project.last_vision_analyzed_sha` |
+| `dashboard/backend/app/schemas.py` | Extend `WebhookRunEvent` with the 3 new run fields; extend `RunRead` with `skip_reason`, `vision_bootstrap_count`; add `VisionProposalsRead` |
+| `dashboard/backend/app/services/run_lifecycle.py` | `handle_finished` persists `vision_bootstrap_count` + `vision_bootstrap_proposals`; `handle_started` no change (already persists `mode`) |
+| `dashboard/backend/app/routers/runs.py` | `RunRead` mapping carries the new fields out; existing `?mode=` filter already works for new value |
+| `dashboard/backend/app/routers/vision.py` | Hook in `commit_vision` (Trigger B); new `GET /{project_id}/vision/proposals` endpoint |
+| `agent/vision_analyst.py` | `run_for_project` posts `started` + `finished` webhooks with the new fields |
+| `agent/station_orchestrator.py` | Replace lines 932–934 (`No eligible issues, skipping`) with dispatch logic + skip-reason webhook |
+
+### Frontend
+
+| File | Change |
+|---|---|
+| `dashboard/frontend/src/lib/types.ts` | Add `skip_reason` and `vision_bootstrap_count` to `Run`; add `VisionProposals` type |
+| `dashboard/frontend/src/lib/api.ts` | Add `getVisionProposals(projectId)` |
+| `dashboard/frontend/src/lib/format.ts` | Add `formatRunMode(mode)` returning `{ icon, label, accent }` |
+| `dashboard/frontend/src/components/runs/RunStatus.svelte` (new, small) | Renders mode-aware icon + label; consumed by Runs list, Run detail, Mission Control |
+| `dashboard/frontend/src/pages/RunsPage.svelte` | Render `skip_reason` hint line under the row when present |
+| `dashboard/frontend/src/components/vision/VisionTab.svelte` | New "Vision analyst" info strip above existing UI |
+| `dashboard/frontend/src/lib/format.test.ts` | Tests for `formatRunMode` |
+| `dashboard/frontend/src/components/vision/VisionTab.test.ts` (new) | Smoke test for the info strip rendering |
+
+### Docs
+
+| File | Change |
+|---|---|
+| `docs/configuration.md` | Document `STATION_VISION_ANALYST_MODEL` env var; new triggers section under "Project config" |
+| `docs/architecture.md` | One paragraph + run-type entry for `vision-bootstrap` |
+
+---
+
+## Task 1: DB schema migration + ORM columns
+
+**Files:**
+- Modify: `dashboard/backend/app/models.py:40-77` (Run class), `:17-37` (Project class)
+- Modify: `dashboard/backend/app/database.py:38-90` (migrations list)
+- Test: `dashboard/backend/tests/test_migrations.py`
+
+- [ ] **Step 1: Write the failing migration test**
+
+Append to `dashboard/backend/tests/test_migrations.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_vision_bootstrap_columns_present():
+    """The four vision-bootstrap columns must exist after migration."""
+    from sqlalchemy import text
+    from app.database import init_db, engine
+
+    await init_db()
+    async with engine.begin() as conn:
+        runs_cols = {row[1] for row in (
+            await conn.execute(text("PRAGMA table_info(runs)"))
+        ).fetchall()}
+        projects_cols = {row[1] for row in (
+            await conn.execute(text("PRAGMA table_info(projects)"))
+        ).fetchall()}
+
+    assert "skip_reason" in runs_cols
+    assert "vision_bootstrap_count" in runs_cols
+    assert "vision_bootstrap_proposals" in runs_cols
+    assert "last_vision_analyzed_sha" in projects_cols
+```
+
+- [ ] **Step 2: Run the test — must fail**
+
+```bash
+cd /home/simon/Documents/claude-agent-station/dashboard/backend
+pytest tests/test_migrations.py::test_vision_bootstrap_columns_present -v
+```
+Expected: FAIL — columns missing.
+
+- [ ] **Step 3: Add columns to ORM models**
+
+In `dashboard/backend/app/models.py`, add inside the `Run` class (after `max_budget_usd` at line 77):
+
+```python
+    # Vision-bootstrap (spec 2026-05-08-vision-issue-bootstrap-design.md)
+    skip_reason = Column(Text, nullable=True)
+    vision_bootstrap_count = Column(Integer, nullable=True)
+    vision_bootstrap_proposals = Column(Text, nullable=True)  # JSON list
+```
+
+Add inside `Project` class (after `vision_cached_at` at line 35):
+
+```python
+    last_vision_analyzed_sha = Column(Text, nullable=True, default=None)
+```
+
+- [ ] **Step 4: Add migration entries**
+
+In `dashboard/backend/app/database.py`, append to the `migrations` list (after line 89):
+
+```python
+        # Vision-bootstrap columns (spec 2026-05-08-vision-issue-bootstrap-design.md)
+        ("runs", "skip_reason", "ALTER TABLE runs ADD COLUMN skip_reason TEXT"),
+        ("runs", "vision_bootstrap_count", "ALTER TABLE runs ADD COLUMN vision_bootstrap_count INTEGER"),
+        ("runs", "vision_bootstrap_proposals", "ALTER TABLE runs ADD COLUMN vision_bootstrap_proposals TEXT"),
+        ("projects", "last_vision_analyzed_sha", "ALTER TABLE projects ADD COLUMN last_vision_analyzed_sha TEXT"),
+```
+
+- [ ] **Step 5: Run the test — must pass**
+
+```bash
+pytest tests/test_migrations.py::test_vision_bootstrap_columns_present -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Run full suite to ensure no regressions**
+
+```bash
+pytest -x --tb=short -q 2>&1 | tail -8
+```
+Expected: 891 passed (was 890), 1 skipped — same baseline plus the new test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/backend/app/models.py dashboard/backend/app/database.py dashboard/backend/tests/test_migrations.py
+git commit -m "feat(db): add vision-bootstrap columns to runs and projects
+
+Adds Run.skip_reason, Run.vision_bootstrap_count,
+Run.vision_bootstrap_proposals, Project.last_vision_analyzed_sha
+per spec 2026-05-08-vision-issue-bootstrap-design.md."
+```
+
+---
+
+## Task 2: Extend webhook schema and lifecycle to persist new fields
+
+**Files:**
+- Modify: `dashboard/backend/app/schemas.py` (find `WebhookRunEvent` and `RunRead`)
+- Modify: `dashboard/backend/app/services/run_lifecycle.py:151-205` (`handle_finished`)
+- Modify: `dashboard/backend/app/routers/runs.py` (`RunRead` field passthrough)
+- Test: `dashboard/backend/tests/test_run_lifecycle.py`
+
+- [ ] **Step 1: Find the schemas to extend**
+
+```bash
+grep -n "class WebhookRunEvent\|class RunRead" /home/simon/Documents/claude-agent-station/dashboard/backend/app/schemas.py
+```
+
+Read each class fully so the additions match the existing style (Optional vs `| None`, snake_case, etc.).
+
+- [ ] **Step 2: Write the failing lifecycle test**
+
+Add to `dashboard/backend/tests/test_run_lifecycle.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_handle_finished_persists_vision_bootstrap_fields(setup_db):
+    from app.services.run_lifecycle import handle_finished
+    from app.schemas import WebhookRunEvent
+    from app.database import async_session
+    from app.models import Run
+
+    event = WebhookRunEvent(
+        event="finished",
+        run_id="run-vb-test-1",
+        project="laboef1900/next-itsm",
+        mode="vision-bootstrap",
+        status="success",
+        vision_bootstrap_count=3,
+        vision_bootstrap_proposals=[
+            {"number": 101, "title": "Add metrics dashboard", "url": "https://github.com/x/y/issues/101"},
+            {"number": 102, "title": "Document API", "url": "https://github.com/x/y/issues/102"},
+            {"number": 103, "title": "Add CI", "url": "https://github.com/x/y/issues/103"},
+        ],
+    )
+    async with async_session() as db:
+        run = await handle_finished(db, event, project_id=None, run=None)
+        await db.commit()
+        await db.refresh(run)
+        assert run.mode == "vision-bootstrap"
+        assert run.vision_bootstrap_count == 3
+        proposals = json.loads(run.vision_bootstrap_proposals)
+        assert len(proposals) == 3
+        assert proposals[0]["number"] == 101
+```
+
+(Add `import json` at the top of the test file if missing.)
+
+- [ ] **Step 3: Run the test — must fail**
+
+```bash
+pytest tests/test_run_lifecycle.py::test_handle_finished_persists_vision_bootstrap_fields -v
+```
+Expected: FAIL — `WebhookRunEvent` rejects unknown fields, or the values aren't persisted.
+
+- [ ] **Step 4: Extend the schema**
+
+In `dashboard/backend/app/schemas.py`, locate `WebhookRunEvent` and add (alphabetically grouped if the existing style is alphabetical, else at the bottom of the field list, before any model_config):
+
+```python
+    # Vision-bootstrap fields — spec 2026-05-08-vision-issue-bootstrap-design.md
+    vision_bootstrap_count: int | None = None
+    vision_bootstrap_proposals: list[dict] | None = None
+    skip_reason: str | None = None
+```
+
+In the same file, locate `RunRead` and add the same three fields (with `int | None`, `list[dict] | None`, `str | None`).
+
+- [ ] **Step 5: Persist in lifecycle**
+
+In `dashboard/backend/app/services/run_lifecycle.py`, inside `handle_finished` after line 184 (`run.model = event.model or run.model`), add:
+
+```python
+    # Vision-bootstrap: only set when the event carries them so we don't
+    # overwrite a regular run's NULLs with NULL-from-event.
+    if event.vision_bootstrap_count is not None:
+        run.vision_bootstrap_count = event.vision_bootstrap_count
+    if event.vision_bootstrap_proposals is not None:
+        run.vision_bootstrap_proposals = json.dumps(event.vision_bootstrap_proposals)
+    if event.skip_reason is not None:
+        run.skip_reason = event.skip_reason
+```
+
+(Verify `import json` is already at the top of `run_lifecycle.py` — it is, used for `employee_report`.)
+
+- [ ] **Step 6: Map fields in the runs router response**
+
+In `dashboard/backend/app/routers/runs.py`, find the `RunRead` construction (typically `RunRead.model_validate(run)` or a manual mapping in `list_runs` / `get_run`). If manual, add:
+
+```python
+    skip_reason=r.skip_reason,
+    vision_bootstrap_count=r.vision_bootstrap_count,
+    vision_bootstrap_proposals=json.loads(r.vision_bootstrap_proposals) if r.vision_bootstrap_proposals else None,
+```
+
+If `RunRead.model_validate(run)` is used, the new fields will pass through automatically — verify by reading the surrounding code.
+
+- [ ] **Step 7: Run the test — must pass**
+
+```bash
+pytest tests/test_run_lifecycle.py::test_handle_finished_persists_vision_bootstrap_fields -v
+```
+Expected: PASS.
+
+- [ ] **Step 8: Run the full suite**
+
+```bash
+pytest -x --tb=short -q 2>&1 | tail -8
+```
+Expected: 892 passed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add dashboard/backend/app/schemas.py dashboard/backend/app/services/run_lifecycle.py dashboard/backend/app/routers/runs.py dashboard/backend/tests/test_run_lifecycle.py
+git commit -m "feat(api): persist vision-bootstrap fields on run-finished
+
+Extends WebhookRunEvent + RunRead with skip_reason,
+vision_bootstrap_count, vision_bootstrap_proposals.
+handle_finished persists them when present."
+```
+
+---
+
+## Task 3: Vision-analyst worker self-registers as a `vision-bootstrap` run
+
+**Files:**
+- Modify: `agent/vision_analyst.py:238-267` (`run_for_project`)
+- Test: `dashboard/backend/tests/test_vision_analyst.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_vision_analyst.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_run_for_project_posts_started_and_finished_webhooks(monkeypatch, tmp_path):
+    """run_for_project must POST started + finished events with mode=vision-bootstrap."""
+    from agent import vision_analyst as va
+
+    posted = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        posted.append({"url": url, "json": json})
+        class R:
+            status_code = 200
+            def raise_for_status(self): pass
+        return R()
+
+    monkeypatch.setattr(va.httpx, "post", fake_post, raising=False)
+    monkeypatch.setattr(va, "_ensure_workspace", lambda w, r: True)
+    monkeypatch.setattr(va, "load_vision", lambda w: {
+        "problem": "p", "users": "u", "end_state": "e",
+        "non_goals": "n", "principles": "pr", "horizons": "h",
+        "anti_patterns": "a",
+    })
+    monkeypatch.setattr(va, "propose_gaps", lambda w, v, r, m: [
+        {"title": "T1", "body": "B1", "priority": "low"},
+    ])
+    monkeypatch.setattr(va, "create_proposed_issues", lambda r, p: [101])
+    monkeypatch.setenv("STATION_WEBHOOK_URL", "http://test/api/webhook/run-event")
+    monkeypatch.setenv("STATION_WORKSPACES", str(tmp_path))
+
+    # A Project row with id=1 needs to exist; reuse the test-db fixture pattern
+    from app.database import async_session, init_db
+    from app.models import Project
+    await init_db()
+    async with async_session() as db:
+        db.add(Project(id=1, repo="x/y", branch="main"))
+        await db.commit()
+
+    result = await va.run_for_project(1)
+    assert result["ok"] is True
+
+    # Two webhook POSTs: started, finished
+    assert len(posted) == 2
+    started = posted[0]["json"]
+    finished = posted[1]["json"]
+    assert started["event"] == "started"
+    assert started["mode"] == "vision-bootstrap"
+    assert started["run_id"].startswith("run-vb-")
+    assert finished["event"] == "finished"
+    assert finished["mode"] == "vision-bootstrap"
+    assert finished["status"] == "success"
+    assert finished["vision_bootstrap_count"] == 1
+    assert finished["vision_bootstrap_proposals"][0]["number"] == 101
+```
+
+- [ ] **Step 2: Run the test — must fail**
+
+```bash
+pytest tests/test_vision_analyst.py::test_run_for_project_posts_started_and_finished_webhooks -v
+```
+Expected: FAIL — `httpx` import missing or no webhook POSTs happen.
+
+- [ ] **Step 3: Add webhook posting helper to `agent/vision_analyst.py`**
+
+At the top of `agent/vision_analyst.py`, after `import sys`, add:
+
+```python
+import uuid
+
+import httpx
+```
+
+After `DISCLAIMER` (around line 27), add:
+
+```python
+def _webhook_url() -> str | None:
+    return os.environ.get("STATION_WEBHOOK_URL") or None
+
+
+def _webhook_secret() -> str | None:
+    return os.environ.get("STATION_WEBHOOK_SECRET") or None
+
+
+def _post_webhook(payload: dict) -> None:
+    """Best-effort POST to STATION_WEBHOOK_URL. Failures are logged, not raised."""
+    url = _webhook_url()
+    if not url:
+        logger.info("vision_analyst: STATION_WEBHOOK_URL unset, skipping webhook")
+        return
+    headers = {}
+    secret = _webhook_secret()
+    if secret:
+        headers["X-Webhook-Token"] = secret
+    try:
+        resp = httpx.post(url, json=payload, headers=headers, timeout=5.0)
+        if resp.status_code >= 400:
+            logger.warning("vision_analyst webhook %s -> %s: %s",
+                           payload.get("event"), resp.status_code, resp.text[:200])
+    except httpx.HTTPError as exc:
+        logger.warning("vision_analyst webhook POST failed: %s", exc)
+```
+
+- [ ] **Step 4: Wrap `run_for_project` with webhook calls**
+
+Replace the existing `run_for_project` body (lines 238–267) so it registers a run and reports back. The new flow:
+
+```python
+async def run_for_project(project_id: int) -> dict:
+    """Entry point: load project from DB, run analyst, return summary.
+
+    Self-registers as a `vision-bootstrap` Run via webhooks so the dashboard
+    sees the activity in Mission Control + Runs list.
+    """
+    from app.database import async_session, init_db
+    from app.models import Project
+    from agent.vision import load_vision
+
+    await init_db()
+    async with async_session() as db:
+        project = await db.get(Project, project_id)
+        if not project:
+            return {"ok": False, "error": "project not found"}
+        repo = project.repo
+
+    workspaces_dir = os.environ.get("STATION_WORKSPACES", "/var/lib/claude-agent-station/workspaces")
+    name = repo.split("/")[-1]
+    workspace = os.path.join(workspaces_dir, name)
+
+    run_id = f"run-vb-{uuid.uuid4().hex[:12]}"
+    _post_webhook({
+        "event": "started",
+        "run_id": run_id,
+        "project": repo,
+        "mode": "vision-bootstrap",
+    })
+
+    def _finish(status: str, **extra) -> None:
+        _post_webhook({
+            "event": "finished",
+            "run_id": run_id,
+            "project": repo,
+            "mode": "vision-bootstrap",
+            "status": status,
+            **extra,
+        })
+
+    if not _ensure_workspace(workspace, repo):
+        _finish("error")
+        return {"ok": False, "error": f"could not clone {repo}"}
+
+    vision = load_vision(workspace)
+    if vision is None:
+        _finish("error")
+        return {"ok": False, "error": "no vision file at docs/vision.md"}
+
+    model = os.environ.get("STATION_VISION_ANALYST_MODEL", "claude-sonnet-4-6")
+    proposals = propose_gaps(workspace, vision, repo, model)
+    if not proposals:
+        _finish("success", vision_bootstrap_count=0, vision_bootstrap_proposals=[])
+        return {"ok": True, "proposals": [], "created": []}
+
+    created = create_proposed_issues(repo, proposals)
+    proposal_records = [
+        {
+            "number": num,
+            "title": p.get("title", ""),
+            "url": f"https://github.com/{repo}/issues/{num}",
+        }
+        for num, p in zip(created, proposals)
+    ]
+    _finish(
+        "success",
+        vision_bootstrap_count=len(created),
+        vision_bootstrap_proposals=proposal_records,
+    )
+    return {"ok": True, "proposals": proposals, "created": created}
+```
+
+- [ ] **Step 5: Run the test — must pass**
+
+```bash
+pytest tests/test_vision_analyst.py -v
+```
+Expected: all `test_vision_analyst.py` tests pass (existing + the new one).
+
+- [ ] **Step 6: Run full suite**
+
+```bash
+pytest -x --tb=short -q 2>&1 | tail -8
+```
+Expected: 893 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/vision_analyst.py dashboard/backend/tests/test_vision_analyst.py
+git commit -m "feat(agent): vision_analyst self-registers as vision-bootstrap run
+
+run_for_project now POSTs started + finished webhooks so the dashboard
+sees the activity end-to-end. Adds STATION_WEBHOOK_URL +
+STATION_WEBHOOK_SECRET integration matching run-manager.sh."
+```
+
+---
+
+## Task 4: Helper — `has_open_vision_proposals`
+
+**Files:**
+- Modify: `agent/station_orchestrator.py` (add helper near `fetch_eligible_issues`)
+- Test: `dashboard/backend/tests/test_orchestrator_wiring.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_orchestrator_wiring.py`:
+
+```python
+def test_has_open_vision_proposals_true_when_label_present(monkeypatch):
+    from agent.station_orchestrator import has_open_vision_proposals
+    fake_stdout = '[{"number": 1, "labels": [{"name": "vision-suggested"}]}]'
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: type("R", (), {"returncode": 0, "stdout": fake_stdout, "stderr": ""}),
+    )
+    assert has_open_vision_proposals("x/y") is True
+
+
+def test_has_open_vision_proposals_false_when_no_matches(monkeypatch):
+    from agent.station_orchestrator import has_open_vision_proposals
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""}),
+    )
+    assert has_open_vision_proposals("x/y") is False
+
+
+def test_has_open_vision_proposals_false_on_gh_failure(monkeypatch):
+    from agent.station_orchestrator import has_open_vision_proposals
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: type("R", (), {"returncode": 1, "stdout": "", "stderr": "boom"}),
+    )
+    assert has_open_vision_proposals("x/y") is False
+```
+
+- [ ] **Step 2: Run the test — must fail**
+
+```bash
+pytest tests/test_orchestrator_wiring.py::test_has_open_vision_proposals_true_when_label_present -v
+```
+Expected: FAIL — function doesn't exist.
+
+- [ ] **Step 3: Add the helper**
+
+In `agent/station_orchestrator.py`, immediately after `fetch_eligible_issues` (after the `eligible[:limit]` return at ~line 233), add:
+
+```python
+def has_open_vision_proposals(repo: str) -> bool:
+    """True if any open issue carries the `vision-suggested` label.
+
+    Used to skip Trigger A when the user hasn't yet processed the prior
+    batch of proposals. A `gh` failure returns False — fail-safe; we'd
+    rather miss a dispatch than spam the operator.
+    """
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", repo,
+        "--state", "open",
+        "--label", "vision-suggested",
+        "--limit", "1",
+        "--json", "number,labels",
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            logger.warning("has_open_vision_proposals: gh failed: %s", result.stderr.strip())
+            return False
+        return len(json.loads(result.stdout or "[]")) > 0
+    except Exception as exc:
+        logger.warning("has_open_vision_proposals: %s", exc)
+        return False
+```
+
+- [ ] **Step 4: Run the tests — must pass**
+
+```bash
+pytest tests/test_orchestrator_wiring.py -k has_open_vision_proposals -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/station_orchestrator.py dashboard/backend/tests/test_orchestrator_wiring.py
+git commit -m "feat(orchestrator): has_open_vision_proposals helper
+
+Returns True when any open issue carries vision-suggested label.
+Used by Trigger A to skip dispatch when prior proposals are pending."
+```
+
+---
+
+## Task 5: Helper — `dispatch_vision_bootstrap`
+
+**Files:**
+- Modify: `agent/station_orchestrator.py` (add helper near `has_open_vision_proposals`)
+- Test: `dashboard/backend/tests/test_orchestrator_wiring.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `dashboard/backend/tests/test_orchestrator_wiring.py`:
+
+```python
+def test_dispatch_vision_bootstrap_returns_dispatched_on_200(monkeypatch):
+    import httpx
+    from agent.station_orchestrator import dispatch_vision_bootstrap
+    class R:
+        status_code = 200
+        text = ""
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: R())
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://launcher:8421")
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "tok")
+    assert dispatch_vision_bootstrap(42) == "dispatched"
+
+
+def test_dispatch_vision_bootstrap_returns_already_running_on_409(monkeypatch):
+    import httpx
+    from agent.station_orchestrator import dispatch_vision_bootstrap
+    class R:
+        status_code = 409
+        text = "vision-analyst already running"
+    monkeypatch.setattr(httpx, "post", lambda *a, **k: R())
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://launcher:8421")
+    assert dispatch_vision_bootstrap(42) == "already-running"
+
+
+def test_dispatch_vision_bootstrap_falls_back_to_subprocess(monkeypatch):
+    """When launcher is unreachable, spawn directly via subprocess."""
+    import httpx
+    from agent.station_orchestrator import dispatch_vision_bootstrap
+    def boom(*a, **k):
+        raise httpx.RequestError("connection refused")
+    monkeypatch.setattr(httpx, "post", boom)
+    spawned = []
+    monkeypatch.setattr(
+        "subprocess.Popen",
+        lambda cmd, *a, **k: spawned.append(cmd) or type("P", (), {"pid": 1234})(),
+    )
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://launcher:8421")
+    assert dispatch_vision_bootstrap(42) == "dispatched"
+    assert spawned == [["python", "-m", "agent.vision_analyst", "--project-id", "42"]]
+```
+
+- [ ] **Step 2: Run the tests — must fail**
+
+```bash
+pytest tests/test_orchestrator_wiring.py -k dispatch_vision_bootstrap -v
+```
+Expected: 3 FAIL — function not defined.
+
+- [ ] **Step 3: Add the helper**
+
+At the top of `agent/station_orchestrator.py`, add (if not already present):
+
+```python
+import httpx
+```
+
+Below `has_open_vision_proposals`, add:
+
+```python
+def dispatch_vision_bootstrap(project_id: int) -> str:
+    """Trigger a vision-analyst run for ``project_id``.
+
+    Tries the in-container launcher first (compose-mode path) and falls
+    back to spawning the worker via subprocess (systemd-mode path or any
+    failure where the launcher is unreachable).
+
+    Returns one of:
+      - "dispatched"      — analyst was started
+      - "already-running" — launcher reported 409
+    """
+    launcher_url = os.environ.get(
+        "STATION_AGENT_LAUNCHER_URL", "http://localhost:8421",
+    ).rstrip("/")
+    token = os.environ.get("STATION_LAUNCHER_TOKEN", "")
+    headers = {"X-Launcher-Token": token} if token else {}
+
+    try:
+        resp = httpx.post(
+            f"{launcher_url}/vision-analyst",
+            params={"project_id": project_id},
+            headers=headers,
+            timeout=5.0,
+        )
+        if resp.status_code == 409:
+            logger.info("vision-analyst already running (409)")
+            return "already-running"
+        if 200 <= resp.status_code < 300:
+            return "dispatched"
+        logger.warning(
+            "launcher /vision-analyst returned %s: %s",
+            resp.status_code, resp.text[:200],
+        )
+    except httpx.RequestError as exc:
+        logger.info("launcher unreachable (%s); falling back to subprocess", exc)
+
+    # Fallback: spawn the worker directly. No cross-process lock; best
+    # effort. systemd path or compose with launcher down.
+    subprocess.Popen(
+        ["python", "-m", "agent.vision_analyst", "--project-id", str(project_id)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return "dispatched"
+```
+
+- [ ] **Step 4: Run the tests — must pass**
+
+```bash
+pytest tests/test_orchestrator_wiring.py -k dispatch_vision_bootstrap -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/station_orchestrator.py dashboard/backend/tests/test_orchestrator_wiring.py
+git commit -m "feat(orchestrator): dispatch_vision_bootstrap helper
+
+POSTs to in-container launcher with subprocess fallback for systemd.
+Returns 'dispatched' or 'already-running' for the per-project loop."
+```
+
+---
+
+## Task 6: Trigger A — orchestrator integrates the helpers
+
+**Files:**
+- Modify: `agent/station_orchestrator.py:931-934` (the `if not issues` skip block)
+- Test: `dashboard/backend/tests/test_orchestrator_wiring.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `dashboard/backend/tests/test_orchestrator_wiring.py`:
+
+```python
+def test_handle_empty_backlog_dispatches_when_vision_and_no_proposals(monkeypatch, tmp_path):
+    """Trigger A: dispatches and reports skip_reason=bootstrap-dispatched."""
+    from agent import station_orchestrator as so
+
+    # Create a fake workspace with docs/vision.md
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    (ws / "docs").mkdir()
+    (ws / "docs" / "vision.md").write_text("## Problem\np\n## Users\nu\n## End-state\ne\n## Non-goals\nn\n## Principles\npr\n## Horizons\nh\n## Anti-patterns\na\n")
+
+    monkeypatch.setattr(so, "has_open_vision_proposals", lambda r: False)
+    dispatched = []
+    monkeypatch.setattr(so, "dispatch_vision_bootstrap", lambda pid: dispatched.append(pid) or "dispatched")
+    posted = []
+    monkeypatch.setattr(so, "post_webhook", lambda cfg, ev, data: posted.append((ev, data)))
+
+    skip_reason = so.handle_empty_backlog(
+        config={}, repo="x/y", project_id=42, workspace=str(ws), run_id="r-1",
+    )
+    assert skip_reason == "no-eligible-issues-bootstrap-dispatched"
+    assert dispatched == [42]
+    # The orchestrator emits a finished webhook for the regular run row
+    assert any(ev == "finished" and d.get("skip_reason") == skip_reason for ev, d in posted)
+
+
+def test_handle_empty_backlog_no_vision(monkeypatch, tmp_path):
+    from agent import station_orchestrator as so
+    ws = tmp_path / "repo"
+    ws.mkdir()  # no docs/vision.md
+    monkeypatch.setattr(so, "has_open_vision_proposals", lambda r: False)
+    dispatched = []
+    monkeypatch.setattr(so, "dispatch_vision_bootstrap", lambda pid: dispatched.append(pid) or "dispatched")
+    monkeypatch.setattr(so, "post_webhook", lambda *a, **k: None)
+    skip_reason = so.handle_empty_backlog(
+        config={}, repo="x/y", project_id=42, workspace=str(ws), run_id="r-1",
+    )
+    assert skip_reason == "no-eligible-issues-no-vision"
+    assert dispatched == []
+
+
+def test_handle_empty_backlog_proposals_pending(monkeypatch, tmp_path):
+    from agent import station_orchestrator as so
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    (ws / "docs").mkdir()
+    (ws / "docs" / "vision.md").write_text("## Problem\np\n## Users\nu\n## End-state\ne\n## Non-goals\nn\n## Principles\npr\n## Horizons\nh\n## Anti-patterns\na\n")
+    monkeypatch.setattr(so, "has_open_vision_proposals", lambda r: True)
+    dispatched = []
+    monkeypatch.setattr(so, "dispatch_vision_bootstrap", lambda pid: dispatched.append(pid) or "dispatched")
+    monkeypatch.setattr(so, "post_webhook", lambda *a, **k: None)
+    skip_reason = so.handle_empty_backlog(
+        config={}, repo="x/y", project_id=42, workspace=str(ws), run_id="r-1",
+    )
+    assert skip_reason == "no-eligible-issues-proposals-pending"
+    assert dispatched == []
+
+
+def test_handle_empty_backlog_already_running(monkeypatch, tmp_path):
+    from agent import station_orchestrator as so
+    ws = tmp_path / "repo"
+    ws.mkdir()
+    (ws / "docs").mkdir()
+    (ws / "docs" / "vision.md").write_text("## Problem\np\n## Users\nu\n## End-state\ne\n## Non-goals\nn\n## Principles\npr\n## Horizons\nh\n## Anti-patterns\na\n")
+    monkeypatch.setattr(so, "has_open_vision_proposals", lambda r: False)
+    monkeypatch.setattr(so, "dispatch_vision_bootstrap", lambda pid: "already-running")
+    monkeypatch.setattr(so, "post_webhook", lambda *a, **k: None)
+    skip_reason = so.handle_empty_backlog(
+        config={}, repo="x/y", project_id=42, workspace=str(ws), run_id="r-1",
+    )
+    assert skip_reason == "no-eligible-issues-bootstrap-already-running"
+```
+
+- [ ] **Step 2: Run the tests — must fail**
+
+```bash
+pytest tests/test_orchestrator_wiring.py -k handle_empty_backlog -v
+```
+Expected: 4 FAIL — `handle_empty_backlog` doesn't exist.
+
+- [ ] **Step 3: Add `handle_empty_backlog` and wire it into the loop**
+
+In `agent/station_orchestrator.py`, add the new function (place it next to `fetch_eligible_issues`):
+
+```python
+def handle_empty_backlog(
+    config: dict,
+    repo: str,
+    project_id: int | None,
+    workspace: str,
+    run_id: str,
+) -> str:
+    """Decide what to do when a project's backlog is empty.
+
+    Returns the skip_reason string. Side-effects:
+      - posts a `finished` webhook for the regular run with skip_reason
+      - dispatches the vision_analyst when conditions match (Trigger A)
+    """
+    has_vision = os.path.isfile(os.path.join(workspace, "docs", "vision.md"))
+    proposals_pending = has_vision and has_open_vision_proposals(repo)
+
+    if not has_vision:
+        skip_reason = "no-eligible-issues-no-vision"
+    elif proposals_pending:
+        skip_reason = "no-eligible-issues-proposals-pending"
+    elif project_id is None:
+        # Can't dispatch without a project_id (manager-config drift).
+        skip_reason = "no-eligible-issues-no-vision"
+    else:
+        outcome = dispatch_vision_bootstrap(project_id)
+        skip_reason = (
+            "no-eligible-issues-bootstrap-dispatched"
+            if outcome == "dispatched"
+            else "no-eligible-issues-bootstrap-already-running"
+        )
+
+    post_webhook(config, "finished", {
+        "run_id": f"run-{run_id}",
+        "project": repo,
+        "mode": "agent-teams",
+        "status": "completed",
+        "skip_reason": skip_reason,
+    })
+    logger.info("Empty backlog for %s: %s", repo, skip_reason)
+    return skip_reason
+```
+
+In the per-project loop at lines 931–934, replace:
+
+```python
+issues = fetch_eligible_issues(repo, max_per_project, workspace)
+if not issues:
+    logger.info("No eligible issues for %s, skipping", repo)
+    continue
+```
+
+with:
+
+```python
+issues = fetch_eligible_issues(repo, max_per_project, workspace)
+if not issues:
+    handle_empty_backlog(
+        config=config,
+        repo=repo,
+        project_id=project.get("id"),
+        workspace=workspace,
+        run_id=run_id,
+    )
+    continue
+```
+
+- [ ] **Step 4: Run the tests — must pass**
+
+```bash
+pytest tests/test_orchestrator_wiring.py -k handle_empty_backlog -v
+```
+Expected: 4 passed.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+cd /home/simon/Documents/claude-agent-station/dashboard/backend
+pytest -x --tb=short -q 2>&1 | tail -8
+```
+Expected: 900 passed (was 893 + 4 new + 3 from Task 4 already counted = 900).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/station_orchestrator.py dashboard/backend/tests/test_orchestrator_wiring.py
+git commit -m "feat(orchestrator): Trigger A — dispatch vision-analyst on empty backlog
+
+When a triggered run finds no eligible issues, branches by:
+  - no docs/vision.md            -> no-eligible-issues-no-vision
+  - vision-suggested issues open -> no-eligible-issues-proposals-pending
+  - otherwise                    -> dispatch + bootstrap-(dispatched|already-running)
+
+The regular run terminates with skip_reason set."
+```
+
+---
+
+## Task 7: Trigger B — vision commit fires the analyst with content-hash gate
+
+**Files:**
+- Modify: `dashboard/backend/app/routers/vision.py:71-121` (`commit_vision`)
+- Test: `dashboard/backend/tests/test_vision_router.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `dashboard/backend/tests/test_vision_router.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_commit_vision_fires_analyst_when_sha_changes(client, setup_db, monkeypatch):
+    """Two commits with different SHAs -> two dispatches."""
+    from app.services import service_control
+    from app.routers import vision as vision_router
+
+    calls = []
+    async def fake_dispatch(project_id):
+        calls.append(project_id)
+        return {"success": True, "status_code": 200}
+    monkeypatch.setattr(service_control, "start_vision_analyst", fake_dispatch)
+    monkeypatch.setattr(vision_router.service_control, "start_vision_analyst", fake_dispatch)
+
+    # ... arrange a project, post commit_vision with two different SHAs
+    # ... assert calls == [project_id, project_id]
+
+
+@pytest.mark.asyncio
+async def test_commit_vision_skips_analyst_when_sha_unchanged(client, setup_db, monkeypatch):
+    """Commit twice with same SHA -> only one dispatch."""
+    # ... similar arrangement; assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_commit_vision_treats_409_as_success(client, setup_db, monkeypatch):
+    """Launcher 409 -> commit_vision still returns 200."""
+    from app.services import service_control
+    from app.routers import vision as vision_router
+    async def fake_dispatch(project_id):
+        return {"success": False, "status_code": 409, "error": "already running"}
+    monkeypatch.setattr(service_control, "start_vision_analyst", fake_dispatch)
+    monkeypatch.setattr(vision_router.service_control, "start_vision_analyst", fake_dispatch)
+    # ... post commit_vision; assert response.status_code == 200
+```
+
+(Read the surrounding `test_vision_router.py` to find the existing `client` and `setup_db` fixtures and the pattern for stubbing `github_contents.write_file` / `read_file`. Reuse them; don't reinvent.)
+
+- [ ] **Step 2: Run the tests — must fail**
+
+```bash
+pytest tests/test_vision_router.py -k commit_vision -v
+```
+Expected: 3 FAIL — analyst not yet wired.
+
+- [ ] **Step 3: Add the post-commit hook**
+
+In `dashboard/backend/app/routers/vision.py`, in `commit_vision` after line 113 (`project.vision_cached_at = now`), add:
+
+```python
+    # Trigger B (spec 2026-05-08-vision-issue-bootstrap-design.md):
+    # fire the analyst when the vision SHA actually changed. We set
+    # last_vision_analyzed_sha at *dispatch* time (not on completion) so a
+    # failed analyst doesn't loop on identical re-commits.
+    if fresh.sha != project.last_vision_analyzed_sha:
+        try:
+            result = await service_control.start_vision_analyst(project_id)
+            if not result.get("success") and result.get("status_code") != 409:
+                logger.warning(
+                    "vision commit B-trigger dispatch failed: %s",
+                    result.get("error") or result.get("stderr"),
+                )
+            else:
+                # 200 or 409 — both mean "an analyst run will happen"
+                project.last_vision_analyzed_sha = fresh.sha
+        except Exception as exc:
+            logger.warning("vision commit B-trigger dispatch exception: %s", exc)
+```
+
+Verify `service_control` is already imported at the top (it is — used by `find_gaps`).
+
+Add `import logging; logger = logging.getLogger(__name__)` if not already present.
+
+- [ ] **Step 4: Run the tests — must pass**
+
+```bash
+pytest tests/test_vision_router.py -k commit_vision -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/backend/app/routers/vision.py dashboard/backend/tests/test_vision_router.py
+git commit -m "feat(vision): Trigger B — auto-fire analyst on vision commit
+
+Content-hash gate via Project.last_vision_analyzed_sha. 409 from
+launcher is treated as success (analyst is already running)."
+```
+
+---
+
+## Task 8: New endpoint — `GET /api/projects/{id}/vision/proposals`
+
+**Files:**
+- Modify: `dashboard/backend/app/routers/vision.py` (add endpoint)
+- Modify: `dashboard/backend/app/schemas.py` (add `VisionProposalsRead`)
+- Test: `dashboard/backend/tests/test_vision_router.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_vision_router.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_vision_proposals_endpoint(client, setup_db, monkeypatch):
+    """GET /api/projects/{id}/vision/proposals returns counts."""
+    import subprocess
+    open_payload = '[{"number": 1}, {"number": 2}, {"number": 3}]'
+
+    def fake_run(cmd, *a, **k):
+        if "--state" in cmd and "open" in cmd:
+            return type("R", (), {"returncode": 0, "stdout": open_payload, "stderr": ""})
+        return type("R", (), {"returncode": 0, "stdout": "[]", "stderr": ""})
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # ... arrange a project (id known), then:
+    resp = await client.get(f"/api/projects/{project_id}/vision/proposals")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["open"] == 3
+    assert body["accepted_recent"] == 0
+```
+
+- [ ] **Step 2: Run the test — must fail**
+
+```bash
+pytest tests/test_vision_router.py::test_vision_proposals_endpoint -v
+```
+Expected: FAIL — 404.
+
+- [ ] **Step 3: Add the schema**
+
+In `dashboard/backend/app/schemas.py` (alphabetically near other Vision* schemas):
+
+```python
+class VisionProposalsRead(BaseModel):
+    open: int
+    accepted_recent: int
+```
+
+- [ ] **Step 4: Add the endpoint with 60-second cache**
+
+In `dashboard/backend/app/routers/vision.py`, append:
+
+```python
+# Module-level cache: {project_id: (timestamp, payload)}.
+# 60-second TTL is enough to absorb dashboard re-renders without
+# overwhelming the rate-limited gh CLI.
+_PROPOSALS_CACHE: dict[int, tuple[float, dict]] = {}
+_PROPOSALS_TTL_S = 60
+
+
+@router.get("/{project_id}/vision/proposals", response_model=VisionProposalsRead)
+async def vision_proposals(project_id: int, db: AsyncSession = Depends(get_db)):
+    """Return open + recently-accepted proposal counts for the Vision tab."""
+    import time
+
+    project = await db.get(Project, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="project not found")
+
+    cached = _PROPOSALS_CACHE.get(project_id)
+    if cached and (time.time() - cached[0]) < _PROPOSALS_TTL_S:
+        return VisionProposalsRead(**cached[1])
+
+    open_count = _count_issues(project.repo, state="open", label="vision-suggested")
+    # Accepted = closed within last 7 days that previously had vision-suggested
+    # is hard to query cheaply via gh; approximate with closed+7d as a proxy.
+    accepted = _count_issues(
+        project.repo, state="closed", label="vision-suggested", days_back=7,
+    )
+
+    payload = {"open": open_count, "accepted_recent": accepted}
+    _PROPOSALS_CACHE[project_id] = (time.time(), payload)
+    return VisionProposalsRead(**payload)
+
+
+def _count_issues(repo: str, *, state: str, label: str, days_back: int | None = None) -> int:
+    """Run `gh issue list` and count results. Returns 0 on any failure."""
+    import subprocess
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", repo,
+        "--state", state,
+        "--label", label,
+        "--limit", "100",
+        "--json", "number",
+    ]
+    if days_back is not None:
+        cmd += ["--search", f"closed:>=$(date -u -d '-{days_back} days' '+%Y-%m-%d')"]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+        if result.returncode != 0:
+            return 0
+        return len(json.loads(result.stdout or "[]"))
+    except Exception:
+        return 0
+```
+
+- [ ] **Step 5: Run the test — must pass**
+
+```bash
+pytest tests/test_vision_router.py::test_vision_proposals_endpoint -v
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/backend/app/routers/vision.py dashboard/backend/app/schemas.py dashboard/backend/tests/test_vision_router.py
+git commit -m "feat(vision): GET /vision/proposals endpoint
+
+Returns open + recently-accepted vision-suggested issue counts.
+60-second server-side cache to limit gh calls."
+```
+
+---
+
+## Task 9: Frontend types and API client
+
+**Files:**
+- Modify: `dashboard/frontend/src/lib/types.ts`
+- Modify: `dashboard/frontend/src/lib/api.ts`
+
+- [ ] **Step 1: Extend the `Run` type**
+
+Find `interface Run` (or `type Run`) in `dashboard/frontend/src/lib/types.ts`. Add at the bottom of its fields:
+
+```typescript
+  skip_reason?: string | null;
+  vision_bootstrap_count?: number | null;
+  vision_bootstrap_proposals?: { number: number; title: string; url: string }[] | null;
+```
+
+- [ ] **Step 2: Add the `VisionProposals` type**
+
+Append to `types.ts`:
+
+```typescript
+export interface VisionProposals {
+  open: number;
+  accepted_recent: number;
+}
+```
+
+- [ ] **Step 3: Add `getVisionProposals` to the API client**
+
+Find the existing vision API helpers in `dashboard/frontend/src/lib/api.ts`. Add next to them:
+
+```typescript
+export async function getVisionProposals(projectId: number): Promise<VisionProposals> {
+  const res = await fetchAuth(`/api/projects/${projectId}/vision/proposals`);
+  if (!res.ok) throw new Error(`getVisionProposals: ${res.status}`);
+  return res.json();
+}
+```
+
+(Use the same `fetchAuth` / fetch pattern used by adjacent functions — don't introduce a new pattern.)
+
+Add `VisionProposals` to the import block at the top:
+
+```typescript
+import type { ..., VisionProposals } from './types';
+```
+
+- [ ] **Step 4: Verify the frontend build passes**
+
+```bash
+cd /home/simon/Documents/claude-agent-station/dashboard/frontend
+npm run build 2>&1 | tail -5
+```
+Expected: build succeeds (warnings allowed; no errors in `types.ts` or `api.ts`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/lib/types.ts dashboard/frontend/src/lib/api.ts
+git commit -m "feat(frontend): types + API client for vision proposals
+
+Extends Run with skip_reason, vision_bootstrap_count, and
+vision_bootstrap_proposals; adds getVisionProposals client."
+```
+
+---
+
+## Task 10: `formatRunMode` utility
+
+**Files:**
+- Modify: `dashboard/frontend/src/lib/format.ts`
+- Modify: `dashboard/frontend/src/lib/format.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/frontend/src/lib/format.test.ts`:
+
+```typescript
+import { formatRunMode } from './format';
+
+describe('formatRunMode', () => {
+  it('returns vision-bootstrap descriptor', () => {
+    const m = formatRunMode('vision-bootstrap');
+    expect(m.label).toBe('Vision bootstrap');
+    expect(m.icon).toBe('✨');
+    expect(m.accent).toBe('violet');
+  });
+
+  it('returns agent-teams descriptor', () => {
+    const m = formatRunMode('agent-teams');
+    expect(m.label).toBe('Agent Teams');
+    expect(m.accent).toBe('default');
+  });
+
+  it('falls back for unknown modes', () => {
+    const m = formatRunMode(null);
+    expect(m.label).toBe('Run');
+    expect(m.accent).toBe('default');
+  });
+});
+```
+
+- [ ] **Step 2: Run — must fail**
+
+```bash
+cd /home/simon/Documents/claude-agent-station/dashboard/frontend
+npm test -- --run format.test.ts 2>&1 | tail -10
+```
+Expected: FAIL — `formatRunMode` not exported.
+
+- [ ] **Step 3: Implement `formatRunMode`**
+
+Append to `dashboard/frontend/src/lib/format.ts`:
+
+```typescript
+export interface RunModeDescriptor {
+  label: string;
+  icon: string;
+  accent: 'default' | 'violet';
+}
+
+/** Map a Run.mode value to its UI descriptor. */
+export function formatRunMode(mode: string | null | undefined): RunModeDescriptor {
+  switch (mode) {
+    case 'vision-bootstrap':
+      return { label: 'Vision bootstrap', icon: '✨', accent: 'violet' };
+    case 'agent-teams':
+      return { label: 'Agent Teams', icon: '◆', accent: 'default' };
+    default:
+      return { label: 'Run', icon: '◆', accent: 'default' };
+  }
+}
+```
+
+- [ ] **Step 4: Run — must pass**
+
+```bash
+npm test -- --run format.test.ts 2>&1 | tail -10
+```
+Expected: 3 new tests pass; total `format.test.ts` count goes from 16 to 19.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/lib/format.ts dashboard/frontend/src/lib/format.test.ts
+git commit -m "feat(frontend): formatRunMode utility for vision-bootstrap rendering"
+```
+
+---
+
+## Task 11: Render vision-bootstrap mode in run list / detail
+
+**Files:**
+- Modify: `dashboard/frontend/src/pages/RunsPage.svelte` (or wherever runs render — verify with `grep -rn 'mode' src/pages/RunsPage.svelte`)
+
+- [ ] **Step 1: Read the existing run-row template**
+
+```bash
+grep -n "mode\|run.status" /home/simon/Documents/claude-agent-station/dashboard/frontend/src/pages/RunsPage.svelte | head -10
+```
+Read enough surrounding code to understand how the badge currently renders.
+
+- [ ] **Step 2: Apply `formatRunMode` to the row's mode label**
+
+Wherever `run.mode` is displayed, replace with the descriptor. Conceptually:
+
+```svelte
+<script lang="ts">
+  import { formatRunMode } from '../lib/format';
+</script>
+
+{#each runs as run}
+  {@const m = formatRunMode(run.mode)}
+  <div class="row" class:accent-violet={m.accent === 'violet'}>
+    <span class="icon">{m.icon}</span>
+    <span class="label">{m.label}</span>
+    <!-- existing status badge etc. -->
+    {#if run.skip_reason}
+      <div class="text-xs text-tertiary mt-1">
+        {skipReasonText(run.skip_reason, run)}
+      </div>
+    {/if}
+  </div>
+{/each}
+```
+
+- [ ] **Step 3: Add the `skipReasonText` helper**
+
+In the same `<script>` block (or in `format.ts` if preferred — the spec calls these "UI hints" so they could live as a util):
+
+```typescript
+function skipReasonText(reason: string, run: Run): string {
+  switch (reason) {
+    case 'no-eligible-issues-no-vision':
+      return 'No vision yet — define one in the Vision tab.';
+    case 'no-eligible-issues-bootstrap-dispatched':
+      return 'Vision analyst dispatched.';
+    case 'no-eligible-issues-bootstrap-already-running':
+      return 'Vision analyst is already running.';
+    case 'no-eligible-issues-proposals-pending':
+      return 'Vision-suggested issues await your acceptance.';
+    default:
+      return reason;
+  }
+}
+```
+
+(Adapt to the `formatRunMode`/utility location; if multiple pages share the helper, put it in `format.ts` and export it.)
+
+- [ ] **Step 4: Add the violet accent class**
+
+Look for the existing CSS pattern (border-l-violet etc.). If unclear, use inline style — match conventions in the surrounding code. Skip mockup-pixel work; the goal is a visible, recognizable distinction, not a finished design.
+
+- [ ] **Step 5: Verify the build passes**
+
+```bash
+cd /home/simon/Documents/claude-agent-station/dashboard/frontend
+npm run build 2>&1 | tail -5
+```
+Expected: build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/frontend/src/pages/RunsPage.svelte
+git commit -m "feat(frontend): render vision-bootstrap rows with skip-reason hint"
+```
+
+---
+
+## Task 12: Vision tab info strip
+
+**Files:**
+- Modify: `dashboard/frontend/src/components/vision/VisionTab.svelte`
+- Test: `dashboard/frontend/src/components/vision/VisionTab.test.ts` (new)
+
+- [ ] **Step 1: Read the existing `VisionTab.svelte`**
+
+```bash
+sed -n '1,80p' /home/simon/Documents/claude-agent-station/dashboard/frontend/src/components/vision/VisionTab.svelte
+```
+
+Understand the existing top-of-tab structure so the info strip slots in cleanly.
+
+- [ ] **Step 2: Write the smoke test**
+
+Create `dashboard/frontend/src/components/vision/VisionTab.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/svelte';
+import VisionTab from './VisionTab.svelte';
+
+vi.mock('../../lib/api', () => ({
+  getVisionProposals: vi.fn().mockResolvedValue({ open: 3, accepted_recent: 1 }),
+}));
+
+describe('VisionTab info strip', () => {
+  it('renders proposal counts when API resolves', async () => {
+    const { findByText } = render(VisionTab, {
+      props: { project: { id: 7, repo: 'x/y', branch: 'main' } as any },
+    });
+    expect(await findByText(/3 proposals open/)).toBeTruthy();
+  });
+});
+```
+
+If `@testing-library/svelte` isn't installed:
+
+```bash
+cd /home/simon/Documents/claude-agent-station/dashboard/frontend
+npm install --save-dev @testing-library/svelte @testing-library/jest-dom jsdom
+```
+
+And update `vite.config.ts` `test.environment` to `'jsdom'` (was `'node'`). If the existing tests need the node environment, set the environment per-file with `// @vitest-environment jsdom` at the top of `VisionTab.test.ts`.
+
+- [ ] **Step 3: Run the test — must fail**
+
+```bash
+npm test -- --run VisionTab.test.ts 2>&1 | tail -10
+```
+Expected: FAIL.
+
+- [ ] **Step 4: Add the info strip**
+
+In `VisionTab.svelte`, near the top of the existing layout, add:
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { getVisionProposals } from '../../lib/api';
+  import type { Project, VisionProposals } from '../../lib/types';
+
+  let { project }: { project: Project } = $props();
+  let proposals = $state<VisionProposals | null>(null);
+
+  onMount(async () => {
+    try { proposals = await getVisionProposals(project.id); }
+    catch { /* silent — info strip just hides the count */ }
+  });
+
+  function rerunAnalyst() {
+    fetch(`/api/projects/${project.id}/vision/find-gaps`, { method: 'POST' })
+      .then(r => r.ok || console.warn('rerun failed', r.status));
+  }
+</script>
+
+<div class="vision-info-strip" style="border:1px solid var(--color-border); border-radius:8px; padding:12px; margin-bottom:12px; display:flex; gap:12px; align-items:center;">
+  <strong>Vision analyst</strong>
+  <span class="text-xs text-tertiary">
+    {#if proposals}
+      {proposals.open} proposals open · {proposals.accepted_recent} accepted last week
+    {:else}
+      Loading…
+    {/if}
+  </span>
+  <span style="flex:1"></span>
+  <button class="btn btn-sm" onclick={rerunAnalyst}>Re-run analyst</button>
+  <a class="btn btn-sm" href="https://github.com/{project.repo}/issues?q=is:open+label:vision-suggested" target="_blank" rel="noopener">View on GitHub</a>
+</div>
+```
+
+- [ ] **Step 5: Run the test — must pass**
+
+```bash
+npm test -- --run VisionTab.test.ts 2>&1 | tail -10
+```
+Expected: PASS.
+
+- [ ] **Step 6: Verify the build**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add dashboard/frontend/src/components/vision/VisionTab.svelte dashboard/frontend/src/components/vision/VisionTab.test.ts dashboard/frontend/package.json dashboard/frontend/package-lock.json dashboard/frontend/vite.config.ts
+git commit -m "feat(frontend): Vision tab info strip with proposal counts"
+```
+
+---
+
+## Task 13: Toast notifications
+
+**Files:**
+- Modify: wherever vision-commit submission happens (likely `VisionTab.svelte` or a sibling)
+- Modify: SSE consumer for run events (likely `dashboard/frontend/src/lib/agent-presence.svelte.ts`)
+
+- [ ] **Step 1: Find the commit-vision submit handler**
+
+```bash
+grep -rn "POST.*vision\|commitVision\|/vision\b" /home/simon/Documents/claude-agent-station/dashboard/frontend/src --include='*.ts' --include='*.svelte' | head
+```
+
+- [ ] **Step 2: Add success toast**
+
+After a successful vision commit, call:
+
+```typescript
+addToast('info', 'Vision analyst running — proposals will appear in a few minutes.');
+```
+
+(Use the existing `addToast` from `lib/toast.svelte`.)
+
+- [ ] **Step 3: Find the SSE run-event consumer**
+
+```bash
+grep -rn "run_event\|runEvent\|EventSource" /home/simon/Documents/claude-agent-station/dashboard/frontend/src/lib --include='*.ts' | head
+```
+
+- [ ] **Step 4: Add completion toast for vision-bootstrap mode**
+
+Where finished events are processed, after persisting the run:
+
+```typescript
+if (event.mode === 'vision-bootstrap' && event.event === 'finished' && event.status === 'success') {
+  const n = event.vision_bootstrap_count ?? 0;
+  addToast(
+    'success',
+    n === 0
+      ? 'Vision analyzed — no gaps found.'
+      : `${n} issue${n === 1 ? '' : 's'} created from vision.`,
+  );
+}
+```
+
+- [ ] **Step 5: Verify the build**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/frontend/src/components/vision/VisionTab.svelte dashboard/frontend/src/lib/agent-presence.svelte.ts
+git commit -m "feat(frontend): toasts for vision-commit dispatch + bootstrap completion"
+```
+
+---
+
+## Task 14: Documentation
+
+**Files:**
+- Modify: `docs/configuration.md`
+- Modify: `docs/architecture.md`
+
+- [ ] **Step 1: Document `STATION_VISION_ANALYST_MODEL` and triggers**
+
+In `docs/configuration.md`, under the Models section (line 28+) add a row to the table for the analyst model:
+
+```
+| Vision analyst | `claude-sonnet-4-6` | env: `STATION_VISION_ANALYST_MODEL` |
+```
+
+Under "Project config" (line 95+) add a subsection:
+
+```markdown
+### Vision-driven issue bootstrap
+
+When a project has `docs/vision.md`, two automatic triggers fire the vision analyst:
+
+- **Trigger A (orchestrator):** triggered runs that find no eligible issues dispatch the analyst when no `vision-suggested` issues are already open. The triggering run terminates with `Run.skip_reason = no-eligible-issues-bootstrap-dispatched`.
+- **Trigger B (vision commit):** committing a new vision via the dashboard fires the analyst when the document SHA changes. Idempotent on identical re-commits.
+
+Both produce `Run.mode = vision-bootstrap` rows that surface in the Runs list and Mission Control. Issues land with the `vision-suggested` label; remove the label to accept (the orchestrator's `SKIP_LABELS` blocks autonomous implementation until then).
+```
+
+- [ ] **Step 2: Document the run type**
+
+In `docs/architecture.md`, in the section that lists run modes / agent flows, add:
+
+```markdown
+- **`vision-bootstrap`** — single-shot run that dispatches `agent/vision_analyst.py` to propose new issues from `docs/vision.md`. Triggered automatically (orchestrator empty backlog, or vision commit with content-hash change) or manually from the Vision tab. Never spawns teammates, never opens PRs.
+```
+
+- [ ] **Step 3: Verify links resolve**
+
+```bash
+cd /home/simon/Documents/claude-agent-station
+grep -n "vision-bootstrap\|vision-issue-bootstrap" docs/*.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/configuration.md docs/architecture.md
+git commit -m "docs: document vision-bootstrap triggers and run type
+
+Per CLAUDE.md project rule: docs stay in sync with code."
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Full backend suite**
+
+```bash
+cd /home/simon/Documents/claude-agent-station/dashboard/backend
+pytest --tb=short -q 2>&1 | tail -8
+```
+Expected: ~905 passed, 1 skipped (was 890; ~15 new tests added).
+
+- [ ] **Step 2: Full frontend suite**
+
+```bash
+cd /home/simon/Documents/claude-agent-station/dashboard/frontend
+npm test 2>&1 | tail -10
+```
+Expected: all passes; new VisionTab + formatRunMode tests pass.
+
+- [ ] **Step 3: Frontend build**
+
+```bash
+npm run build 2>&1 | tail -5
+```
+
+- [ ] **Step 4: Rebuild compose dashboard image and restart**
+
+```bash
+cd /home/simon/Documents/claude-agent-station
+docker compose build dashboard agent
+docker compose up -d
+docker compose ps
+```
+
+- [ ] **Step 5: Manual smoke test (operator playthrough)**
+
+Reload http://localhost:8420. With a project that has `docs/vision.md` but zero open issues:
+
+1. Trigger a run → expect a regular run with `skip_reason = bootstrap-dispatched` plus a new `vision-bootstrap` run row appearing in the Runs list with the violet accent.
+2. Wait for the bootstrap run to complete → expect a toast and N new GitHub issues with the `vision-suggested` label.
+3. Edit the vision in the Vision tab and commit → expect the toast and a second bootstrap run.
+4. Edit the vision again with no content change → expect no toast and no new run.
+
+- [ ] **Step 6: Push and open the PR**
+
+```bash
+git push -u origin feature/vision-bootstrap
+gh pr create --base dev --title "feat: vision-driven issue bootstrap" --body-file docs/superpowers/specs/2026-05-08-vision-issue-bootstrap-design.md
+```
+
+---
+
+## Self-review notes
+
+Coverage check against the spec:
+
+| Spec section | Task(s) |
+|---|---|
+| Run-type contract (mode, columns) | 1, 2 |
+| Trigger A — orchestrator | 4, 5, 6 |
+| Trigger B — vision commit | 7 |
+| Skip-reason hints | 6 (backend), 11 (UI) |
+| `/vision/proposals` endpoint | 8 |
+| Run rendering (icon, label, color) | 10, 11 |
+| Vision tab info strip | 12 |
+| Toasts | 13 |
+| SSE event surfacing | 13 (re-uses existing run_event flow — no new event type) |
+| Worker self-registers as run | 3 |
+| Edge cases (409, no vision, proposals pending, fallback) | 5, 6, 7 |
+| DB migration | 1 |
+| Tests | every task |
+| Docs | 14 |
+
+Type-consistency check:
+
+- `Run.mode` values used: `"vision-bootstrap"`, `"agent-teams"` — match across orchestrator, worker webhook, frontend `formatRunMode`.
+- `skip_reason` values used: 4 strings — defined in Task 6, consumed in Task 11. Verified identical.
+- Webhook payload field names: `vision_bootstrap_count`, `vision_bootstrap_proposals`, `skip_reason` — defined in Task 2 schema, populated in Tasks 3 + 6, persisted by `handle_finished` in Task 2.

--- a/docs/superpowers/specs/2026-05-08-vision-issue-bootstrap-design.md
+++ b/docs/superpowers/specs/2026-05-08-vision-issue-bootstrap-design.md
@@ -1,0 +1,225 @@
+# Vision-driven issue bootstrap
+
+*Design spec — 2026-05-08*
+
+## Goal
+
+A project's vision becomes its initial backlog without manual steps. Two triggers feed the existing `vision_analyst` worker:
+
+- **Trigger A** — orchestrator fires the analyst when a triggered run finds no eligible issues but the project has a vision.
+- **Trigger B** — backend fires the analyst when a vision commit changes the document SHA.
+
+Both surface as a distinct **`vision-bootstrap`** run type in the dashboard, so operators can tell "creating issues" apart from "implementing issues" at a glance.
+
+## Non-goals
+
+- Auto-accepting proposals. The existing `SKIP_LABELS` gate (`vision-suggested`) stays — humans accept by removing the label.
+- Scheduled / cron-style vision sweeps. Future enhancement.
+- Multi-project parallel analysis. The single-instance launcher lock is sufficient for now.
+- Rendering proposals inside the dashboard. They live on GitHub; the UI deep-links there.
+
+## What already exists (do not rebuild)
+
+| Layer | File | What it does |
+|---|---|---|
+| Worker | `agent/vision_analyst.py` | Reads `docs/vision.md`, snapshots repo state, calls a model, creates issues with the `vision-suggested` label. Capped at `MAX_PROPOSALS = 5`. |
+| Launcher | `agent/launcher.py:176-212` | `POST /vision-analyst?project_id=N` spawns the worker detached. Single-instance lock at line 190 returns 409 if already running. |
+| Backend dispatch | `dashboard/backend/app/routers/vision.py:242` (existing) + `app/services/service_control.py:start_vision_analyst` | Routes manual dispatch from the dashboard; works in compose and systemd. |
+| Orchestrator skip | `agent/station_orchestrator.py:89` | `SKIP_LABELS` includes `"vision-suggested"`, so analyst-created issues are not auto-implemented. |
+| Tests | `dashboard/backend/tests/test_vision_analyst.py`, `test_vision_router.py` | Cover the worker and the existing manual route. |
+
+This design only adds *triggers* and *UI surfacing*. The worker, launcher endpoint, and dispatch service stay as-is.
+
+## Run-type contract
+
+A new value `"vision-bootstrap"` for `Run.mode`, alongside the existing `"agent-teams"`. Run lifecycle and webhook plumbing reuse the existing `/api/webhook/run-event` endpoint.
+
+| Field | Value |
+|---|---|
+| `Run.mode` | `"vision-bootstrap"` |
+| `Run.status` lifecycle | `running` → `completed` (or `failed` / `interrupted`) |
+| `Run.verdict` | unused (no manager review for these runs) |
+| Carries on completion | `vision_bootstrap_count`, `vision_bootstrap_proposals` (new nullable columns) |
+| Lifecycle | Single-shot — never spawns teammates, never opens PRs |
+| Visible in UI as | "Vision bootstrap" with a distinct icon (proposed: ✨ / lightbulb) |
+
+`Run.mode` is currently free-form text in the model; no enum constraint to widen. Frontend `lib/types.ts` already exposes `mode` as a string. New mode values are non-disruptive additions.
+
+## Trigger A — orchestrator dispatches on empty backlog
+
+### Decision site
+
+`agent/station_orchestrator.py`, in the per-project loop where today the orchestrator logs `"No eligible issues for {repo}, skipping"`. New flow:
+
+```
+for project in projects:
+    issues   = fetch_open_issues(project)
+    eligible = filter_eligible(issues)              # SKIP_LABELS etc.
+    if not eligible:
+        if has_vision(workspace) and not has_open_proposals(project):
+            dispatch_vision_bootstrap(project)
+        else:
+            log_skip_reason(project, has_vision, has_open_proposals)
+        continue
+    ...
+```
+
+### Dispatch is fire-and-forget
+
+`dispatch_vision_bootstrap` calls the same launcher endpoint the dashboard already uses (`POST /vision-analyst?project_id=N`). The orchestrator does NOT run the analyst inline. Reasons:
+
+1. Reuses tested infrastructure (process model, log paths, the single-instance lock at `launcher.py:190`).
+2. The regular run terminates promptly with a clear status; the bootstrap shows up as its own run record.
+3. A duplicate from B is rejected cleanly with 409.
+
+### Skip reasons surface UI hints
+
+The regular run terminates `status: completed` with a new `Run.skip_reason` text field populated:
+
+| `skip_reason` | UI hint |
+|---|---|
+| `no-eligible-issues-no-vision` | "No vision yet — define one in the Vision tab so the agent can bootstrap." |
+| `no-eligible-issues-bootstrap-dispatched` | "Vision analyst dispatched — see run #N." |
+| `no-eligible-issues-bootstrap-already-running` | "Vision analyst is already running — see active runs." |
+| `no-eligible-issues-proposals-pending` | "N `vision-suggested` issues await your acceptance." |
+
+`skip_reason` is a free-form text field used only for UI hints. Same pattern as the existing `Run.verdict_detail`. No status churn — keeps every existing consumer of `Run.status` working unchanged.
+
+### Run-record creation
+
+The `vision_analyst` worker creates the `vision-bootstrap` Run record itself. On startup it POSTs to `/api/webhook/run-event` with `mode: "vision-bootstrap"` and a fresh `run_id`. On completion it posts back with `status: completed`, `vision_bootstrap_count`, and `vision_bootstrap_proposals`. Existing webhook auth (`STATION_WEBHOOK_SECRET`), the run-lifecycle service, and the SSE event bus are reused unchanged.
+
+## Trigger B — vision commit fires the analyst
+
+### Site
+
+`dashboard/backend/app/routers/vision.py:71` — `POST /api/projects/{project_id}/vision` (`commit_vision`). After the GitHub commit succeeds and the cache update lands, fire the analyst as a side-effect.
+
+### Content-hash gate
+
+A new `Project.last_vision_analyzed_sha` column (nullable text) records the `vision_cached_sha` current at the last analyst dispatch.
+
+```
+new_sha = result.commit_sha
+if project.last_vision_analyzed_sha == new_sha:
+    return  # nothing changed, no fire
+service_control.start_vision_analyst(project_id)   # async
+project.last_vision_analyzed_sha = new_sha
+```
+
+The SHA is set **at dispatch time, not on completion**. Rationale: a failed analyst run shouldn't cause a retry-loop on subsequent same-content commits. If the user actually wants to retry, they hit the manual "Re-run analyst" button on the Vision tab.
+
+### Single-instance contract
+
+`launcher.py:190` returns 409 if `vision-analyst` is already running. The vision-commit hook treats 409 as success — the goal is "an analyst run will happen", not "this specific call did it". 409 is logged at INFO and the router returns 200 to the dashboard.
+
+### No new endpoint
+
+The hook is implementation-internal to `commit_vision`. Tests stub `service_control.start_vision_analyst`.
+
+### Trigger surface summary
+
+| Trigger | Site | Sync? | Fires when |
+|---|---|---|---|
+| A — orchestrator on empty backlog | `station_orchestrator.py` per-project loop | Async (POST to launcher) | `eligible == 0` AND `has_vision` AND no open `vision-suggested` issues |
+| B — vision commit | `routers/vision.py:commit_vision` | Async (POST to launcher) | Vision SHA changed from `last_vision_analyzed_sha` |
+| Manual | Existing dispatch route + Vision tab button | Async | Always (existing behavior preserved) |
+
+All three converge on the same launcher endpoint and worker, so behavior, logs, and observability are identical regardless of trigger.
+
+## UI
+
+### Run-type rendering
+
+Wherever `Run.mode` renders (Runs page list, Run detail header, Mission Control header, Agent Teams canvas):
+
+- **Icon + label:** `✨ Vision bootstrap` (final glyph chosen during impl from the existing icon set)
+- **Color:** `--color-violet` accent — distinct from agent-teams; vision is product/strategy-flavored
+- **Status row, when running:** "Generating issues from vision…"
+- **Status row, when completed:** "Created N issues — `vision-suggested`"
+- **Status row, when failed:** failure reason + "Re-run" button (calls existing manual dispatch)
+
+### Skip-reason hints on regular runs
+
+The four `skip_reason` values from the trigger-A table render as a one-line secondary hint under the status badge in the Runs list, and in the summary panel of the Run detail page. The text-and-link mapping is in the table above.
+
+### Vision tab additions (`VisionTab.svelte`)
+
+A new info strip above the existing chat/render surface:
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│ Vision analyst                                                │
+│ Last analyzed: 2h ago · 3 proposals open · 1 accepted last week│
+│ [Re-run analyst]   [View proposals on GitHub]                 │
+└───────────────────────────────────────────────────────────────┘
+```
+
+Data sources:
+
+- *Last analyzed* — `Project.last_vision_analyzed_sha` joined with the latest `vision-bootstrap` run for this project (latest `started_at`).
+- *Proposals open* — count of open issues with the `vision-suggested` label, served by a new `GET /api/projects/{id}/vision/proposals` (added to `dashboard/backend/app/routers/vision.py`) returning `{open: int, accepted_recent: int}`. Cached for 60 s server-side to limit `gh` calls.
+- *Re-run analyst* — existing manual dispatch endpoint.
+- *View proposals on GitHub* — deep link `https://github.com/{repo}/issues?q=is:open+label:vision-suggested`.
+
+### Toasts and live signals
+
+- **B fires** (vision commit) → toast: "Vision analyst running — proposals will appear in a few minutes."
+- **`vision-bootstrap` run completes** (any trigger) → toast on the originating tab: "N issues created from vision. [Review on GitHub]"
+- **Mission Control / Agent Teams canvas** picks up the live `vision-bootstrap` run via the existing SSE event bus. No new event types needed; the `run_event` payload simply carries `mode: vision-bootstrap`.
+
+### Surfaces that do NOT change
+
+- Project create wizard (vision is added later via the Vision tab).
+- Settings page.
+- Queue board (vision-bootstrap runs don't queue — they're triggered, not enqueued).
+
+## Edge cases
+
+- **A and B race.** Launcher's `_current_analyst` lock at `launcher.py:190` returns 409 to the second caller. Both A and B treat 409 as "good enough" and log at INFO. No retry storms.
+- **Worker model call fails.** `vision-bootstrap` run terminates `status: failed`, error message in `verdict_detail`. UI shows failure + "Re-run" button. No issues created.
+- **Worker creates 0 proposals.** Run terminates `status: completed`, `vision_bootstrap_count: 0`. UI: "Vision analyzed — no gaps found." Valid outcome, not an error.
+- **`docs/vision.md` exists but parses empty.** `agent/vision.py:load_vision` returns `None` on all-empty sections — orchestrator treats as no vision → `no-eligible-issues-no-vision` skip reason.
+- **Duplicate proposal text across runs.** `vision_analyst._gather_repo_state` already includes existing open + closed issues in the prompt context, and the prompt instructs the model not to duplicate. Not airtight, but adequate behind the human-acceptance gate. Out of scope to enforce in code; flag for future hardening if operators report dupes.
+- **Open `vision-suggested` issues from a prior run.** A skips dispatch (per the trigger condition). B still fires when the user rewrites the vision; the worker's prompt context will see existing proposals and either dedupe or supersede.
+- **`last_vision_analyzed_sha` not yet backfilled.** New column is nullable; `NULL == new_sha` is false, so the first commit after rollout dispatches once. Subsequent same-content commits don't.
+- **GitHub PAT/App token missing.** Worker fails at `gh issue create`; run terminates `failed` with a clear message. Same failure mode as today's manual dispatch — no new auth surface introduced.
+- **Concurrent `agent-teams` run.** Independent. Vision-bootstrap and teammate runs are orthogonal.
+
+## Tests
+
+| Test | Layer | Asserts |
+|---|---|---|
+| `test_orchestrator_dispatches_vision_bootstrap_on_empty_backlog` | backend (orchestrator) | `eligible=[]` + has-vision + no-open-proposals → calls `start_vision_analyst`; run terminates `skip_reason="no-eligible-issues-bootstrap-dispatched"` |
+| `test_orchestrator_skips_dispatch_when_proposals_pending` | backend | Same condition with one open `vision-suggested` issue → does NOT dispatch; `skip_reason="no-eligible-issues-proposals-pending"` |
+| `test_orchestrator_no_vision_skip_reason` | backend | No `docs/vision.md` → does NOT dispatch; `skip_reason="no-eligible-issues-no-vision"` |
+| `test_orchestrator_skips_dispatch_when_analyst_running` | backend | Launcher returns 409 → run terminates `skip_reason="no-eligible-issues-bootstrap-already-running"` |
+| `test_commit_vision_fires_analyst_on_sha_change` | backend (router) | Mock `start_vision_analyst`; commit twice with different SHAs → called twice; same SHA → called once |
+| `test_commit_vision_treats_409_as_success` | backend | Mock launcher returning 409 → router returns 200 |
+| `test_vision_bootstrap_run_lifecycle` | backend (run-lifecycle service) | Webhook with `mode=vision-bootstrap`, `vision_bootstrap_count=N` → row written, SSE event emitted |
+| `test_runs_router_filters_by_mode` | backend | Existing `?mode=agent-teams` filter still works; new `?mode=vision-bootstrap` returns only those rows |
+| `test_proposals_endpoint_returns_open_count` | backend | `GET /api/projects/{id}/vision/proposals` returns the open + accepted-recent counts |
+| `VisionTab.test.ts` smoke | frontend (Vitest) | Renders "Last analyzed" and proposal count from a fixture API response; "Re-run" button calls dispatch endpoint |
+| Manual playthrough | end-to-end | (a) Trigger run on project with vision + zero issues → vision-bootstrap run appears, issues land on GitHub. (b) Edit vision via dashboard → toast + new run. (c) Edit vision again with no content change → no new run. |
+
+## Migration & rollout
+
+Add four nullable columns via the existing in-code `ALTER TABLE` pattern in `dashboard/backend/app/database.py`:
+
+- `Project.last_vision_analyzed_sha TEXT NULL`
+- `Run.skip_reason TEXT NULL`
+- `Run.vision_bootstrap_count INT NULL`
+- `Run.vision_bootstrap_proposals TEXT NULL` (JSON-encoded list)
+
+No backfill needed. No flag/rollback — new behavior fires only under conditions that previously did nothing (empty backlog, vision commit). Existing flows untouched.
+
+Docs updated per CLAUDE.md project rule:
+
+- `docs/configuration.md` — `STATION_VISION_ANALYST_MODEL` env var (already exists in code; documented here as part of this rollout) plus the trigger conditions.
+- `docs/architecture.md` — paragraph on the bootstrap run type and a small diagram update showing the new edge.
+
+## Open items deliberately deferred
+
+- Final glyph for the `vision-bootstrap` run icon — chosen during implementation from the existing icon set.
+- The exact wording of the Vision tab info strip — likely refined during UI implementation.
+- Idempotency hardening for the worker (server-side dedupe of proposed issue titles) — track separately if dupes appear in practice.


### PR DESCRIPTION
## Summary

A project's vision becomes its initial backlog without manual steps. Two automatic triggers feed the existing `vision_analyst` worker, surfaced as a distinct **`vision-bootstrap`** run type in the dashboard.

- **Trigger A** — orchestrator dispatches the analyst when a triggered run finds no eligible issues but the project has `docs/vision.md`.
- **Trigger B** — backend dispatches the analyst when a vision commit changes the document SHA. Idempotent on identical re-commits via `Project.last_vision_analyzed_sha`.

Both produce `Run.mode = vision-bootstrap` rows visible in the Runs list and Mission Control. Issues land with the `vision-suggested` label; remove the label to accept (the orchestrator's `SKIP_LABELS` blocks autonomous implementation until then).

Spec: `docs/superpowers/specs/2026-05-08-vision-issue-bootstrap-design.md`
Plan: `docs/superpowers/plans/2026-05-08-vision-issue-bootstrap.md`

## What's wired

- 4 new DB columns: `Run.skip_reason`, `Run.vision_bootstrap_count`, `Run.vision_bootstrap_proposals`, `Project.last_vision_analyzed_sha`
- `vision_analyst.run_for_project` self-registers as a `vision-bootstrap` Run via `started`/`finished` webhooks
- New helpers in `agent/station_orchestrator.py`: `has_open_vision_proposals`, `dispatch_vision_bootstrap` (launcher HTTP with subprocess.Popen fallback), `handle_empty_backlog`
- `commit_vision` post-commit hook with content-hash gate; treats 409 as success
- New endpoint `GET /api/projects/{id}/vision/proposals` (60s cached, async-safe via `asyncio.to_thread`)
- SSE broadcast carries the new fields end-to-end so the frontend toast can read the count
- Frontend: `formatRunMode` / `formatSkipReason` utilities, vision-bootstrap row rendering on RunsPage + RunDetail, Vision tab info strip, toasts on commit + completion
- Docs: `configuration.md` Models table + Vision-driven issue bootstrap section; `architecture.md` Run modes section

## Tests

- Backend: **910 passed, 1 skipped** (was 890 baseline; +20 new tests across orchestrator wiring, vision router, run lifecycle, webhook propagation, vision-analyst webhook integration)
- Frontend: **30 tests passing** (was 24 baseline; +6 new tests for `formatRunMode` and `formatSkipReason`)
- Build: green

## Test plan

- [ ] Trigger a run on a project with `docs/vision.md` and zero open issues → expect a regular run with `skip_reason = bootstrap-dispatched` plus a new `vision-bootstrap` run row appearing with the violet accent.
- [ ] Wait for the bootstrap run to complete → expect a toast and N new GitHub issues with the `vision-suggested` label.
- [ ] Edit the vision in the Vision tab and commit → expect "Vision analyst running…" toast and a second bootstrap run.
- [ ] Edit the vision again with no content change → expect no new run (SHA gate).
- [ ] Project with no vision → expect `skip_reason = no-vision` and a clear UI hint pointing to the Vision tab.

## Dependency

This branch was rebased on top of `feature/readiness-fixes` (PR #265) for working environment — frontend Vitest infra and rewritten skipped backend tests. The two `chore(readiness)` and `chore(ui)` commits are part of #265; merge that first and this diff narrows accordingly. Targeting `dev` per project memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)