### PR TITLE
fix(vision): refresh workspace before reading docs/vision.md (#271)

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -52,6 +52,7 @@ from agent.run_control import (
     drain_pending_controls,
     set_run_paused,
 )
+from agent.vision_analyst import _ensure_workspace
 
 logger = logging.getLogger(__name__)
 
@@ -1035,7 +1036,6 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
         # docs/vision.md files (issue #271). Best-effort: clone-if-missing
         # plus fetch+reset; failures are logged but non-fatal.
         try:
-            from agent.vision_analyst import _ensure_workspace
             _ensure_workspace(workspace, repo, project_branch)
         except Exception as exc:  # pragma: no cover - defensive
             logger.warning(

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1027,6 +1027,21 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
         repo = project["repo"]
         repo_name = repo.split("/")[-1] if "/" in repo else repo
         workspace = os.path.join(workspaces_dir, repo_name)
+        project_branch = project.get("branch") or "main"
+
+        # Refresh the workspace to the tip of the project's default branch
+        # before deciding eligibility. Without this, persistent compose
+        # volumes keep stale checkouts that hide newly-committed
+        # docs/vision.md files (issue #271). Best-effort: clone-if-missing
+        # plus fetch+reset; failures are logged but non-fatal.
+        try:
+            from agent.vision_analyst import _ensure_workspace
+            _ensure_workspace(workspace, repo, project_branch)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "workspace refresh for %s failed: %s",
+                workspace, exc,
+            )
 
         # Resolve autonomy per ADR-0001. Level comes from project config
         # (falls back to config-level default, then to 'assisted'). The

--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -269,10 +269,14 @@ def _ensure_workspace(workspace: str, repo: str, branch: str = "main") -> bool:
     name = os.path.basename(workspace)
     if not os.path.isdir(os.path.join(workspace, ".git")):
         os.makedirs(parent, exist_ok=True)
-        clone = subprocess.run(
-            ["gh", "repo", "clone", repo, name],
-            cwd=parent, capture_output=True, text=True, timeout=120,
-        )
+        try:
+            clone = subprocess.run(
+                ["gh", "repo", "clone", repo, name],
+                cwd=parent, capture_output=True, text=True, timeout=120,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("gh repo clone %s timed out", repo)
+            return False
         if clone.returncode != 0:
             logger.warning(
                 "gh repo clone %s failed: %s",
@@ -281,10 +285,15 @@ def _ensure_workspace(workspace: str, repo: str, branch: str = "main") -> bool:
             return False
 
     # Refresh the existing checkout to the tip of the configured branch.
-    fetch = subprocess.run(
-        ["git", "-C", workspace, "fetch", "--depth", "1", "origin", branch],
-        capture_output=True, text=True, timeout=60,
-    )
+    try:
+        fetch = subprocess.run(
+            ["git", "-C", workspace, "fetch", "--depth", "1", "origin", branch],
+            capture_output=True, text=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("git fetch in %s timed out", workspace)
+        # Fall through — try to use whatever is on disk.
+        return True
     if fetch.returncode != 0:
         logger.warning(
             "git fetch in %s failed: %s",
@@ -294,10 +303,14 @@ def _ensure_workspace(workspace: str, repo: str, branch: str = "main") -> bool:
         return True
     logger.info("git fetch in %s: ok (origin/%s)", workspace, branch)
 
-    reset = subprocess.run(
-        ["git", "-C", workspace, "reset", "--hard", f"origin/{branch}"],
-        capture_output=True, text=True, timeout=30,
-    )
+    try:
+        reset = subprocess.run(
+            ["git", "-C", workspace, "reset", "--hard", f"origin/{branch}"],
+            capture_output=True, text=True, timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning("git reset in %s timed out", workspace)
+        return True
     if reset.returncode != 0:
         logger.warning(
             "git reset in %s failed: %s",

--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -254,18 +254,58 @@ def create_proposed_issues(repo: str, proposals: list[dict]) -> list[tuple[int, 
     return created
 
 
-def _ensure_workspace(workspace: str, repo: str) -> bool:
-    """Clone the repo into workspace if not already present."""
-    if os.path.isdir(os.path.join(workspace, ".git")):
-        return True
+def _ensure_workspace(workspace: str, repo: str, branch: str = "main") -> bool:
+    """Clone the repo into workspace if not already present, then refresh
+    the checkout to the tip of ``branch``.
+
+    The refresh is best-effort: if ``git fetch`` or ``git reset --hard`` fails
+    we still return ``True`` so the caller can attempt to read whatever is on
+    disk. ``load_vision`` will surface a clear error if the file is missing.
+
+    Logs each git step so operators can ``grep`` worker output for stale-
+    workspace symptoms without inspecting the volume.
+    """
     parent = os.path.dirname(workspace)
     name = os.path.basename(workspace)
-    os.makedirs(parent, exist_ok=True)
-    result = subprocess.run(
-        ["gh", "repo", "clone", repo, name],
-        cwd=parent, capture_output=True, text=True, timeout=120,
+    if not os.path.isdir(os.path.join(workspace, ".git")):
+        os.makedirs(parent, exist_ok=True)
+        clone = subprocess.run(
+            ["gh", "repo", "clone", repo, name],
+            cwd=parent, capture_output=True, text=True, timeout=120,
+        )
+        if clone.returncode != 0:
+            logger.warning(
+                "gh repo clone %s failed: %s",
+                repo, clone.stderr.strip(),
+            )
+            return False
+
+    # Refresh the existing checkout to the tip of the configured branch.
+    fetch = subprocess.run(
+        ["git", "-C", workspace, "fetch", "--depth", "1", "origin", branch],
+        capture_output=True, text=True, timeout=60,
     )
-    return result.returncode == 0
+    if fetch.returncode != 0:
+        logger.warning(
+            "git fetch in %s failed: %s",
+            workspace, fetch.stderr.strip(),
+        )
+        # Fall through — try to use whatever is on disk.
+        return True
+    logger.info("git fetch in %s: ok (origin/%s)", workspace, branch)
+
+    reset = subprocess.run(
+        ["git", "-C", workspace, "reset", "--hard", f"origin/{branch}"],
+        capture_output=True, text=True, timeout=30,
+    )
+    if reset.returncode != 0:
+        logger.warning(
+            "git reset in %s failed: %s",
+            workspace, reset.stderr.strip(),
+        )
+    else:
+        logger.info("git reset in %s: ok (origin/%s)", workspace, branch)
+    return True
 
 
 async def run_for_project(project_id: int) -> dict:
@@ -283,6 +323,7 @@ async def run_for_project(project_id: int) -> dict:
         if not project:
             return {"ok": False, "error": "project not found"}
         repo = project.repo
+        branch = project.branch or "main"
 
     workspaces_dir = os.environ.get("STATION_WORKSPACES", "/var/lib/claude-agent-station/workspaces")
     name = repo.split("/")[-1]
@@ -306,7 +347,7 @@ async def run_for_project(project_id: int) -> dict:
             **extra,
         })
 
-    if not _ensure_workspace(workspace, repo):
+    if not _ensure_workspace(workspace, repo, branch):
         _finish("error")
         return {"ok": False, "error": f"could not clone {repo}"}
 

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -1,5 +1,4 @@
 import json
-import os
 import pytest
 from unittest.mock import patch, MagicMock
 from agent.vision_analyst import propose_gaps, format_proposal_body, _ensure_workspace

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -1,7 +1,8 @@
 import json
+import os
 import pytest
 from unittest.mock import patch, MagicMock
-from agent.vision_analyst import propose_gaps, format_proposal_body
+from agent.vision_analyst import propose_gaps, format_proposal_body, _ensure_workspace
 
 
 VISION = {"problem": "P", "users": "U", "end_state": "E", "non_goals": "N",
@@ -49,7 +50,7 @@ async def test_run_for_project_posts_started_and_finished_webhooks(monkeypatch, 
         return R()
 
     monkeypatch.setattr(va.httpx, "post", fake_post, raising=False)
-    monkeypatch.setattr(va, "_ensure_workspace", lambda w, r: True)
+    monkeypatch.setattr(va, "_ensure_workspace", lambda w, r, b="main": True)
     monkeypatch.setattr(va, "load_vision", lambda w: {
         "problem": "p", "users": "u", "end_state": "e",
         "non_goals": "n", "principles": "pr", "horizons": "h",
@@ -84,6 +85,105 @@ async def test_run_for_project_posts_started_and_finished_webhooks(monkeypatch, 
     assert finished["status"] == "success"
     assert finished["vision_bootstrap_count"] == 1
     assert finished["vision_bootstrap_proposals"][0]["number"] == 101
+
+
+def _ok(stdout: str = "") -> object:
+    return type("R", (), {"returncode": 0, "stdout": stdout, "stderr": ""})()
+
+
+def _fail(stderr: str = "boom", code: int = 1) -> object:
+    return type("R", (), {"returncode": code, "stdout": "", "stderr": stderr})()
+
+
+def test_ensure_workspace_refreshes_existing_clone_with_branch(monkeypatch, tmp_path):
+    """When .git already exists, _ensure_workspace must run
+    `git fetch --depth 1 origin <branch>` followed by
+    `git reset --hard origin/<branch>` against the right branch."""
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / ".git").mkdir()  # simulate existing clone
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(list(cmd))
+        return _ok()
+
+    monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+
+    ok = _ensure_workspace(str(workspace), "owner/repo", "develop")
+    assert ok is True
+
+    # Two calls: fetch then reset --hard. No clone (git dir already present).
+    assert len(calls) == 2
+    fetch_cmd = calls[0]
+    reset_cmd = calls[1]
+    assert fetch_cmd == [
+        "git", "-C", str(workspace), "fetch", "--depth", "1",
+        "origin", "develop",
+    ]
+    assert reset_cmd == [
+        "git", "-C", str(workspace), "reset", "--hard", "origin/develop",
+    ]
+
+
+def test_ensure_workspace_defaults_to_main(monkeypatch, tmp_path):
+    """Branch default is 'main' when not supplied."""
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / ".git").mkdir()
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(list(cmd))
+        return _ok()
+
+    monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    ok = _ensure_workspace(str(workspace), "owner/repo")
+    assert ok is True
+    assert calls[0][-1] == "main"
+    assert calls[1][-1] == "origin/main"
+
+
+def test_ensure_workspace_returns_true_when_fetch_fails(monkeypatch, tmp_path, caplog):
+    """If `git fetch` fails the function still returns True so the caller
+    can fall through to load_vision; the failure is logged."""
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / ".git").mkdir()
+
+    def fake_run(cmd, *a, **kw):
+        # Fail the first (fetch) call.
+        return _fail("network down")
+
+    monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    with caplog.at_level("WARNING"):
+        ok = _ensure_workspace(str(workspace), "owner/repo", "main")
+    assert ok is True
+    assert any("git fetch" in rec.message and "failed" in rec.message
+               for rec in caplog.records)
+
+
+def test_ensure_workspace_clones_when_missing_then_refreshes(monkeypatch, tmp_path):
+    """When .git is absent, clone first, then run fetch + reset."""
+    workspace = tmp_path / "repo"
+    # workspace dir does NOT exist yet — clone path
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(list(cmd))
+        return _ok()
+
+    monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    ok = _ensure_workspace(str(workspace), "owner/repo", "main")
+    assert ok is True
+    # clone, fetch, reset
+    assert len(calls) == 3
+    assert calls[0][:3] == ["gh", "repo", "clone"]
+    assert calls[1][:5] == ["git", "-C", str(workspace), "fetch", "--depth"]
+    assert calls[2][:5] == ["git", "-C", str(workspace), "reset", "--hard"]
 
 
 def test_create_proposed_issues_pairs_failures_correctly(monkeypatch):


### PR DESCRIPTION
## Summary
- `_ensure_workspace` now fetches + hard-resets existing clones to the tip of the project's default branch, so persistent compose volumes can no longer hide newly-committed `docs/vision.md` files.
- Caller `run_for_project` passes `project.branch or "main"`. Orchestrator's per-project loop refreshes the workspace once before `fetch_eligible_issues` so Trigger A also benefits.
- Each git step logs explicit `ok` / `failed: <stderr>` / `timed out` lines so operators can grep without inspecting the volume.

Closes #271

## Test plan
- [x] `pytest dashboard/backend/tests/test_vision_analyst.py` (9 passed)
- [x] `pytest dashboard/backend/tests/` full backend suite (no regressions)
- [ ] Live: commit `docs/vision.md` via dashboard, click "Re-run analyst", verify successful run without manual workspace deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)