### PR TITLE
feat(orchestrator): wire project mode into Agent Teams flow (#266)

### DIFF
--- a/agent/agents/issue-worker.md
+++ b/agent/agents/issue-worker.md
@@ -73,6 +73,59 @@ This narration is streamed to the operator's Bridge in real time. Never skip it.
 3. Create a step-by-step implementation plan.
 4. If your plan touches files another teammate is working on, **message them to coordinate**.
 
+### Mode Branching (READ CAREFULLY before Step 4)
+
+Your spawn prompt may contain a mode block. Detect it FIRST and branch
+accordingly — the wrong choice here is the most expensive mistake you can
+make in this role.
+
+#### If your prompt contains an `ANALYZE_MODE` section
+
+You are in **read-only investigation mode**. Do NOT proceed to Step 4.
+
+1. Do NOT create a feature branch. Do NOT modify, create, or delete any
+   source file. Do NOT run `git commit` or `git push`.
+2. Produce findings: file:line references, severities, recommendations.
+3. Write your analyze report to the path indicated in the ANALYZE_MODE
+   block (typically `.claude-analyze-report-<index>.json`):
+
+```json
+{
+  "mode": "analyze",
+  "issue_number": 42,
+  "findings": [
+    {"file": "src/auth.py", "line": 117, "severity": "warning", "summary": "..."}
+  ],
+  "files_inspected": ["src/auth.py"],
+  "recommendations": ["..."],
+  "notes": ""
+}
+```
+
+4. Stop. The manager reviews under Analyze Mode Review and never rejects
+   for "no code changes".
+
+#### If your prompt contains a `PLAN_ONLY_MODE` section
+
+You are in **pre-implementation gate mode**. Do NOT proceed to Step 4.
+
+1. Do NOT create a feature branch. Do NOT modify, create, or delete any
+   source file. Do NOT run `git commit` or `git push`.
+2. Write your plan to `.claude-employee-plan-<index>.json` using the
+   schema in `agent/prompts/REPORT-SCHEMAS.md` ("Employee Plan").
+3. If your prompt also contains a `PLAN_REVISION` block, the manager
+   reviewed your previous plan and requested changes. Read the prior plan
+   file referenced in the block, apply the feedback, and overwrite the
+   same plan output path with the revised plan.
+4. Write a brief report with `"mode": "plan_only"` and stop.
+
+#### Otherwise — proceed normally
+
+Step 4 + Step 5 below apply unmodified for `full` and `plan` mode runs.
+For `plan` mode the manager reviews under Plan Mode Review and rejects if
+any source file was modified — you may produce a plan-quality output but
+must stay read-only.
+
 ### Step 4: Implement
 1. Create feature branch: `git checkout -b autonomous/issue-<number>`
 2. Implement changes following your plan.
@@ -89,6 +142,7 @@ This narration is streamed to the operator's Bridge in real time. Never skip it.
 ```json
 {
   "status": "success|failure",
+  "mode": "full|plan|plan_only|analyze",
   "issue_number": 42,
   "issue_title": "...",
   "branch": "autonomous/issue-42",
@@ -106,6 +160,11 @@ This narration is streamed to the operator's Bridge in real time. Never skip it.
   "notes": ""
 }
 ```
+
+For `plan_only` mode, set `"mode": "plan_only"`, leave `branch` /
+`commits` / `files_changed` empty, and reference your plan file path in
+`notes`. For `analyze` mode, prefer the analyze report schema above
+instead of this one.
 
 ## Collaboration
 

--- a/agent/plan_review_gate.py
+++ b/agent/plan_review_gate.py
@@ -33,12 +33,16 @@ plan as guidance (see ``employee.md`` ``APPROVED_PLAN`` block).
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
+
+import httpx
 
 logger = logging.getLogger(__name__)
 
@@ -280,3 +284,444 @@ def build_followup_queue_item(action: GateAction) -> dict:
             "parent_employee_index": ctx.get("parent_employee_index"),
         }),
     }
+
+
+# ── Live wiring ───────────────────────────────────────────────────────────
+#
+# The pure helpers above are unit-testable in isolation. Everything below
+# wires them into the live system:
+#
+# - :func:`post_queue_item` POSTs to ``/api/queue`` with auth.
+# - :func:`post_run_event` POSTs to ``/api/webhook/run-event`` to flip the
+#   run's status to ``awaiting_plan_review``, ``plan_approved``, or
+#   ``plan_rejected`` (handlers added in run_lifecycle.py).
+# - :func:`apply_plan_review_gate` is the orchestrator-side entry point:
+#   parse → decide → execute. Called by :func:`main` (CLI) which is in
+#   turn invoked from :file:`agent/scripts/run-manager.sh` after the
+#   manager review phase, gated on ``project.mode == "plan_only"``.
+#
+# Network failures are logged and converted to non-zero exits so the
+# shell driver can surface them, but they never raise — the gate is a
+# side-effect layer, not a fail-stop in the main flow.
+
+
+def _resolve_dashboard_url(api_url: str | None = None) -> str:
+    """Resolve the dashboard base URL.
+
+    Precedence: explicit arg → ``STATION_DASHBOARD_URL`` env →
+    ``STATION_WEBHOOK_URL`` env (stripped of the ``/api/webhook/...``
+    suffix) → ``http://127.0.0.1:8420``. Matches ``run-manager.sh``
+    queue_api/webhook_event resolution so a single deployment env var
+    works for both layers.
+    """
+    if api_url:
+        return api_url.rstrip("/")
+    env = os.environ.get("STATION_DASHBOARD_URL", "").strip()
+    if env:
+        return env.rstrip("/")
+    wh = os.environ.get("STATION_WEBHOOK_URL", "").strip()
+    if wh:
+        # Strip a trailing /api/webhook/... path component to recover the
+        # base URL.
+        for suffix in ("/api/webhook/run-event", "/api/webhook"):
+            if wh.endswith(suffix):
+                return wh[: -len(suffix)].rstrip("/")
+        return wh.rstrip("/")
+    return "http://127.0.0.1:8420"
+
+
+def _auth_headers() -> dict[str, str]:
+    """Return Bearer-auth headers when ``STATION_API_KEY`` is set.
+
+    Mirrors the dashboard's :func:`verify_api_key` dep — open-by-default
+    when the key is empty so unauth'd local dev keeps working.
+    """
+    key = os.environ.get("STATION_API_KEY", "").strip()
+    if not key:
+        return {}
+    return {"Authorization": f"Bearer {key}"}
+
+
+def _webhook_auth_headers() -> dict[str, str]:
+    """Return webhook auth header when ``STATION_WEBHOOK_SECRET`` is set."""
+    secret = os.environ.get("STATION_WEBHOOK_SECRET", "").strip()
+    if not secret:
+        return {}
+    return {"X-Webhook-Token": secret}
+
+
+def post_queue_item(
+    payload: dict[str, Any],
+    *,
+    api_url: str | None = None,
+    timeout: float = 5.0,
+) -> dict[str, Any] | None:
+    """POST a queue-item payload to the dashboard's ``/api/queue`` endpoint.
+
+    Returns the parsed response on success (the new queue item) or
+    ``None`` on any error. Best-effort — logs and swallows network errors
+    so the gate driver can finish even if the dashboard is unreachable.
+
+    The ``payload`` argument should already match :class:`QueueItemCreate`
+    (typically built by :func:`build_followup_queue_item`).
+    """
+    base = _resolve_dashboard_url(api_url)
+    url = f"{base}/api/queue"
+    headers = {"Content-Type": "application/json", **_auth_headers()}
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(url, json=payload, headers=headers)
+        if 200 <= resp.status_code < 300:
+            try:
+                return resp.json()
+            except ValueError:
+                logger.warning("Queue POST returned non-JSON: %s", resp.text[:200])
+                return None
+        logger.warning(
+            "Queue POST %s returned %d: %s",
+            url, resp.status_code, resp.text[:200],
+        )
+    except httpx.RequestError as exc:
+        logger.warning("Queue POST %s failed: %s", url, exc)
+    return None
+
+
+def post_run_event(
+    event: str,
+    run_id: str,
+    *,
+    extra: dict[str, Any] | None = None,
+    api_url: str | None = None,
+    timeout: float = 3.0,
+) -> bool:
+    """POST a webhook ``run-event`` to flip a Run's status.
+
+    Used by the gate to drive ``awaiting_plan_review`` →
+    ``plan_approved`` / ``plan_rejected`` transitions on the Run row.
+    The handlers live in :mod:`app.services.run_lifecycle`.
+
+    Returns ``True`` on 2xx, ``False`` otherwise. Network failures are
+    logged but never raise — the gate side-effects are best-effort by
+    design.
+    """
+    base = _resolve_dashboard_url(api_url)
+    url = f"{base}/api/webhook/run-event"
+    headers = {"Content-Type": "application/json", **_webhook_auth_headers()}
+    body: dict[str, Any] = {"event": event, "run_id": run_id}
+    if extra:
+        body.update(extra)
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(url, json=body, headers=headers)
+        if 200 <= resp.status_code < 300:
+            return True
+        logger.warning(
+            "run-event %s for %s returned %d: %s",
+            event, run_id, resp.status_code, resp.text[:200],
+        )
+    except httpx.RequestError as exc:
+        logger.warning("run-event %s for %s failed: %s", event, run_id, exc)
+    return False
+
+
+def write_revision_feedback(
+    workspace: str | os.PathLike,
+    employee_index: int,
+    feedback: str,
+    *,
+    revision_count: int,
+    prior_plan_path: str | None,
+) -> str:
+    """Write REVISE_PLAN feedback to a workspace file the next teammate
+    re-spawn can pick up.
+
+    The actual live re-spawn loop is deferred (see TODO in
+    :func:`apply_plan_verdict`); this helper at least preserves the
+    feedback durably so a follow-up run can find it. Returns the path
+    written.
+    """
+    ws = Path(workspace)
+    ws.mkdir(parents=True, exist_ok=True)
+    path = ws / f".claude-plan-revision-feedback-{employee_index}.json"
+    payload = {
+        "employee_index": employee_index,
+        "revision_count": revision_count,
+        "prior_plan_path": prior_plan_path,
+        "feedback": feedback,
+    }
+    path.write_text(json.dumps(payload, indent=2))
+    return str(path)
+
+
+@dataclass(frozen=True)
+class GateOutcome:
+    """Aggregated result of running the gate over one verdict.
+
+    Returned to the CLI / shell driver so it can log per-verdict outcomes
+    and decide whether the gate as a whole succeeded.
+    """
+    action_kind: str
+    verdict_kind: str
+    issue_number: int | None
+    queue_item_id: int | None  # populated on enqueue_full_run success
+    feedback_path: str | None  # populated on revise
+    next_run_state: str
+    posted_status_event: bool
+
+
+def apply_plan_review_gate(
+    project_mode: str,
+    verdicts_path: str | os.PathLike,
+    project_repo: str,
+    run_id: str,
+    *,
+    workspace: str | os.PathLike | None = None,
+    revision_count: int = 0,
+    api_url: str | None = None,
+) -> list[GateOutcome]:
+    """Drive the plan-review gate for one project's manager-review output.
+
+    This is the orchestrator-side entry point. It:
+
+    1. Returns immediately with an empty list when ``project_mode`` is not
+       ``"plan_only"`` — every other mode skips the gate entirely.
+    2. Posts an ``awaiting_plan_review`` run event so the dashboard banner
+       reflects the gate before any side-effects fire.
+    3. Reads the manager's plan verdicts via :func:`parse_plan_verdicts`.
+    4. For each verdict, decides via :func:`apply_plan_verdict`, executes
+       the resulting :class:`GateAction`, and posts a follow-up run event
+       to flip the Run row to ``plan_approved`` / ``plan_rejected``.
+
+    A REVISE_PLAN within budget keeps the run in ``awaiting_plan_review``
+    and writes the feedback to a workspace file via
+    :func:`write_revision_feedback`. The actual live re-spawn loop is a
+    documented TODO — wiring it into the SDK session is intentionally
+    out-of-scope for the initial cut (see issue #266 deliverable
+    summary).
+    """
+    if project_mode != "plan_only":
+        logger.debug("Gate skipped: project_mode=%s is not plan_only", project_mode)
+        return []
+
+    # Mark the run as awaiting plan review BEFORE applying any verdicts so
+    # operators see the gate engage even if the verdicts file is malformed
+    # or the manager produced nothing. The ``plan_reviewing`` window is
+    # the manager-review phase itself (handled by run-manager.sh emitting
+    # plan_review_start for plan_only projects); ``awaiting_plan_review``
+    # is the post-review window where the gate is applying verdicts.
+    post_run_event(
+        "awaiting_plan_review",
+        run_id,
+        extra={"status": "awaiting_plan_review", "project": project_repo, "mode": project_mode},
+        api_url=api_url,
+    )
+
+    verdicts = parse_plan_verdicts(verdicts_path)
+    if not verdicts:
+        logger.warning(
+            "Gate: no plan verdicts found at %s for run %s; leaving status as "
+            "awaiting_plan_review for manual resolution.",
+            verdicts_path, run_id,
+        )
+        return []
+
+    outcomes: list[GateOutcome] = []
+    any_approved = False
+    any_active_revision = False
+
+    for verdict in verdicts:
+        action = apply_plan_verdict(
+            verdict,
+            project_repo=project_repo,
+            revision_count=revision_count,
+        )
+        queue_item_id: int | None = None
+        feedback_path: str | None = None
+        posted = False
+
+        if action.kind == "enqueue_full_run":
+            payload = build_followup_queue_item(action)
+            resp = post_queue_item(payload, api_url=api_url)
+            if resp:
+                queue_item_id = resp.get("id")
+                logger.info(
+                    "Gate: APPROVE_PLAN issue #%s → enqueued follow-up full run "
+                    "(queue_item_id=%s, plan=%s)",
+                    verdict.issue_number, queue_item_id,
+                    (action.follow_up_context or {}).get("approved_plan_path"),
+                )
+                any_approved = True
+            else:
+                logger.warning(
+                    "Gate: APPROVE_PLAN for issue #%s — queue POST failed; "
+                    "follow-up run NOT enqueued.",
+                    verdict.issue_number,
+                )
+                # If the enqueue fails, the gate should NOT mark the run as
+                # plan_approved — that would lose the work. Leave it in
+                # awaiting_plan_review for operator inspection.
+                outcomes.append(GateOutcome(
+                    action_kind=action.kind,
+                    verdict_kind=verdict.verdict,
+                    issue_number=verdict.issue_number,
+                    queue_item_id=None,
+                    feedback_path=None,
+                    next_run_state=RUN_STATE_AWAITING_PLAN_REVIEW,
+                    posted_status_event=False,
+                ))
+                continue
+
+        elif action.kind == "revise":
+            if workspace is not None:
+                feedback_path = write_revision_feedback(
+                    workspace,
+                    verdict.employee_index,
+                    verdict.feedback,
+                    revision_count=(action.follow_up_context or {}).get(
+                        "revision_count", revision_count + 1,
+                    ),
+                    prior_plan_path=verdict.plan_path,
+                )
+            logger.info(
+                "Gate: REVISE_PLAN issue #%s (revision %s/%s) — feedback at %s. "
+                "TODO: wire live re-spawn loop into the SDK session.",
+                verdict.issue_number,
+                (action.follow_up_context or {}).get("revision_count", "?"),
+                get_plan_revision_max(),
+                feedback_path or "<workspace not provided>",
+            )
+            any_active_revision = True
+
+        elif action.kind == "halt_revisions_exhausted":
+            logger.info(
+                "Gate: REVISE_PLAN exhausted (%s/%s) for issue #%s — treating as "
+                "REJECT_PLAN.",
+                revision_count, get_plan_revision_max(), verdict.issue_number,
+            )
+
+        else:  # reject
+            logger.info(
+                "Gate: REJECT_PLAN issue #%s — no follow-up enqueued. Reasoning: %s",
+                verdict.issue_number, (verdict.feedback or "")[:200],
+            )
+
+        outcomes.append(GateOutcome(
+            action_kind=action.kind,
+            verdict_kind=verdict.verdict,
+            issue_number=verdict.issue_number,
+            queue_item_id=queue_item_id,
+            feedback_path=feedback_path,
+            next_run_state=action.next_run_state,
+            posted_status_event=False,
+        ))
+
+    # Decide the run-level status transition. If ANY verdict approved a
+    # plan and the enqueue succeeded, the run is plan_approved. Otherwise,
+    # if ANY revision is in flight, leave the run in awaiting_plan_review.
+    # Otherwise (all rejects / exhausted), mark the run as plan_rejected.
+    if any_approved:
+        terminal_event = "plan_approved"
+    elif any_active_revision:
+        terminal_event = "awaiting_plan_review"
+    else:
+        terminal_event = "plan_rejected"
+
+    posted_terminal = post_run_event(
+        terminal_event,
+        run_id,
+        extra={
+            "status": terminal_event,
+            "project": project_repo,
+            "mode": project_mode,
+        },
+        api_url=api_url,
+    )
+    # Backfill the posted flag on the most recent outcome so callers can
+    # see that the terminal status was sent. We only emit one per gate
+    # invocation (multiple verdicts collapse to a single run state).
+    if outcomes:
+        last = outcomes[-1]
+        outcomes[-1] = GateOutcome(
+            action_kind=last.action_kind,
+            verdict_kind=last.verdict_kind,
+            issue_number=last.issue_number,
+            queue_item_id=last.queue_item_id,
+            feedback_path=last.feedback_path,
+            next_run_state=last.next_run_state,
+            posted_status_event=posted_terminal,
+        )
+
+    return outcomes
+
+
+# ── CLI entry point ─────────────────────────────────────────────────────
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m agent.plan_review_gate",
+        description=(
+            "Plan-review gate driver. Invoked by run-manager.sh after the "
+            "manager review phase for plan_only projects. Reads the manager's "
+            "plan-verdicts JSON, decides per-verdict, and executes the "
+            "follow-up actions (enqueue full run, write revision feedback, "
+            "or close the planning thread)."
+        ),
+    )
+    p.add_argument("--project-mode", required=True,
+                   help="Project mode (full / analyze / plan / plan_only). "
+                        "Gate is a no-op for anything except plan_only.")
+    p.add_argument("--verdicts", required=True,
+                   help="Path to the manager's plan-verdicts JSON file.")
+    p.add_argument("--project-repo", required=True,
+                   help="GitHub repo (owner/name) the gate applies to.")
+    p.add_argument("--run-id", required=True,
+                   help="Full run id including 'run-' prefix.")
+    p.add_argument("--workspace", default=None,
+                   help="Workspace dir for writing revision feedback files.")
+    p.add_argument("--revision-count", type=int, default=0,
+                   help="Current revision count (0 for first review pass).")
+    p.add_argument("--api-url", default=None,
+                   help="Dashboard base URL. Defaults to STATION_DASHBOARD_URL "
+                        "/ STATION_WEBHOOK_URL / http://127.0.0.1:8420.")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    args = _build_arg_parser().parse_args(argv)
+
+    outcomes = apply_plan_review_gate(
+        project_mode=args.project_mode,
+        verdicts_path=args.verdicts,
+        project_repo=args.project_repo,
+        run_id=args.run_id,
+        workspace=args.workspace,
+        revision_count=args.revision_count,
+        api_url=args.api_url,
+    )
+
+    # Summary JSON to stdout for the shell driver to capture.
+    summary = {
+        "outcomes": [
+            {
+                "action_kind": o.action_kind,
+                "verdict_kind": o.verdict_kind,
+                "issue_number": o.issue_number,
+                "queue_item_id": o.queue_item_id,
+                "feedback_path": o.feedback_path,
+                "next_run_state": o.next_run_state,
+                "posted_status_event": o.posted_status_event,
+            }
+            for o in outcomes
+        ],
+    }
+    print(json.dumps(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/plan_review_gate.py
+++ b/agent/plan_review_gate.py
@@ -1,0 +1,282 @@
+"""Plan review gate — pre-implementation enforcement for ``plan_only`` mode.
+
+Issue #266 introduces a four-state project mode. The ``plan_only`` mode
+inserts a manual gate between plan-writing and implementation:
+
+    teammate writes plan → manager reviews plan →
+        APPROVE_PLAN  → enqueue follow-up ``full`` run referencing the plan
+        REVISE_PLAN   → re-spawn the same teammate with feedback (bounded
+                        by STATION_PLAN_REVISION_MAX, default 2)
+        REJECT_PLAN   → close the issue path with a comment, do not
+                        implement
+
+This module owns the post-run gate logic: parsing the manager's plan
+verdict, enqueuing follow-up work, and emitting the corresponding run
+state transitions. The actual re-spawn loop for REVISE_PLAN is currently
+implemented as a documented helper that the run-manager shell driver
+calls between iterations — wiring it into the live SDK session is
+deliberately out-of-scope for the initial cut (see TODO in
+``apply_plan_verdict``).
+
+States added to the run / queue lifecycle (additive — both columns are
+TEXT in SQLite, so old code accepts the new strings without a
+migration):
+
+- ``awaiting_plan_review`` — plan_only run finished, manager verdict pending
+- ``plan_approved``        — APPROVE_PLAN; follow-up ``full`` run enqueued
+- ``plan_rejected``        — REJECT_PLAN; no follow-up
+
+The follow-up ``full`` run carries an ``approved_plan_path`` in its
+``QueueItem.context`` so the implementing teammate reads the approved
+plan as guidance (see ``employee.md`` ``APPROVED_PLAN`` block).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+
+# Lifecycle states (issue #266). Additive — old code keeps working.
+RUN_STATE_AWAITING_PLAN_REVIEW = "awaiting_plan_review"
+RUN_STATE_PLAN_APPROVED = "plan_approved"
+RUN_STATE_PLAN_REJECTED = "plan_rejected"
+
+PLAN_REVIEW_RUN_STATES = (
+    RUN_STATE_AWAITING_PLAN_REVIEW,
+    RUN_STATE_PLAN_APPROVED,
+    RUN_STATE_PLAN_REJECTED,
+)
+
+
+# Default max revisions per plan_only run before we give up. Override via
+# STATION_PLAN_REVISION_MAX env var. Kept as a module constant so tests can
+# patch it cheaply; the env-var read happens in ``get_plan_revision_max()``
+# so changes apply at call time, not import time.
+DEFAULT_PLAN_REVISION_MAX = 2
+
+
+def get_plan_revision_max() -> int:
+    """Return the max plan-revision iteration count.
+
+    Reads ``STATION_PLAN_REVISION_MAX`` at call time (so tests can monkey-
+    patch the environment), falling back to ``DEFAULT_PLAN_REVISION_MAX``.
+    Negative or non-integer values fall back to the default.
+    """
+    raw = os.environ.get("STATION_PLAN_REVISION_MAX")
+    if not raw:
+        return DEFAULT_PLAN_REVISION_MAX
+    try:
+        n = int(raw)
+    except ValueError:
+        logger.warning(
+            "STATION_PLAN_REVISION_MAX=%r is not an integer; using default %d",
+            raw, DEFAULT_PLAN_REVISION_MAX,
+        )
+        return DEFAULT_PLAN_REVISION_MAX
+    return n if n >= 0 else DEFAULT_PLAN_REVISION_MAX
+
+
+@dataclass(frozen=True)
+class PlanVerdict:
+    """A single manager verdict on a plan_only employee plan."""
+    verdict: Literal["APPROVE_PLAN", "REVISE_PLAN", "REJECT_PLAN"]
+    employee_index: int
+    issue_number: int | None
+    plan_path: str | None  # Absolute path to .claude-employee-plan-{index}.json
+    feedback: str  # Required for REVISE_PLAN; informational otherwise
+    plan_quality_score: int | None = None
+
+
+@dataclass(frozen=True)
+class GateAction:
+    """The orchestrator's resolved next-step after a plan verdict.
+
+    ``kind`` decides downstream behavior:
+
+    - ``"enqueue_full_run"``   — build a follow-up run with mode="full" and
+                                 ``approved_plan_path`` in the queue item
+                                 context. ``next_run_state`` is
+                                 ``plan_approved``.
+    - ``"revise"``             — re-spawn the same teammate with the manager
+                                 feedback + prior plan path. The orchestrator
+                                 / run-manager shim drives the loop, bounded
+                                 by ``get_plan_revision_max()``.
+    - ``"reject"``             — close the planning thread, no follow-up.
+                                 ``next_run_state`` is ``plan_rejected``.
+    - ``"halt_revisions_exhausted"`` — REVISE_PLAN was returned but the
+                                 revision counter has hit the cap. Treated
+                                 as a soft REJECT.
+    """
+    kind: Literal[
+        "enqueue_full_run",
+        "revise",
+        "reject",
+        "halt_revisions_exhausted",
+    ]
+    verdict: PlanVerdict
+    next_run_state: str
+    follow_up_context: dict | None = None  # for enqueue_full_run / revise
+
+
+def parse_plan_verdicts(verdicts_path: str | os.PathLike) -> list[PlanVerdict]:
+    """Read a manager plan-verdicts JSON file and return parsed entries.
+
+    File layout matches ``REPORT-SCHEMAS.md`` "Manager Plan Verdict":
+
+    .. code-block:: json
+
+        {
+          "plan_verdicts": [
+            {"verdict": "APPROVE_PLAN", "employee_index": 0,
+             "issue_number": 42, "feedback": "..."}
+          ]
+        }
+
+    Returns an empty list if the file is missing, unreadable, or contains
+    no ``plan_verdicts`` key — never raises. Bad rows are skipped with a
+    warning rather than aborting the whole batch.
+    """
+    p = Path(verdicts_path)
+    if not p.is_file():
+        logger.info("Plan verdicts file not found: %s", p)
+        return []
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("Failed to parse plan verdicts file %s: %s", p, exc)
+        return []
+
+    rows = data.get("plan_verdicts") or []
+    if not isinstance(rows, list):
+        return []
+
+    out: list[PlanVerdict] = []
+    for raw in rows:
+        if not isinstance(raw, dict):
+            continue
+        v = raw.get("verdict")
+        if v not in ("APPROVE_PLAN", "REVISE_PLAN", "REJECT_PLAN"):
+            logger.warning("Skipping plan verdict with unknown verdict %r", v)
+            continue
+        try:
+            out.append(PlanVerdict(
+                verdict=v,
+                employee_index=int(raw.get("employee_index", 0)),
+                issue_number=raw.get("issue_number"),
+                plan_path=raw.get("plan_path") or raw.get("approved_plan_path"),
+                feedback=str(raw.get("feedback") or ""),
+                plan_quality_score=raw.get("plan_quality_score"),
+            ))
+        except (TypeError, ValueError) as exc:
+            logger.warning("Malformed plan verdict %r: %s", raw, exc)
+    return out
+
+
+def apply_plan_verdict(
+    verdict: PlanVerdict,
+    *,
+    project_repo: str,
+    revision_count: int = 0,
+) -> GateAction:
+    """Resolve a single plan verdict into the next gate action.
+
+    The caller (orchestrator post-run hook OR run-manager shim) is
+    responsible for actually performing the side-effects implied by the
+    returned ``GateAction``:
+
+    - ``enqueue_full_run``  → POST a new ``QueueItem`` with mode="full",
+                              context={"approved_plan_path": ...}, and
+                              parent run linkage.
+    - ``revise``            → re-spawn the same teammate; pass the manager
+                              feedback as ``plan_revision_feedback`` to
+                              :func:`build_mode_block`.
+    - ``reject`` /
+      ``halt_revisions_exhausted`` → close the issue path with a comment.
+
+    REVISE_PLAN past ``get_plan_revision_max()`` is downgraded to
+    ``halt_revisions_exhausted`` — we treat exhausted-revisions as a soft
+    rejection, matching the issue body's "loop bounded by config".
+
+    TODO(#266 follow-up): wire ``revise`` into the live SDK session. The
+    current iteration implements the verdict mapping + tests; the actual
+    re-spawn-with-feedback loop is driven by the run-manager shell driver
+    between iterations.
+    """
+    if verdict.verdict == "APPROVE_PLAN":
+        return GateAction(
+            kind="enqueue_full_run",
+            verdict=verdict,
+            next_run_state=RUN_STATE_PLAN_APPROVED,
+            follow_up_context={
+                "project_repo": project_repo,
+                "issue_number": verdict.issue_number,
+                "approved_plan_path": verdict.plan_path,
+                "mode": "full",
+                "parent_employee_index": verdict.employee_index,
+            },
+        )
+
+    if verdict.verdict == "REVISE_PLAN":
+        if revision_count >= get_plan_revision_max():
+            return GateAction(
+                kind="halt_revisions_exhausted",
+                verdict=verdict,
+                next_run_state=RUN_STATE_PLAN_REJECTED,
+            )
+        return GateAction(
+            kind="revise",
+            verdict=verdict,
+            next_run_state=RUN_STATE_AWAITING_PLAN_REVIEW,
+            follow_up_context={
+                "project_repo": project_repo,
+                "issue_number": verdict.issue_number,
+                "prior_plan_path": verdict.plan_path,
+                "plan_revision_feedback": verdict.feedback,
+                "revision_count": revision_count + 1,
+            },
+        )
+
+    # REJECT_PLAN
+    return GateAction(
+        kind="reject",
+        verdict=verdict,
+        next_run_state=RUN_STATE_PLAN_REJECTED,
+    )
+
+
+def build_followup_queue_item(action: GateAction) -> dict:
+    """Build the ``QueueItem`` payload for an ``enqueue_full_run`` action.
+
+    Returns a dict matching the QueueCreate Pydantic schema:
+
+    - ``project_repo`` from the gate context
+    - ``issue_number`` from the original plan_only run
+    - ``mode="full"``
+    - ``state="pending"`` so the next run picks it up
+    - ``context`` carries the approved plan path so the implementing
+      teammate can read it as ``APPROVED_PLAN`` (per employee.md).
+    """
+    if action.kind != "enqueue_full_run":
+        raise ValueError(
+            f"build_followup_queue_item: expected enqueue_full_run action, "
+            f"got {action.kind}"
+        )
+    ctx = action.follow_up_context or {}
+    return {
+        "project_repo": ctx.get("project_repo", ""),
+        "issue_number": ctx.get("issue_number"),
+        "mode": "full",
+        "state": "pending",
+        "context": json.dumps({
+            "approved_plan_path": ctx.get("approved_plan_path"),
+            "from_plan_only_run": True,
+            "parent_employee_index": ctx.get("parent_employee_index"),
+        }),
+    }

--- a/agent/prompts/REPORT-SCHEMAS.md
+++ b/agent/prompts/REPORT-SCHEMAS.md
@@ -47,9 +47,14 @@ Written to the file path specified in the user prompt.
 
 ---
 
-## Employee Plan (`employee.md` — plan_only mode)
+## Employee Plan (`employee.md` and `agents/issue-worker.md` — plan_only mode)
 
-Written to the plan output file path specified in the user prompt (`.claude-employee-plan-{index}.json`).
+Written to the plan output file path specified in the user prompt
+(`.claude-employee-plan-{index}.json`). This is the artifact the manager
+reviews under **Plan Review Mode** (`MODE: PLAN_REVIEW` header). An
+APPROVE_PLAN verdict triggers a follow-up `full` run that reads this file
+as `APPROVED_PLAN` guidance; REVISE_PLAN re-spawns the same teammate
+with manager feedback; REJECT_PLAN closes the planning thread.
 
 ```json
 {
@@ -109,6 +114,7 @@ Written to the verdict file path provided in the user prompt.
       "verdict": "APPROVE_PLAN|REVISE_PLAN|REJECT_PLAN",
       "employee_index": 0,
       "issue_number": 42,
+      "plan_path": "/path/to/.claude-employee-plan-0.json",
       "plan_quality_score": 85,
       "feedback": "Specific feedback for the employee",
       "missing_requirements": [],
@@ -123,10 +129,50 @@ Written to the verdict file path provided in the user prompt.
 | `verdict` | `"APPROVE_PLAN"\|"REVISE_PLAN"\|"REJECT_PLAN"` | yes | |
 | `employee_index` | int | yes | 0-based |
 | `issue_number` | int | yes | |
+| `plan_path` | string | yes | Absolute path to the `.claude-employee-plan-{index}.json` file. The plan-review gate (issue #266) reads this back when enqueuing the follow-up `full` run on APPROVE_PLAN. |
 | `plan_quality_score` | int | yes | 0-100 |
 | `feedback` | string | yes | Required for REVISE_PLAN; specific and actionable |
 | `missing_requirements` | string[] | yes | Requirements not covered by the plan |
 | `suggested_changes` | string[] | yes | Specific changes to make |
+
+---
+
+## Issue-Worker Analyze Report (`agents/issue-worker.md` — analyze mode)
+
+Written to `.claude-analyze-report-{index}.json` when the teammate's
+spawn prompt contains an `ANALYZE_MODE` block. Distinct from the
+`analyst.md` analyst report below: this is a per-teammate read-only
+investigation of a single issue, not a backlog-grooming pass.
+
+```json
+{
+  "mode": "analyze",
+  "issue_number": 42,
+  "findings": [
+    {"file": "src/auth.py", "line": 117, "severity": "warning", "summary": "Null cookie path is unhandled"},
+    {"file": "src/login.tsx", "line": 42, "severity": "info", "summary": "Hover state is hardcoded"}
+  ],
+  "files_inspected": ["src/auth.py", "src/login.tsx"],
+  "recommendations": [
+    "Add unit test for the null-cookie path",
+    "Refactor `validate_token()` into smaller pieces"
+  ],
+  "notes": ""
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `mode` | `"analyze"` | yes | Always `"analyze"` |
+| `issue_number` | int | yes | The issue this analysis covers |
+| `findings` | array | yes | Each: `file`, `line`, `severity`, `summary` |
+| `findings[].severity` | `"info"\|"warning"\|"critical"` | yes | |
+| `files_inspected` | string[] | yes | All files read during investigation |
+| `recommendations` | string[] | yes | Concrete next-action recommendations |
+| `notes` | string | no | |
+
+Reviewed under **Analyze Mode Review** — never rejected for "no code
+changes" / "no diff" / "no branch" (that is the expected output).
 
 ---
 

--- a/agent/prompts/manager.md
+++ b/agent/prompts/manager.md
@@ -224,6 +224,7 @@ Write your verdicts to the file path provided in your prompt:
       "verdict": "APPROVE_PLAN|REVISE_PLAN|REJECT_PLAN",
       "employee_index": 0,
       "issue_number": 42,
+      "plan_path": "/path/to/.claude-employee-plan-0.json",
       "plan_quality_score": 85,
       "feedback": "Specific feedback for the employee (required for REVISE_PLAN)",
       "missing_requirements": [],
@@ -234,6 +235,7 @@ Write your verdicts to the file path provided in your prompt:
 ```
 
 - `verdict`: one of `APPROVE_PLAN`, `REVISE_PLAN`, `REJECT_PLAN`
+- `plan_path`: absolute path to the `.claude-employee-plan-{index}.json` file you reviewed. The orchestrator uses this to pass the approved plan into the follow-up `full` run as `APPROVED_PLAN` context.
 - `feedback`: required for `REVISE_PLAN` — must be specific and actionable
 - `plan_quality_score`: 0-100 score for plan quality
 - `missing_requirements`: list of requirements from the issue not covered by the plan

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -1721,6 +1721,25 @@ run_manager_review() {
     log_info "MANAGER: Reviewing employee work" >&2
     log_info "==========================================" >&2
 
+    # Issue #266: if any project is plan_only, also emit plan_review_start so
+    # the dashboard banner reflects the plan_reviewing state during this
+    # window. The standard manager_review event still fires for full-mode
+    # consumers; the two are additive.
+    local _has_plan_only="false"
+    local _project_count
+    _project_count=$(json_get "$CONFIG_FILE" "projects" 2>/dev/null | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
+    for ((_pi = 0; _pi < _project_count; _pi++)); do
+        local _pm
+        _pm=$(get_project_field "$_pi" "mode" 2>/dev/null || echo "full")
+        if [ "$_pm" = "plan_only" ]; then
+            _has_plan_only="true"
+            break
+        fi
+    done
+    if [ "$_has_plan_only" = "true" ]; then
+        webhook_event "plan_review_start" review_package "$review_package" >&2
+    fi
+
     webhook_event "manager_review" review_package "$review_package" >&2
 
     local model max_turns
@@ -2820,6 +2839,39 @@ print(json.dumps(result))
 
     # ---- PHASE 3: Execute verdicts ----
     execute_verdicts "$verdicts_file"
+
+    # ---- PHASE 3.5: Plan-review gate (issue #266) ----
+    # For each plan_only project, drive the gate: parse the manager's
+    # plan_verdicts, enqueue follow-up full runs on APPROVE_PLAN, write
+    # revision feedback on REVISE_PLAN, log REJECT_PLAN. The Python
+    # driver flips the Run row's status via the dashboard webhook.
+    for ((i = 0; i < project_count; i++)); do
+        local repo_pg enabled_pg mode_pg
+        repo_pg=$(get_project_field "$i" "repo")
+        enabled_pg=$(get_project_field "$i" "enabled" 2>/dev/null || echo "true")
+        [ "$enabled_pg" = "false" ] && continue
+        mode_pg=$(get_project_field "$i" "mode" 2>/dev/null || echo "full")
+        [ -z "$mode_pg" ] && mode_pg="full"
+        if [ "$mode_pg" != "plan_only" ]; then
+            continue
+        fi
+
+        local name_pg
+        name_pg=$(repo_name "$repo_pg")
+        local workspace_pg="$WORKSPACES_DIR/$name_pg"
+
+        log_info "Plan-review gate: applying for $repo_pg (run-$RUN_ID)"
+        local agent_dir_pg
+        agent_dir_pg="$(cd "$SCRIPT_DIR/.." && pwd)"
+        PYTHONPATH="$agent_dir_pg/.." python3 -m agent.plan_review_gate \
+            --project-mode "plan_only" \
+            --verdicts "$verdicts_file" \
+            --project-repo "$repo_pg" \
+            --run-id "run-$RUN_ID" \
+            --workspace "$workspace_pg" \
+            2>&1 | while IFS= read -r line; do log_info "  gate: $line"; done || \
+            log_warn "Plan-review gate exited non-zero for $repo_pg"
+    done
 
     # ---- PHASE 3a: Clean up approved plan files and assignment files (no longer needed after verdicts) ----
     for ((i = 0; i < project_count; i++)); do

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -1510,19 +1510,41 @@ collect_employee_reports() {
         echo "## Project: $repo" >> "$review_package"
         echo "" >> "$review_package"
 
-        # Detect project mode from config
+        # Detect project mode from config and emit the matching MODE header.
+        # The manager prompt (agent/prompts/manager.md:23-33) keys its
+        # review-criteria branching off these exact headers — keep them in
+        # lockstep with that contract. Issue #266: cover all four modes,
+        # not just analyze.
         local project_mode
         project_mode=$(get_project_field "$i" "mode" 2>/dev/null || echo "full")
         [ -z "$project_mode" ] && project_mode="full"
         if [ "$project_mode" = "analyze" ]; then
+            echo "MODE: ANALYZE" >> "$review_package"
+            echo "" >> "$review_package"
             echo "### ⚠️ MODE: ANALYZE — No code changes expected" >> "$review_package"
             echo "" >> "$review_package"
             echo "This project is running in **analyze mode**. The employee was instructed to read code and create/refine GitHub issues ONLY — not to make any code changes. **Do NOT reject for absence of code changes.** Review the quality of created/refined issues instead." >> "$review_package"
             echo "" >> "$review_package"
+        elif [ "$project_mode" = "plan" ]; then
+            echo "MODE: PLAN" >> "$review_package"
+            echo "" >> "$review_package"
+            echo "### ⚠️ MODE: PLAN — Plan-quality output expected, source must be untouched" >> "$review_package"
+            echo "" >> "$review_package"
+            echo "This project is running in **plan mode**. The employee was instructed to produce plan-quality output (rich, file:line-referenced plans). Apply **Plan Mode Review** criteria. **Reject** if any source file was modified." >> "$review_package"
+            echo "" >> "$review_package"
+        elif [ "$project_mode" = "plan_only" ]; then
+            echo "MODE: PLAN_REVIEW" >> "$review_package"
+            echo "" >> "$review_package"
+            echo "### ⚠️ MODE: PLAN_REVIEW — Pre-implementation plan gate" >> "$review_package"
+            echo "" >> "$review_package"
+            echo "This project is running in **plan_only mode**. The employee wrote an implementation plan and stopped — no code, no branch, no commits. Apply **Plan Review Mode** criteria and verdict APPROVE_PLAN / REVISE_PLAN / REJECT_PLAN. Approve only if the plan covers all issue requirements and the approach is sound." >> "$review_package"
+            echo "" >> "$review_package"
         fi
 
-        # Verify no source files were modified in analyze/plan modes (defense in depth)
-        if [ "$project_mode" = "analyze" ] || [ "$project_mode" = "plan" ]; then
+        # Verify no source files were modified in analyze / plan / plan_only modes
+        # (defense in depth). plan_only stops before Step 4 — any non-plan-file
+        # change is a violation.
+        if [ "$project_mode" = "analyze" ] || [ "$project_mode" = "plan" ] || [ "$project_mode" = "plan_only" ]; then
             local dirty_files
             dirty_files=$(cd "$workspace" && { git diff --name-only 2>/dev/null; git ls-files --others --exclude-standard 2>/dev/null; } | grep -v '\.claude-' | grep -v 'node_modules')
             if [ -n "$dirty_files" ]; then
@@ -1590,6 +1612,29 @@ collect_employee_reports() {
                 echo "" >> "$review_package"
             fi
 
+            # Issue #266: surface the plan_only plan file so the manager can
+            # actually evaluate it under Plan Review Mode. Without this the
+            # review package contains only the report stub and the manager
+            # has nothing to score.
+            local plan_only_f="$workspace/.claude-employee-plan-${report_idx}.json"
+            if [ -f "$plan_only_f" ] && [ "$project_mode" = "plan_only" ]; then
+                echo "### ${employee_label} Plan (plan_only mode — review THIS, not a diff)" >> "$review_package"
+                echo '```json' >> "$review_package"
+                cat "$plan_only_f" >> "$review_package"
+                echo '```' >> "$review_package"
+                echo "" >> "$review_package"
+            fi
+
+            # Issue #266: surface the analyze report file similarly.
+            local analyze_f="$workspace/.claude-analyze-report-${report_idx}.json"
+            if [ -f "$analyze_f" ] && [ "$project_mode" = "analyze" ]; then
+                echo "### ${employee_label} Analyze Report" >> "$review_package"
+                echo '```json' >> "$review_package"
+                cat "$analyze_f" >> "$review_package"
+                echo '```' >> "$review_package"
+                echo "" >> "$review_package"
+            fi
+
             # Git diff (main vs current branch)
             cd "$workspace"
 
@@ -1651,6 +1696,10 @@ with open('$report_file') as f:
 
                 if [ "$project_mode" = "analyze" ] || [ "$report_mode" = "analyze" ]; then
                     echo "### ${employee_label}: Analyze mode — no code changes expected (this is correct behavior)" >> "$review_package"
+                elif [ "$project_mode" = "plan_only" ] || [ "$report_mode" = "plan_only" ]; then
+                    echo "### ${employee_label}: Plan-only mode — plan written, no code changes expected (this is correct behavior)" >> "$review_package"
+                elif [ "$project_mode" = "plan" ] || [ "$report_mode" = "plan" ]; then
+                    echo "### ${employee_label}: Plan mode — no code changes expected (review plan-quality output)" >> "$review_package"
                 else
                     echo "### ${employee_label}: No changes (employee stayed on $report_base_branch)" >> "$review_package"
                 fi

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -341,10 +341,12 @@ def handle_empty_backlog(
             else "no-eligible-issues-bootstrap-already-running"
         )
 
+    # Empty-backlog skip: mode is unknown here (no project context loaded
+    # at this layer); leave as None so handle_finished doesn't overwrite an
+    # earlier project-mode value with a stale "agent-teams" sentinel.
     post_webhook(config, "finished", {
         "run_id": f"run-{run_id}",
         "project": repo,
-        "mode": "agent-teams",
         "status": "completed",
         "skip_reason": skip_reason,
     })
@@ -357,6 +359,129 @@ def handle_empty_backlog(
 TEAMMATE_ROLES = ["backend", "frontend", "qa"]
 
 
+VALID_PROJECT_MODES = ("full", "analyze", "plan", "plan_only")
+
+
+def _normalize_project_mode(raw: str | None) -> str:
+    """Coerce a project.mode value to one of VALID_PROJECT_MODES.
+
+    Issue #266: legacy/unknown values default to ``"full"`` so the
+    orchestrator never silently misinterprets a typo. ``triage`` and
+    ``review`` are out-of-scope for this gate (see github_webhook router)
+    and are also coerced to ``"full"`` here — they take a different
+    code path.
+    """
+    if not raw:
+        return "full"
+    raw = str(raw).strip().lower()
+    return raw if raw in VALID_PROJECT_MODES else "full"
+
+
+def build_mode_block(
+    project_mode: str,
+    workspace: str,
+    plan_revision_feedback: str | None = None,
+    prior_plan_path: str | None = None,
+) -> str:
+    """Build the mode-specific block to inject into a teammate spawn prompt.
+
+    Returns an empty string for ``full`` and ``plan`` (no extra block — the
+    worker proceeds normally; for ``plan`` the manager reviews under Plan
+    Mode Review and rejects any source modification).
+
+    For ``analyze`` returns an ``ANALYZE_MODE`` block instructing read-only
+    investigation and pointing at the analyze-report file.
+
+    For ``plan_only`` returns a ``PLAN_ONLY_MODE`` block matching the
+    contract documented in ``agent/prompts/employee.md:72-109`` —
+    teammate writes a plan to ``.claude-employee-plan-{index}.json`` and
+    stops before any branch / commit / push.
+
+    When ``plan_revision_feedback`` is provided (REVISE_PLAN loop), append
+    a ``PLAN_REVISION`` section with the manager's feedback and the prior
+    plan path so the teammate revises rather than starts from scratch.
+    """
+    if project_mode == "analyze":
+        return f"""
+
+## ANALYZE_MODE — READ-ONLY INVESTIGATION
+
+You are in **analyze mode**. Your role is investigation, not implementation.
+
+**STRICT RULES:**
+- Do NOT modify, create, or delete any source file under any circumstance.
+- Do NOT create a feature branch, commit, or push.
+- Do NOT run `gh issue edit ... --add-label autonomous-agent/in-progress` or any GitHub
+  state-changing command on production code.
+- The ONLY file you may write is your analyze report at
+  ``{workspace}/.claude-analyze-report-{{index}}.json``.
+
+**WHAT TO PRODUCE** (JSON shape):
+```json
+{{
+  "mode": "analyze",
+  "issue_number": 42,
+  "findings": [
+    {{"file": "src/auth.py", "line": 117, "severity": "warning", "summary": "..."}}
+  ],
+  "files_inspected": ["src/auth.py", "src/login.tsx"],
+  "recommendations": [
+    "Add unit test for the null-cookie path",
+    "Refactor `validate_token()` into smaller pieces"
+  ],
+  "notes": ""
+}}
+```
+
+The manager reviews under **Analyze Mode Review** — never rejects for
+"no code changes". Stay strictly read-only.
+"""
+
+    if project_mode == "plan_only":
+        revision_block = ""
+        if plan_revision_feedback and prior_plan_path:
+            revision_block = f"""
+
+### PLAN_REVISION — manager requested changes
+
+The manager reviewed your previous plan and requested revisions.
+
+Prior plan file: ``{prior_plan_path}``
+
+Manager feedback:
+{plan_revision_feedback}
+
+Read the prior plan, apply the feedback, and write the **updated** plan
+to the same plan output path below. Do not start from scratch — improve
+the existing plan.
+"""
+        return f"""
+
+## PLAN_ONLY_MODE — PRE-IMPLEMENTATION GATE
+
+You are in **plan-only mode**. Produce an implementation plan and stop —
+do NOT write any code, do NOT create a branch, do NOT commit, do NOT push.
+
+**STRICT RULES:**
+- After Step 3 (Plan), STOP. Do not proceed to Step 4 (Implement).
+- Write the plan to ``{workspace}/.claude-employee-plan-{{index}}.json``
+  using the Plan JSON schema in ``agent/prompts/REPORT-SCHEMAS.md``.
+- Write your final report with ``"mode": "plan_only"`` (not ``"full"``).
+- Leave the working tree clean: no source changes, no new files except
+  the plan file.
+
+After the manager reviews the plan, an **APPROVE_PLAN** verdict triggers a
+follow-up run that implements your plan. **REVISE_PLAN** sends you back
+with feedback. **REJECT_PLAN** stops the issue entirely. Treat the plan
+as a real deliverable — depth matters.{revision_block}
+"""
+
+    # full / plan / unknown → no extra block. The 'plan' path runs the
+    # standard worker flow but is reviewed under Plan Mode Review by the
+    # manager (which rejects if any source was modified).
+    return ""
+
+
 def build_team_prompt(
     repo: str,
     issues: list[dict],
@@ -365,6 +490,7 @@ def build_team_prompt(
     workspace: str = "",
     worktree_paths: dict[str, str] | None = None,
     vision: dict | None = None,
+    project_mode: str = "full",
 ) -> str:
     """Build the lead agent prompt that creates and manages the team."""
     issue_entries = []
@@ -391,6 +517,34 @@ def build_team_prompt(
     if worktree_paths:
         wt_lines = [f"- **{role}** specialist → `{path}`" for role, path in worktree_paths.items()]
         wt_section = "\n".join(wt_lines)
+
+    project_mode = _normalize_project_mode(project_mode)
+    mode_block = build_mode_block(project_mode, workspace)
+    mode_instruction = ""
+    if project_mode == "analyze":
+        mode_instruction = (
+            "\n## Project Mode: ANALYZE (read-only)\n\n"
+            "This project is in **analyze mode**. Each teammate must operate read-only — "
+            "no source edits, no branches, no commits, no pushes. They write findings to "
+            "`.claude-analyze-report-<index>.json` and stop. Include the ANALYZE_MODE block "
+            "below verbatim in every teammate spawn prompt.\n"
+        )
+    elif project_mode == "plan":
+        mode_instruction = (
+            "\n## Project Mode: PLAN (read-only plan output)\n\n"
+            "This project is in **plan mode**. Teammates produce plan-quality output but "
+            "must NOT modify any source file. The manager reviews under Plan Mode Review "
+            "and will reject any read-only violation.\n"
+        )
+    elif project_mode == "plan_only":
+        mode_instruction = (
+            "\n## Project Mode: PLAN_ONLY (pre-implementation gate)\n\n"
+            "This project is in **plan-only mode**. Each teammate writes an implementation "
+            "plan to `.claude-employee-plan-<index>.json` and STOPS — no branch, no commit, "
+            "no push. The manager will review the plan and decide APPROVE_PLAN / REVISE_PLAN "
+            "/ REJECT_PLAN. Include the PLAN_ONLY_MODE block below verbatim in every "
+            "teammate spawn prompt.\n"
+        )
 
     vision_section = ""
     if vision is not None:
@@ -431,7 +585,7 @@ plan does not violate the non-goals or anti-patterns below. If it does:
 """
 
     return f"""You are the lead of an agent team implementing GitHub issues for **{repo}**.
-
+{mode_instruction}
 ## Your Workflow
 
 1. **Create a team** called "{repo.split('/')[-1]}-{run_id[:8]}"
@@ -527,7 +681,8 @@ and your teammates lose their work. You must keep making tool calls to stay aliv
 - Workspace: {workspace}
 - Base branch: `{base_branch}` (teammates must branch FROM this)
 - GH_TOKEN is available for GitHub CLI operations
-{vision_section}"""
+{vision_section}
+{mode_block}"""
 
 
 def build_followup_prompt(
@@ -1085,6 +1240,10 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
         default_level = config.get("autonomy", {}).get("default_level", "assisted")
         autonomy_level = _coerce_level(project.get("autonomy_level") or default_level)
         max_budget_usd = project.get("max_budget_usd")
+        # Issue #266: read project mode and propagate to spawn prompt + webhooks.
+        # Falls back to "full" for legacy projects without an explicit mode.
+        project_mode = _normalize_project_mode(project.get("mode"))
+        logger.info("Project mode for %s: %s", repo, project_mode)
 
         logger.info(
             "Processing project: %s (autonomy=%s, budget=%s)",
@@ -1176,11 +1335,15 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
             else:
                 logger.warning("Failed to create worktree for %s: %s", role, result.stderr.strip())
 
-        # Notify dashboard
+        # Notify dashboard. Issue #266: webhook 'mode' carries the project's
+        # configured mode (full/analyze/plan/plan_only) so the dashboard,
+        # manager, and downstream consumers can branch on it. The Agent
+        # Teams flow is implied by the orchestrator emitting these events
+        # at all — no separate "agent-teams" sentinel is needed.
         post_webhook(config, "run_start", {
             "run_id": f"run-{run_id}",
             "project": repo,
-            "mode": "agent-teams",
+            "mode": project_mode,
             "employee_count": len(issues),
             "concurrent_group_id": f"group-{run_id}",
         })
@@ -1193,7 +1356,7 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
         post_webhook(config, "employee_start", {
             "run_id": f"run-{run_id}",
             "project": repo,
-            "mode": "agent-teams",
+            "mode": project_mode,
             "employee_index": 0,
             "concurrent_group_id": f"group-{run_id}",
         })
@@ -1248,7 +1411,10 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                             iteration + 1, max_reentries, session_id,
                         )
                     else:
-                        prompt = build_team_prompt(repo, issues, config, run_id, workspace, worktree_paths, vision=vision)
+                        prompt = build_team_prompt(
+                            repo, issues, config, run_id, workspace, worktree_paths,
+                            vision=vision, project_mode=project_mode,
+                        )
 
                     # Build options — use resume for follow-up iterations.
                     # Auto Mode (ADR-0001) is wired here: can_use_tool runs
@@ -1313,7 +1479,7 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                             if not first_init_sent:
                                 post_webhook(config, "orchestrator_start", {
                                     "run_id": f"run-{run_id}",
-                                    "mode": "agent-teams",
+                                    "mode": project_mode,
                                 })
                                 first_init_sent = True
 

--- a/dashboard/backend/app/routers/webhook.py
+++ b/dashboard/backend/app/routers/webhook.py
@@ -38,6 +38,11 @@ _RUN_HANDLERS = {
     "reviewing": run_lifecycle.handle_reviewing,
     "plan_reviewing": run_lifecycle.handle_plan_reviewing,
     "plan_review_done": run_lifecycle.handle_plan_review_done,
+    # Plan-review gate (issue #266) — emitted by agent.plan_review_gate
+    # via the post-manager-review hook in run-manager.sh.
+    "awaiting_plan_review": run_lifecycle.handle_awaiting_plan_review,
+    "plan_approved": run_lifecycle.handle_plan_approved,
+    "plan_rejected": run_lifecycle.handle_plan_rejected,
 }
 
 _TASK_EVENTS = {"task_started", "task_completed", "task_failed", "task_ready", "task_blocked"}

--- a/dashboard/backend/app/services/run_lifecycle.py
+++ b/dashboard/backend/app/services/run_lifecycle.py
@@ -332,6 +332,74 @@ async def handle_plan_review_done(
     return run
 
 
+async def handle_awaiting_plan_review(
+    db: AsyncSession, event: WebhookRunEvent, project_id: int | None, run: Run | None
+) -> Run:
+    """Plan-review gate (issue #266): plan_only run finished, manager verdict
+    not yet applied. Set status to ``awaiting_plan_review`` so the dashboard
+    banner can surface the gate.
+    """
+    if not run:
+        run = Run(
+            run_id=event.run_id,
+            project_id=project_id,
+            status="awaiting_plan_review",
+            started_at=datetime.now(timezone.utc),
+            trace_id=event.trace_id,
+        )
+        db.add(run)
+    else:
+        run.status = "awaiting_plan_review"
+        run.trace_id = event.trace_id or run.trace_id
+    return run
+
+
+async def handle_plan_approved(
+    db: AsyncSession, event: WebhookRunEvent, project_id: int | None, run: Run | None
+) -> Run:
+    """Plan-review gate: APPROVE_PLAN — a follow-up ``full`` run has been
+    enqueued. Terminal status for the plan_only run itself.
+    """
+    if not run:
+        run = Run(
+            run_id=event.run_id,
+            project_id=project_id,
+            status="plan_approved",
+            started_at=datetime.now(timezone.utc),
+            trace_id=event.trace_id,
+        )
+        db.add(run)
+    else:
+        run.status = "plan_approved"
+        run.trace_id = event.trace_id or run.trace_id
+        if not run.finished_at:
+            run.finished_at = datetime.now(timezone.utc)
+    return run
+
+
+async def handle_plan_rejected(
+    db: AsyncSession, event: WebhookRunEvent, project_id: int | None, run: Run | None
+) -> Run:
+    """Plan-review gate: REJECT_PLAN or revisions exhausted — no follow-up
+    run will be enqueued. Terminal status.
+    """
+    if not run:
+        run = Run(
+            run_id=event.run_id,
+            project_id=project_id,
+            status="plan_rejected",
+            started_at=datetime.now(timezone.utc),
+            trace_id=event.trace_id,
+        )
+        db.add(run)
+    else:
+        run.status = "plan_rejected"
+        run.trace_id = event.trace_id or run.trace_id
+        if not run.finished_at:
+            run.finished_at = datetime.now(timezone.utc)
+    return run
+
+
 async def handle_progress_update(run: Run, event: WebhookRunEvent) -> None:
     """Update token/turn counts without changing run status."""
     if event.tokens_input is not None:

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -545,3 +545,330 @@ async def test_orchestrate_skips_disabled_projects_in_mixed_config(monkeypatch, 
     assert fetched == ["x/enabled-a", "x/enabled-c"], (
         f"disabled project must not be processed; fetched={fetched}"
     )
+
+
+# --- Issue #266: project-mode wiring ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, "full"),
+        ("", "full"),
+        ("full", "full"),
+        ("FULL", "full"),
+        ("analyze", "analyze"),
+        ("plan", "plan"),
+        ("plan_only", "plan_only"),
+        ("triage", "full"),  # out-of-scope mode coerced to full
+        ("garbage", "full"),
+    ],
+)
+def test_normalize_project_mode(raw, expected):
+    """All four valid modes survive; everything else falls back to 'full'."""
+    assert station_orchestrator._normalize_project_mode(raw) == expected
+
+
+def test_build_mode_block_full_is_empty():
+    """'full' must inject no block — that's the contract."""
+    assert station_orchestrator.build_mode_block("full", "/tmp/ws") == ""
+
+
+def test_build_mode_block_plan_is_empty():
+    """'plan' has no spawn-prompt block; it's enforced at manager review."""
+    assert station_orchestrator.build_mode_block("plan", "/tmp/ws") == ""
+
+
+def test_build_mode_block_analyze_contains_strict_rules():
+    block = station_orchestrator.build_mode_block("analyze", "/var/ws/repo")
+    assert "ANALYZE_MODE" in block
+    assert "READ-ONLY" in block
+    # Must point at the analyze report file path inside the workspace.
+    assert "/var/ws/repo/.claude-analyze-report-" in block
+    # Must explicitly forbid branches and pushes.
+    assert "Do NOT create a feature branch" in block
+
+
+def test_build_mode_block_plan_only_contains_plan_path():
+    block = station_orchestrator.build_mode_block("plan_only", "/var/ws/repo")
+    assert "PLAN_ONLY_MODE" in block
+    assert "PRE-IMPLEMENTATION GATE" in block
+    # Must point at the plan output file path.
+    assert "/var/ws/repo/.claude-employee-plan-" in block
+    # Must explicitly forbid Step 4.
+    assert "STOP" in block
+
+
+def test_build_mode_block_plan_only_with_revision_includes_feedback():
+    block = station_orchestrator.build_mode_block(
+        "plan_only", "/ws", plan_revision_feedback="Add error handling for null inputs",
+        prior_plan_path="/ws/.claude-employee-plan-0.json",
+    )
+    assert "PLAN_REVISION" in block
+    assert "Add error handling for null inputs" in block
+    assert "/ws/.claude-employee-plan-0.json" in block
+
+
+def test_build_team_prompt_full_has_no_mode_section():
+    """'full' team prompt does NOT contain ANALYZE_MODE / PLAN_ONLY_MODE blocks."""
+    prompt = station_orchestrator.build_team_prompt(
+        repo="x/y",
+        issues=[{"number": 1, "title": "t", "body": "b", "labels": []}],
+        config={},
+        run_id="run-x",
+        workspace="/ws",
+        worktree_paths={"backend": "/ws-b"},
+        project_mode="full",
+    )
+    assert "ANALYZE_MODE" not in prompt
+    assert "PLAN_ONLY_MODE" not in prompt
+    # No Project Mode banner for full mode.
+    assert "Project Mode:" not in prompt
+
+
+def test_build_team_prompt_analyze_injects_block_and_banner():
+    prompt = station_orchestrator.build_team_prompt(
+        repo="x/y",
+        issues=[{"number": 1, "title": "t", "body": "b", "labels": []}],
+        config={},
+        run_id="run-x",
+        workspace="/ws",
+        worktree_paths={"backend": "/ws-b"},
+        project_mode="analyze",
+    )
+    assert "ANALYZE_MODE" in prompt
+    assert "Project Mode: ANALYZE" in prompt
+    assert "PLAN_ONLY_MODE" not in prompt
+
+
+def test_build_team_prompt_plan_only_injects_block_and_banner():
+    prompt = station_orchestrator.build_team_prompt(
+        repo="x/y",
+        issues=[{"number": 1, "title": "t", "body": "b", "labels": []}],
+        config={},
+        run_id="run-x",
+        workspace="/ws",
+        worktree_paths={"backend": "/ws-b"},
+        project_mode="plan_only",
+    )
+    assert "PLAN_ONLY_MODE" in prompt
+    assert "Project Mode: PLAN_ONLY" in prompt
+    assert "ANALYZE_MODE" not in prompt
+
+
+def test_build_team_prompt_plan_has_banner_but_no_extra_block():
+    """'plan' mode needs an instruction banner so the lead enforces it,
+    even though there is no ANALYZE_MODE/PLAN_ONLY_MODE spawn-prompt block.
+    """
+    prompt = station_orchestrator.build_team_prompt(
+        repo="x/y",
+        issues=[{"number": 1, "title": "t", "body": "b", "labels": []}],
+        config={},
+        run_id="run-x",
+        workspace="/ws",
+        worktree_paths={"backend": "/ws-b"},
+        project_mode="plan",
+    )
+    assert "Project Mode: PLAN" in prompt
+    assert "ANALYZE_MODE" not in prompt
+    assert "PLAN_ONLY_MODE" not in prompt
+
+
+# --- Plan review gate (issue #266) -----------------------------------------
+
+
+def test_plan_review_gate_approve_enqueues_full_run():
+    from agent.plan_review_gate import (
+        PlanVerdict, apply_plan_verdict, build_followup_queue_item,
+        RUN_STATE_PLAN_APPROVED,
+    )
+    verdict = PlanVerdict(
+        verdict="APPROVE_PLAN",
+        employee_index=0,
+        issue_number=42,
+        plan_path="/ws/.claude-employee-plan-0.json",
+        feedback="LGTM",
+    )
+    action = apply_plan_verdict(verdict, project_repo="x/y")
+    assert action.kind == "enqueue_full_run"
+    assert action.next_run_state == RUN_STATE_PLAN_APPROVED
+    assert action.follow_up_context["approved_plan_path"] == "/ws/.claude-employee-plan-0.json"
+
+    item = build_followup_queue_item(action)
+    assert item["mode"] == "full"
+    assert item["state"] == "pending"
+    assert item["project_repo"] == "x/y"
+    assert item["issue_number"] == 42
+    import json
+    ctx = json.loads(item["context"])
+    assert ctx["approved_plan_path"] == "/ws/.claude-employee-plan-0.json"
+    assert ctx["from_plan_only_run"] is True
+
+
+def test_plan_review_gate_revise_within_budget_loops():
+    from agent.plan_review_gate import (
+        PlanVerdict, apply_plan_verdict, RUN_STATE_AWAITING_PLAN_REVIEW,
+    )
+    v = PlanVerdict(
+        verdict="REVISE_PLAN",
+        employee_index=0,
+        issue_number=42,
+        plan_path="/ws/.claude-employee-plan-0.json",
+        feedback="Add more detail on error handling",
+    )
+    action = apply_plan_verdict(v, project_repo="x/y", revision_count=0)
+    assert action.kind == "revise"
+    assert action.next_run_state == RUN_STATE_AWAITING_PLAN_REVIEW
+    assert action.follow_up_context["plan_revision_feedback"] == "Add more detail on error handling"
+    assert action.follow_up_context["revision_count"] == 1
+
+
+def test_plan_review_gate_revise_past_budget_halts(monkeypatch):
+    from agent.plan_review_gate import (
+        PlanVerdict, apply_plan_verdict, RUN_STATE_PLAN_REJECTED,
+    )
+    monkeypatch.setenv("STATION_PLAN_REVISION_MAX", "2")
+    v = PlanVerdict(
+        verdict="REVISE_PLAN",
+        employee_index=0,
+        issue_number=42,
+        plan_path="/ws/.claude-employee-plan-0.json",
+        feedback="still no good",
+    )
+    action = apply_plan_verdict(v, project_repo="x/y", revision_count=2)
+    assert action.kind == "halt_revisions_exhausted"
+    assert action.next_run_state == RUN_STATE_PLAN_REJECTED
+
+
+def test_plan_review_gate_reject_no_followup():
+    from agent.plan_review_gate import (
+        PlanVerdict, apply_plan_verdict, build_followup_queue_item,
+        RUN_STATE_PLAN_REJECTED,
+    )
+    v = PlanVerdict(
+        verdict="REJECT_PLAN",
+        employee_index=0,
+        issue_number=42,
+        plan_path=None,
+        feedback="issue is not viable",
+    )
+    action = apply_plan_verdict(v, project_repo="x/y")
+    assert action.kind == "reject"
+    assert action.next_run_state == RUN_STATE_PLAN_REJECTED
+    # build_followup_queue_item refuses to build for non-enqueue actions.
+    import pytest as _pt
+    with _pt.raises(ValueError):
+        build_followup_queue_item(action)
+
+
+def test_parse_plan_verdicts_reads_manager_output(tmp_path):
+    """parse_plan_verdicts handles the schema in REPORT-SCHEMAS.md."""
+    from agent.plan_review_gate import parse_plan_verdicts
+    f = tmp_path / "verdicts.json"
+    f.write_text("""{
+      "run_id": "run-1",
+      "plan_verdicts": [
+        {"verdict": "APPROVE_PLAN", "employee_index": 0, "issue_number": 42,
+         "plan_quality_score": 90, "feedback": "ok",
+         "plan_path": "/ws/.claude-employee-plan-0.json"}
+      ]
+    }""")
+    rows = parse_plan_verdicts(f)
+    assert len(rows) == 1
+    assert rows[0].verdict == "APPROVE_PLAN"
+    assert rows[0].issue_number == 42
+    assert rows[0].plan_quality_score == 90
+
+
+def test_parse_plan_verdicts_skips_unknown_verdict(tmp_path):
+    from agent.plan_review_gate import parse_plan_verdicts
+    f = tmp_path / "verdicts.json"
+    f.write_text("""{
+      "plan_verdicts": [
+        {"verdict": "GARBAGE", "employee_index": 0},
+        {"verdict": "REJECT_PLAN", "employee_index": 1, "issue_number": 7,
+         "feedback": "bad"}
+      ]
+    }""")
+    rows = parse_plan_verdicts(f)
+    assert len(rows) == 1
+    assert rows[0].verdict == "REJECT_PLAN"
+
+
+def test_parse_plan_verdicts_missing_file_returns_empty(tmp_path):
+    from agent.plan_review_gate import parse_plan_verdicts
+    assert parse_plan_verdicts(tmp_path / "nope.json") == []
+
+
+def test_get_plan_revision_max_default():
+    from agent.plan_review_gate import (
+        get_plan_revision_max, DEFAULT_PLAN_REVISION_MAX,
+    )
+    import os
+    os.environ.pop("STATION_PLAN_REVISION_MAX", None)
+    assert get_plan_revision_max() == DEFAULT_PLAN_REVISION_MAX
+    assert DEFAULT_PLAN_REVISION_MAX == 2
+
+
+def test_get_plan_revision_max_env_override(monkeypatch):
+    from agent.plan_review_gate import get_plan_revision_max
+    monkeypatch.setenv("STATION_PLAN_REVISION_MAX", "5")
+    assert get_plan_revision_max() == 5
+
+
+def test_get_plan_revision_max_invalid_falls_back(monkeypatch):
+    from agent.plan_review_gate import (
+        get_plan_revision_max, DEFAULT_PLAN_REVISION_MAX,
+    )
+    monkeypatch.setenv("STATION_PLAN_REVISION_MAX", "garbage")
+    assert get_plan_revision_max() == DEFAULT_PLAN_REVISION_MAX
+
+
+# --- Manager review package: MODE: header (issue #266) ---------------------
+
+
+def test_run_manager_emits_mode_headers():
+    """Verify run-manager.sh emits MODE: ANALYZE / MODE: PLAN / MODE: PLAN_REVIEW
+    headers in the review package per project mode. This is a string-level
+    assertion against the shell script — we don't actually run the script
+    in tests because it's a long pipeline.
+    """
+    import pathlib
+    script = pathlib.Path(__file__).parents[3] / "agent" / "scripts" / "run-manager.sh"
+    text = script.read_text()
+    # Each header must be emitted with the exact substring that manager.md
+    # detects (lines 26-31).
+    assert 'echo "MODE: ANALYZE"' in text
+    assert 'echo "MODE: PLAN"' in text
+    assert 'echo "MODE: PLAN_REVIEW"' in text
+    # And only the analyze-mode banner emoji line was present before this
+    # change — guard against accidental removal.
+    assert 'project_mode" = "plan_only"' in text
+
+
+# --- Frontend dropdown values match backend (issue #266) -------------------
+
+
+def test_frontend_dropdown_values_match_backend_modes():
+    """Smoke test: the four <option value="..."> entries in ProjectDetail
+    and ProjectsPage must match VALID_PROJECT_MODES on the backend.
+    Drift in either direction is a defect.
+    """
+    import pathlib
+    valid = set(station_orchestrator.VALID_PROJECT_MODES)
+
+    pd = pathlib.Path(__file__).parents[3] / "dashboard" / "frontend" / "src" / "pages" / "ProjectDetail.svelte"
+    pp = pathlib.Path(__file__).parents[3] / "dashboard" / "frontend" / "src" / "pages" / "ProjectsPage.svelte"
+    pd_text = pd.read_text()
+    pp_text = pp.read_text()
+
+    for mode in valid:
+        assert f'value="{mode}"' in pd_text, f"ProjectDetail missing dropdown option for mode {mode}"
+        assert f'value="{mode}"' in pp_text, f"ProjectsPage missing dropdown option for mode {mode}"
+
+    # ProjectDetail must have inline help text under the dropdown.
+    # We assert the existence of one short phrase per mode.
+    assert "Read-only investigation" in pd_text  # analyze
+    assert "Pre-implementation gate" in pd_text  # plan_only
+    assert "Plan-quality output" in pd_text  # plan
+    assert "Plan and implement" in pd_text  # full

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -846,6 +846,469 @@ def test_run_manager_emits_mode_headers():
     assert 'project_mode" = "plan_only"' in text
 
 
+# --- Plan-review gate live wiring (issue #266 review feedback) -------------
+
+
+def test_apply_plan_review_gate_skips_non_plan_only_modes(monkeypatch, tmp_path):
+    """The gate is a no-op for full / analyze / plan — it must never POST
+    when the project mode is not plan_only.
+    """
+    from agent import plan_review_gate as g
+
+    posted: list[tuple[str, dict]] = []
+    monkeypatch.setattr(g, "post_queue_item", lambda *a, **k: posted.append(("queue", a)) or {"id": 999})
+    monkeypatch.setattr(g, "post_run_event", lambda ev, rid, **k: posted.append(("event", {"event": ev, "rid": rid})) or True)
+
+    for mode in ("full", "analyze", "plan", "garbage"):
+        outcomes = g.apply_plan_review_gate(
+            project_mode=mode,
+            verdicts_path=tmp_path / "doesnt-exist.json",
+            project_repo="x/y",
+            run_id="run-skip",
+        )
+        assert outcomes == []
+
+    assert posted == [], f"Gate must not POST for non-plan_only modes, got {posted}"
+
+
+def test_apply_plan_review_gate_approve_posts_queue_and_status(monkeypatch, tmp_path):
+    """APPROVE_PLAN end-to-end: parse verdicts → POST /api/queue → POST
+    plan_approved run-event.
+    """
+    import json
+    from agent import plan_review_gate as g
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps({
+        "run_id": "run-1",
+        "plan_verdicts": [
+            {
+                "project": "x/y", "verdict": "APPROVE_PLAN",
+                "employee_index": 0, "issue_number": 42,
+                "plan_path": "/ws/.claude-employee-plan-0.json",
+                "plan_quality_score": 90, "feedback": "ok",
+            }
+        ],
+    }))
+
+    queue_calls: list[dict] = []
+    event_calls: list[tuple[str, str, dict]] = []
+
+    monkeypatch.setattr(
+        g, "post_queue_item",
+        lambda payload, **kw: queue_calls.append(payload) or {"id": 7, "state": "pending"},
+    )
+    monkeypatch.setattr(
+        g, "post_run_event",
+        lambda ev, rid, **kw: event_calls.append((ev, rid, kw.get("extra") or {})) or True,
+    )
+
+    outcomes = g.apply_plan_review_gate(
+        project_mode="plan_only",
+        verdicts_path=verdicts_file,
+        project_repo="x/y",
+        run_id="run-1",
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].action_kind == "enqueue_full_run"
+    assert outcomes[0].queue_item_id == 7
+    assert outcomes[0].posted_status_event is True
+
+    # Queue payload shape
+    assert len(queue_calls) == 1
+    payload = queue_calls[0]
+    assert payload["mode"] == "full"
+    assert payload["state"] == "pending"
+    assert payload["project_repo"] == "x/y"
+    assert payload["issue_number"] == 42
+    # context is JSON-encoded (single-encoded — schema column is str | None)
+    assert isinstance(payload["context"], str)
+    ctx = json.loads(payload["context"])
+    assert ctx["approved_plan_path"] == "/ws/.claude-employee-plan-0.json"
+    assert ctx["from_plan_only_run"] is True
+
+    # Event sequence: awaiting_plan_review FIRST, then plan_approved
+    events = [e[0] for e in event_calls]
+    assert events == ["awaiting_plan_review", "plan_approved"]
+    # Both events must reference the same run_id and mode
+    for _ev, rid, extra in event_calls:
+        assert rid == "run-1"
+        assert extra["mode"] == "plan_only"
+        assert extra["project"] == "x/y"
+
+
+def test_apply_plan_review_gate_reject_does_not_post_queue(monkeypatch, tmp_path):
+    """REJECT_PLAN end-to-end: NO POST to /api/queue, status flips to
+    plan_rejected.
+    """
+    import json
+    from agent import plan_review_gate as g
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps({
+        "plan_verdicts": [
+            {"verdict": "REJECT_PLAN", "employee_index": 0, "issue_number": 7,
+             "feedback": "fundamentally broken approach"},
+        ],
+    }))
+
+    queue_calls: list = []
+    event_calls: list[str] = []
+    monkeypatch.setattr(g, "post_queue_item", lambda *a, **kw: queue_calls.append(a) or {"id": 99})
+    monkeypatch.setattr(g, "post_run_event", lambda ev, rid, **kw: event_calls.append(ev) or True)
+
+    outcomes = g.apply_plan_review_gate(
+        project_mode="plan_only",
+        verdicts_path=verdicts_file,
+        project_repo="x/y",
+        run_id="run-2",
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].action_kind == "reject"
+    assert outcomes[0].queue_item_id is None
+    # CRITICAL: no queue POST on reject.
+    assert queue_calls == []
+    # Status flips: awaiting_plan_review (initial) → plan_rejected (terminal).
+    assert event_calls == ["awaiting_plan_review", "plan_rejected"]
+
+
+def test_apply_plan_review_gate_revise_writes_feedback_no_queue_post(monkeypatch, tmp_path):
+    """REVISE_PLAN within budget: NO queue POST, feedback is written to
+    workspace, run stays in awaiting_plan_review (not flipped to a
+    terminal state).
+    """
+    import json
+    from pathlib import Path
+    from agent import plan_review_gate as g
+
+    monkeypatch.setenv("STATION_PLAN_REVISION_MAX", "3")
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps({
+        "plan_verdicts": [
+            {"verdict": "REVISE_PLAN", "employee_index": 0, "issue_number": 9,
+             "plan_path": "/ws/.claude-employee-plan-0.json",
+             "feedback": "Add error handling for null inputs"},
+        ],
+    }))
+
+    workspace = tmp_path / "ws"
+
+    queue_calls: list = []
+    event_calls: list[str] = []
+    monkeypatch.setattr(g, "post_queue_item", lambda *a, **kw: queue_calls.append(a) or {"id": 99})
+    monkeypatch.setattr(g, "post_run_event", lambda ev, rid, **kw: event_calls.append(ev) or True)
+
+    outcomes = g.apply_plan_review_gate(
+        project_mode="plan_only",
+        verdicts_path=verdicts_file,
+        project_repo="x/y",
+        run_id="run-3",
+        workspace=workspace,
+        revision_count=0,
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].action_kind == "revise"
+    # No queue POST on revise.
+    assert queue_calls == []
+    # Run stays in awaiting_plan_review (not plan_approved or plan_rejected).
+    assert event_calls == ["awaiting_plan_review", "awaiting_plan_review"]
+    # Feedback file exists and contains the manager's text.
+    fb_path = outcomes[0].feedback_path
+    assert fb_path is not None
+    fb_data = json.loads(Path(fb_path).read_text())
+    assert fb_data["feedback"] == "Add error handling for null inputs"
+    assert fb_data["prior_plan_path"] == "/ws/.claude-employee-plan-0.json"
+    assert fb_data["revision_count"] == 1
+
+
+def test_apply_plan_review_gate_revise_past_budget_rejects(monkeypatch, tmp_path):
+    """REVISE_PLAN past STATION_PLAN_REVISION_MAX → halt → terminal
+    plan_rejected event, no queue POST.
+    """
+    import json
+    from agent import plan_review_gate as g
+
+    monkeypatch.setenv("STATION_PLAN_REVISION_MAX", "2")
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps({
+        "plan_verdicts": [
+            {"verdict": "REVISE_PLAN", "employee_index": 0, "issue_number": 9,
+             "plan_path": "/ws/p.json", "feedback": "still no good"},
+        ],
+    }))
+
+    queue_calls: list = []
+    event_calls: list[str] = []
+    monkeypatch.setattr(g, "post_queue_item", lambda *a, **kw: queue_calls.append(a) or {"id": 99})
+    monkeypatch.setattr(g, "post_run_event", lambda ev, rid, **kw: event_calls.append(ev) or True)
+
+    outcomes = g.apply_plan_review_gate(
+        project_mode="plan_only",
+        verdicts_path=verdicts_file,
+        project_repo="x/y",
+        run_id="run-4",
+        revision_count=2,  # already at the budget
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].action_kind == "halt_revisions_exhausted"
+    assert queue_calls == []
+    assert event_calls == ["awaiting_plan_review", "plan_rejected"]
+
+
+def test_apply_plan_review_gate_queue_post_failure_does_not_flip_to_approved(
+    monkeypatch, tmp_path,
+):
+    """When the queue POST fails, the run must NOT be marked plan_approved
+    (that would silently lose work). Stay in awaiting_plan_review.
+    """
+    import json
+    from agent import plan_review_gate as g
+
+    verdicts_file = tmp_path / "verdicts.json"
+    verdicts_file.write_text(json.dumps({
+        "plan_verdicts": [
+            {"verdict": "APPROVE_PLAN", "employee_index": 0, "issue_number": 42,
+             "plan_path": "/ws/p.json", "feedback": "ok"},
+        ],
+    }))
+
+    event_calls: list[str] = []
+    monkeypatch.setattr(g, "post_queue_item", lambda *a, **kw: None)  # simulate failure
+    monkeypatch.setattr(g, "post_run_event", lambda ev, rid, **kw: event_calls.append(ev) or True)
+
+    outcomes = g.apply_plan_review_gate(
+        project_mode="plan_only",
+        verdicts_path=verdicts_file,
+        project_repo="x/y",
+        run_id="run-fail",
+    )
+
+    assert len(outcomes) == 1
+    assert outcomes[0].queue_item_id is None
+    assert outcomes[0].action_kind == "enqueue_full_run"
+    # Initial awaiting + a final awaiting — never plan_approved.
+    assert "plan_approved" not in event_calls
+
+
+def test_apply_plan_review_gate_missing_verdicts_file_keeps_awaiting(
+    monkeypatch, tmp_path,
+):
+    """Malformed/missing verdicts file: run stays in awaiting_plan_review
+    for manual operator resolution; no queue POST.
+    """
+    from agent import plan_review_gate as g
+
+    queue_calls: list = []
+    event_calls: list[str] = []
+    monkeypatch.setattr(g, "post_queue_item", lambda *a, **kw: queue_calls.append(a) or {"id": 99})
+    monkeypatch.setattr(g, "post_run_event", lambda ev, rid, **kw: event_calls.append(ev) or True)
+
+    outcomes = g.apply_plan_review_gate(
+        project_mode="plan_only",
+        verdicts_path=tmp_path / "missing.json",
+        project_repo="x/y",
+        run_id="run-missing",
+    )
+
+    assert outcomes == []
+    assert queue_calls == []
+    # Just the initial awaiting_plan_review event — no terminal flip.
+    assert event_calls == ["awaiting_plan_review"]
+
+
+def test_post_queue_item_uses_dashboard_url_and_bearer_auth(monkeypatch):
+    """post_queue_item respects STATION_DASHBOARD_URL and STATION_API_KEY."""
+    import httpx
+    from agent import plan_review_gate as g
+
+    monkeypatch.setenv("STATION_DASHBOARD_URL", "http://dash:9999")
+    monkeypatch.setenv("STATION_API_KEY", "tok-xyz")
+
+    captured = {}
+
+    class _StubClient:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def post(self, url, json, headers):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["body"] = json
+            class R:
+                status_code = 201
+                def json(self): return {"id": 11}
+            return R()
+
+    monkeypatch.setattr(httpx, "Client", _StubClient)
+
+    out = g.post_queue_item({"project_repo": "x/y", "mode": "full", "state": "pending"})
+    assert out == {"id": 11}
+    assert captured["url"] == "http://dash:9999/api/queue"
+    assert captured["headers"]["Authorization"] == "Bearer tok-xyz"
+    assert captured["body"]["mode"] == "full"
+
+
+def test_post_queue_item_returns_none_on_network_error(monkeypatch):
+    """Network failure must be swallowed — gate is best-effort."""
+    import httpx
+    from agent import plan_review_gate as g
+
+    class _StubClient:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def post(self, *a, **kw):
+            raise httpx.RequestError("connection refused")
+
+    monkeypatch.setattr(httpx, "Client", _StubClient)
+    assert g.post_queue_item({"project_repo": "x/y"}) is None
+
+
+def test_post_run_event_uses_webhook_secret_when_configured(monkeypatch):
+    """post_run_event sends X-Webhook-Token when STATION_WEBHOOK_SECRET is set."""
+    import httpx
+    from agent import plan_review_gate as g
+
+    monkeypatch.setenv("STATION_WEBHOOK_SECRET", "wh-tok")
+    monkeypatch.delenv("STATION_DASHBOARD_URL", raising=False)
+    monkeypatch.setenv("STATION_WEBHOOK_URL", "http://wh:8420/api/webhook/run-event")
+
+    captured = {}
+
+    class _StubClient:
+        def __init__(self, *a, **kw): pass
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def post(self, url, json, headers):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["body"] = json
+            class R:
+                status_code = 200
+                text = ""
+            return R()
+
+    monkeypatch.setattr(httpx, "Client", _StubClient)
+
+    ok = g.post_run_event("plan_approved", "run-1", extra={"project": "x/y"})
+    assert ok is True
+    # URL is the dashboard base + /api/webhook/run-event
+    assert captured["url"] == "http://wh:8420/api/webhook/run-event"
+    assert captured["headers"]["X-Webhook-Token"] == "wh-tok"
+    assert captured["body"]["event"] == "plan_approved"
+    assert captured["body"]["run_id"] == "run-1"
+    assert captured["body"]["project"] == "x/y"
+
+
+# --- Webhook-side handlers (issue #266) ------------------------------------
+
+
+async def test_handle_awaiting_plan_review_sets_status():
+    """The webhook lifecycle handler flips Run.status to awaiting_plan_review."""
+    from datetime import datetime, timezone
+    from app.models import Run
+    from app.schemas import WebhookRunEvent
+    from app.services import run_lifecycle
+
+    class _StubDb:
+        def __init__(self): self.added = []
+        def add(self, o): self.added.append(o)
+
+    db = _StubDb()
+    event = WebhookRunEvent(event="awaiting_plan_review", run_id="run-1", project="x/y")
+    run = Run(run_id="run-1", project_id=1, status="reviewing",
+              started_at=datetime.now(timezone.utc))
+    out = await run_lifecycle.handle_awaiting_plan_review(db, event, 1, run)
+    assert out.status == "awaiting_plan_review"
+
+
+async def test_handle_plan_approved_sets_terminal():
+    from datetime import datetime, timezone
+    from app.models import Run
+    from app.schemas import WebhookRunEvent
+    from app.services import run_lifecycle
+
+    class _StubDb:
+        def __init__(self): self.added = []
+        def add(self, o): self.added.append(o)
+
+    db = _StubDb()
+    event = WebhookRunEvent(event="plan_approved", run_id="run-2", project="x/y")
+    run = Run(run_id="run-2", project_id=1, status="awaiting_plan_review",
+              started_at=datetime.now(timezone.utc))
+    out = await run_lifecycle.handle_plan_approved(db, event, 1, run)
+    assert out.status == "plan_approved"
+    assert out.finished_at is not None
+
+
+async def test_handle_plan_rejected_sets_terminal():
+    from datetime import datetime, timezone
+    from app.models import Run
+    from app.schemas import WebhookRunEvent
+    from app.services import run_lifecycle
+
+    class _StubDb:
+        def __init__(self): self.added = []
+        def add(self, o): self.added.append(o)
+
+    db = _StubDb()
+    event = WebhookRunEvent(event="plan_rejected", run_id="run-3", project="x/y")
+    run = Run(run_id="run-3", project_id=1, status="awaiting_plan_review",
+              started_at=datetime.now(timezone.utc))
+    out = await run_lifecycle.handle_plan_rejected(db, event, 1, run)
+    assert out.status == "plan_rejected"
+    assert out.finished_at is not None
+
+
+def test_webhook_router_registers_plan_review_handlers():
+    """Regression guard: the three new run lifecycle events must be wired
+    into the webhook router's _RUN_HANDLERS dispatch table.
+    """
+    from app.routers import webhook
+    for ev in ("awaiting_plan_review", "plan_approved", "plan_rejected"):
+        assert ev in webhook._RUN_HANDLERS, (
+            f"webhook router missing handler for {ev}"
+        )
+
+
+# --- Run-manager.sh emits plan_review_start for plan_only ------------------
+
+
+def test_run_manager_emits_plan_review_start_for_plan_only_projects():
+    """The shell driver must emit plan_review_start when any project is in
+    plan_only mode so the dashboard banner reflects plan_reviewing during
+    the manager-review window.
+    """
+    import pathlib
+    script = pathlib.Path(__file__).parents[3] / "agent" / "scripts" / "run-manager.sh"
+    text = script.read_text()
+    assert 'webhook_event "plan_review_start"' in text
+    assert '_pm" = "plan_only"' in text
+
+
+# --- Plan-review gate is invoked from run-manager.sh -----------------------
+
+
+def test_run_manager_invokes_plan_review_gate():
+    """The shell driver must invoke `python -m agent.plan_review_gate` after
+    execute_verdicts for plan_only projects. Without this the gate is dead
+    code and acceptance criterion #5 (approve plan_only enqueues follow-up)
+    fails at runtime.
+    """
+    import pathlib
+    script = pathlib.Path(__file__).parents[3] / "agent" / "scripts" / "run-manager.sh"
+    text = script.read_text()
+    assert "agent.plan_review_gate" in text, (
+        "run-manager.sh must invoke python -m agent.plan_review_gate"
+    )
+    # Must be gated on plan_only projects, not run unconditionally.
+    assert '"plan_only"' in text
+
+
 # --- Frontend dropdown values match backend (issue #266) -------------------
 
 

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -4,8 +4,8 @@
 // ============================================
 
 // --- Enums ---
-export type AgentMode = 'full' | 'analyze' | 'plan' | 'triage' | 'review' | 'fix';
-export type RunStatus = 'started' | 'employee_done' | 'reviewing' | 'finished' | 'verdict' | 'plan_reviewing' | 'plan_review_done' | string;
+export type AgentMode = 'full' | 'analyze' | 'plan' | 'plan_only' | 'triage' | 'review' | 'fix';
+export type RunStatus = 'started' | 'employee_done' | 'reviewing' | 'finished' | 'verdict' | 'plan_reviewing' | 'plan_review_done' | 'awaiting_plan_review' | 'plan_approved' | 'plan_rejected' | string;
 export type Verdict = 'APPROVE' | 'PR' | 'REJECT';
 export type QueueState = 'pending' | 'assigned' | 'claimed' | 'planning' | 'in_progress' | 'review' | 'verifying' | 'approved' | 'rejected' | 'escalated' | 'paused' | 'failed' | 'cancelled' | 'completed';
 export type PlanStatus = 'draft' | 'approved' | 'implementing' | 'completed' | 'rejected';

--- a/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
+++ b/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
@@ -17,6 +17,19 @@
   let latestRunId = $derived(agentPresence.latestRunId);
   let agents = $derived(agentPresence.agents);
   let isActive = $derived(agents.length > 0 || employees.length > 0);
+  // Issue #266: surface the plan-review gate so the team canvas shows
+  // when a plan_only run is awaiting manager review.
+  let activeRun = $derived(agentPresence.activeRuns.find((r) => r.run_id === latestRunId) ?? null);
+  let planReviewStatus = $derived<string | null>(
+    activeRun && (
+      activeRun.status === 'awaiting_plan_review' ||
+      activeRun.status === 'plan_approved' ||
+      activeRun.status === 'plan_rejected' ||
+      activeRun.status === 'plan_reviewing'
+    )
+      ? (activeRun.status as string)
+      : null
+  );
 
   // Fetch coordinator data
   $effect(() => {
@@ -158,6 +171,22 @@
   </div>
 
 {:else}
+  {#if planReviewStatus}
+    <div
+      style="position: fixed; top: 54px; left: 0; right: 0; padding: 8px 16px; font-size: 12px; z-index: 2; color: white; background: {planReviewStatus === 'plan_approved' ? '#16a34a' : planReviewStatus === 'plan_rejected' ? '#dc2626' : '#d97706'};"
+      data-testid="plan-review-banner"
+    >
+      {#if planReviewStatus === 'awaiting_plan_review'}
+        <strong>Plan awaiting review.</strong> The teammate has written a plan; the manager will approve, request revisions, or reject it before any code is written.
+      {:else if planReviewStatus === 'plan_reviewing'}
+        <strong>Manager reviewing plan…</strong>
+      {:else if planReviewStatus === 'plan_approved'}
+        <strong>Plan approved.</strong> A follow-up full run has been enqueued.
+      {:else if planReviewStatus === 'plan_rejected'}
+        <strong>Plan rejected.</strong> No follow-up run will be queued.
+      {/if}
+    </div>
+  {/if}
   <!-- Active team canvas -->
   <div style="position: fixed; top: 54px; left: 0; right: 0; bottom: 0; z-index: 1; display: grid; grid-template-columns: 1fr 280px;">
 

--- a/dashboard/frontend/src/pages/MissionControl.svelte
+++ b/dashboard/frontend/src/pages/MissionControl.svelte
@@ -21,6 +21,18 @@
   let isLive = $derived(agentPresence.activeRuns.length > 0);
   let runPaused = $derived(!!agentPresence.pausedRuns[currentRunId]);
   let pendingDecisions = $derived(agentPresence.pendingDecisionCount);
+  // Issue #266: surface the plan-review gate so operators can see when a
+  // plan_only run is waiting on the manager (or has been approved/rejected).
+  let planReviewStatus = $derived<string | null>(
+    currentRun && (
+      currentRun.status === 'awaiting_plan_review' ||
+      currentRun.status === 'plan_approved' ||
+      currentRun.status === 'plan_rejected' ||
+      currentRun.status === 'plan_reviewing'
+    )
+      ? (currentRun.status as string)
+      : null
+  );
 
   // Operator message input — goes straight to the agent's next turn.
   let messageText = $state('');
@@ -136,6 +148,28 @@
 
   <!-- Intervention bar -->
   <InterventionBar runId={currentRunId} />
+
+  <!-- Plan-review gate banner (issue #266) -->
+  {#if planReviewStatus}
+    <div
+      class="px-4 py-2 text-xs border-b border-border"
+      class:bg-amber-500={planReviewStatus === 'awaiting_plan_review' || planReviewStatus === 'plan_reviewing'}
+      class:bg-green-600={planReviewStatus === 'plan_approved'}
+      class:bg-red-600={planReviewStatus === 'plan_rejected'}
+      class:text-white={true}
+      data-testid="plan-review-banner"
+    >
+      {#if planReviewStatus === 'awaiting_plan_review'}
+        <strong>Plan awaiting review.</strong> The teammate has written an implementation plan; the manager will approve, request revisions, or reject it before any code is written.
+      {:else if planReviewStatus === 'plan_reviewing'}
+        <strong>Manager reviewing plan…</strong>
+      {:else if planReviewStatus === 'plan_approved'}
+        <strong>Plan approved.</strong> A follow-up full run has been enqueued to implement the approved plan.
+      {:else if planReviewStatus === 'plan_rejected'}
+        <strong>Plan rejected.</strong> No follow-up run will be queued. See the manager verdict for reasoning.
+      {/if}
+    </div>
+  {/if}
 
   <!-- Main content -->
   <div class="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-0">

--- a/dashboard/frontend/src/pages/ProjectDetail.svelte
+++ b/dashboard/frontend/src/pages/ProjectDetail.svelte
@@ -91,6 +91,17 @@
               <option value="plan">Plan</option>
               <option value="plan_only">Plan Only</option>
             </select>
+            <p class="mt-1 text-[11px] leading-snug text-tertiary">
+              {#if project.mode === 'full'}
+                Plan and implement: teammates write code, run tests, and push a feature branch for the manager to review.
+              {:else if project.mode === 'analyze'}
+                Read-only investigation: teammates inspect code and write findings to a report file. No source changes, no branches, no commits.
+              {:else if project.mode === 'plan'}
+                Plan-quality output, source untouched: teammates produce inline-rich plans; the manager rejects any source modification.
+              {:else if project.mode === 'plan_only'}
+                Pre-implementation gate: teammates write a plan and stop. The manager approves, requests revisions, or rejects before any code is written.
+              {/if}
+            </p>
           </div>
           <div>
             <label class="text-xs text-tertiary mb-1 block">Priority</label>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -285,11 +285,43 @@ See [`configuration.md`](configuration.md#environment-variables) for the full ta
 
 The orchestrator dispatches runs in different modes, each with distinct behavior and responsibilities:
 
-- **`agent-teams`** — full autonomous workflow: lead decomposes eligible issues into tasks, spawns three teammates in isolated worktrees, manager reviews each implementation, verdicts issued (APPROVE/PR/REJECT).
+### Project mode (per-project, set via UI)
+
+Each project picks one of four modes (`Project.mode`). The Agent Teams
+orchestrator branches on this value to shape both the spawn prompt and
+the manager review package — see [`configuration.md` §
+Project mode](configuration.md#project-mode) for the full table and
+[`agent/prompts/manager.md`](../agent/prompts/manager.md) for the
+review-criteria branching.
+
+- **`full`** — plan + implement + push branch. Manager review under Full Mode Review.
+- **`analyze`** — read-only investigation; teammates write findings to a report file. Reviewed under Analyze Mode Review.
+- **`plan`** — plan-quality output, source untouched. Reviewed under Plan Mode Review.
+- **`plan_only`** — pre-implementation gate. Teammates write a plan and stop. Reviewed under Plan Review Mode (`APPROVE_PLAN` / `REVISE_PLAN` / `REJECT_PLAN`). On approve, a follow-up `full` run is enqueued referencing the approved plan.
+
+### Run-level run kinds
+
+- **Agent Teams flow** (the default for `full`/`analyze`/`plan`/`plan_only`) — lead decomposes eligible issues into tasks, spawns three teammates in isolated worktrees, manager reviews each implementation, verdicts issued (APPROVE/PR/REJECT for `full`; APPROVE_PLAN/REVISE_PLAN/REJECT_PLAN for `plan_only`).
 - **`vision-bootstrap`** — single-shot run that dispatches `agent/vision_analyst.py` to propose new issues from `docs/vision.md`. Triggered automatically (orchestrator empty backlog, or vision commit with content-hash change) or manually from the Vision tab. Never spawns teammates, never opens PRs.
-- **`fix`** — single-issue repair mode for regressions and urgent bugs.
-- **`triage`** — issue classification and labeling without implementation.
-- **`review`** — security or code review mode for pull requests.
+- **`fix`** — single-issue repair mode for regressions and urgent bugs (legacy; not exposed in the project mode dropdown).
+- **`triage`** — issue classification and labeling without implementation (legacy).
+- **`review`** — security or code review mode for pull requests (legacy).
+
+### Plan-review gate
+
+The `plan_only` mode adds a manual checkpoint between plan-writing and
+implementation. The flow:
+
+```
+plan_only run finishes → manager reviews plan
+  ├── APPROVE_PLAN → enqueue follow-up `full` run (passes plan path as APPROVED_PLAN)
+  ├── REVISE_PLAN  → re-spawn same teammate with feedback (loop bounded by STATION_PLAN_REVISION_MAX)
+  └── REJECT_PLAN  → close planning thread, no follow-up
+```
+
+Run-state additions: `awaiting_plan_review` → `plan_approved` /
+`plan_rejected`. The dashboard surfaces the gate via banners on Mission
+Control and the Agent Teams canvas. Implementation: `agent/plan_review_gate.py`.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -310,18 +310,43 @@ review-criteria branching.
 ### Plan-review gate
 
 The `plan_only` mode adds a manual checkpoint between plan-writing and
-implementation. The flow:
+implementation. The gate is implemented by `agent/plan_review_gate.py`
+and invoked by `agent/scripts/run-manager.sh` after the manager review
+phase. Run-status transitions are driven by webhook events handled in
+`app/services/run_lifecycle.py`.
 
 ```
-plan_only run finishes → manager reviews plan
-  ├── APPROVE_PLAN → enqueue follow-up `full` run (passes plan path as APPROVED_PLAN)
-  ├── REVISE_PLAN  → re-spawn same teammate with feedback (loop bounded by STATION_PLAN_REVISION_MAX)
-  └── REJECT_PLAN  → close planning thread, no follow-up
+plan_only employee writes plan
+   │  (Run.status = running)
+   ▼
+run-manager.sh emits plan_review_start
+   │  (Run.status = plan_reviewing)
+   ▼
+manager reviews plan → run-<id>-verdicts.json
+   │
+   ▼
+run-manager.sh: python -m agent.plan_review_gate
+   │  emits awaiting_plan_review
+   │  (Run.status = awaiting_plan_review)
+   │
+   ├── APPROVE_PLAN → POST /api/queue { mode: "full", context.approved_plan_path }
+   │                  → emit plan_approved (Run.status = plan_approved, finished_at set)
+   │                  → next cycle picks up the follow-up full run
+   │
+   ├── REVISE_PLAN within budget → write feedback file, stay at awaiting_plan_review
+   │                               (TODO: live re-spawn loop)
+   │
+   ├── REVISE_PLAN past STATION_PLAN_REVISION_MAX → emit plan_rejected
+   │
+   └── REJECT_PLAN → emit plan_rejected (Run.status = plan_rejected, finished_at set)
 ```
 
-Run-state additions: `awaiting_plan_review` → `plan_approved` /
-`plan_rejected`. The dashboard surfaces the gate via banners on Mission
-Control and the Agent Teams canvas. Implementation: `agent/plan_review_gate.py`.
+If the queue POST fails the run stays in `awaiting_plan_review` instead
+of flipping to `plan_approved` — losing the approved plan would be
+worse than leaving the gate engaged for manual recovery. The dashboard
+surfaces every gate state via banners on Mission Control and the Agent
+Teams canvas. See `docs/configuration.md#plan-review-gate-plan_only-only`
+for the full env-var matrix and verdict-action table.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,25 +143,43 @@ Agent Teams orchestrator.
 #### Plan-review gate (`plan_only` only)
 
 `plan_only` introduces a pre-implementation gate between plan-writing and
-code:
+code. The gate is implemented by `agent/plan_review_gate.py` and invoked
+by `agent/scripts/run-manager.sh` after the manager review phase.
 
-- **APPROVE_PLAN** → orchestrator enqueues a follow-up `full` run on the
-  same issue with the approved plan path passed in `QueueItem.context.approved_plan_path`.
-  The implementing teammate reads it as `APPROVED_PLAN` guidance.
-- **REVISE_PLAN** → the same teammate is re-spawned with the manager's
-  feedback and the prior plan path. Bounded by `STATION_PLAN_REVISION_MAX`
-  (default `2`) — once exhausted, the gate downgrades to a soft reject.
-- **REJECT_PLAN** → the planning thread closes with a comment; no
-  follow-up run is enqueued.
+**Pipeline (per `plan_only` project):**
 
-Run statuses added to track the gate (additive — old code keeps working):
+1. `run-manager.sh` emits `plan_review_start` (→ `Run.status = plan_reviewing`) before invoking the manager review.
+2. Manager review runs and writes verdicts to `run-<id>-verdicts.json`.
+3. `run-manager.sh` invokes `python -m agent.plan_review_gate` for each plan_only project. The driver:
+   - POSTs `awaiting_plan_review` (→ `Run.status = awaiting_plan_review`) to mark the gate as engaged.
+   - Parses each plan verdict and dispatches per the table below.
+   - POSTs a terminal status event (`plan_approved` / `plan_rejected`) once all verdicts are processed.
+
+**Verdict actions:**
+
+| Verdict | Side effects | Run.status (terminal) |
+|---------|-------------|------------------------|
+| `APPROVE_PLAN` | POSTs a new `QueueItem` to `/api/queue` with `mode=full`, `state=pending`, and `context={"approved_plan_path": ..., "from_plan_only_run": true}`. The follow-up `full` run picks this up on the next cycle and the implementing teammate reads the approved plan as `APPROVED_PLAN` guidance. | `plan_approved` |
+| `REVISE_PLAN` (within budget) | Writes the manager feedback to `<workspace>/.claude-plan-revision-feedback-<index>.json` for the next teammate spawn to consume. **The live re-spawn loop is a documented TODO** — feedback is durably persisted but the orchestrator does not yet re-inject it into a running SDK session. Expect a manual trigger or follow-up issue. | stays at `awaiting_plan_review` |
+| `REVISE_PLAN` (past budget) | Treated as a soft reject. | `plan_rejected` |
+| `REJECT_PLAN` | Logged. No queue POST, no follow-up run. | `plan_rejected` |
+
+If the queue POST for `APPROVE_PLAN` fails (network error, dashboard
+down, dedup hit), the run is **not** flipped to `plan_approved` —
+it stays in `awaiting_plan_review` so an operator can re-run the gate
+manually. The gate is best-effort by design.
+
+**Run statuses added** (additive — old code keeps working):
 `awaiting_plan_review`, `plan_approved`, `plan_rejected`. The dashboard
-surfaces the gate via a banner on Mission Control and the Agent Teams
+surfaces these via a banner on Mission Control and the Agent Teams
 canvas.
 
 | Env var | Default | Description |
 |---------|---------|-------------|
-| `STATION_PLAN_REVISION_MAX` | `2` | Maximum REVISE_PLAN iterations before the gate auto-rejects. Read at gate-evaluation time. |
+| `STATION_PLAN_REVISION_MAX` | `2` | Maximum `REVISE_PLAN` iterations before the gate auto-rejects. Read at gate-evaluation time so changes apply on the next gate run. |
+| `STATION_DASHBOARD_URL` | `http://127.0.0.1:8420` | Dashboard base URL the gate POSTs to. Falls back to `STATION_WEBHOOK_URL` (with `/api/webhook/...` stripped) and finally the default. |
+| `STATION_API_KEY` | _(unset)_ | When set, the gate adds `Authorization: Bearer <key>` on `/api/queue` POSTs. |
+| `STATION_WEBHOOK_SECRET` | _(unset)_ | When set, the gate adds `X-Webhook-Token: <secret>` on `/api/webhook/run-event` POSTs. |
 
 ### Vision-driven issue bootstrap
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,7 +102,7 @@ Each managed repository is one row in the `projects` table. The dashboard's Proj
 |-------|------|---------|-------------|
 | `repo` | string | _(required)_ | GitHub repository in `owner/repo` format. |
 | `priority` | string | `"medium"` | Scheduling priority: `high`, `medium`, or `low`. |
-| `mode` | string | `"full"` | Agent operating mode: `full`, `analyze`, `plan`, `fix`, `triage`, or `review`. |
+| `mode` | string | `"full"` | Project mode — see [Project mode](#project-mode) below. |
 | `enabled` | boolean | `true` | Whether the project is picked up by the scheduler. |
 | `branch` | string | `"main"` | Default branch the agent targets. |
 | `custom_instructions` | string | _(none)_ | Extra instructions appended to the agent prompt for this project. |
@@ -124,6 +124,44 @@ Example JSON for the `POST /api/projects` request body:
   "setup_script": "pip install -r requirements.txt"
 }
 ```
+
+### Project mode
+
+Each project picks one of four modes. The orchestrator branches on this
+value to shape both the teammate spawn prompt and the manager review
+package (issue #266). Out-of-scope values (`triage`, `review`, `fix`)
+exist on the schema for legacy reasons but are coerced to `full` by the
+Agent Teams orchestrator.
+
+| Mode | Spawn-prompt block | Worker behavior | Manager review |
+|------|--------------------|-----------------|----------------|
+| `full` | _(none)_ | Plan + implement + push branch. | Full Mode Review (default). |
+| `analyze` | `ANALYZE_MODE` | Read-only investigation; writes findings to `.claude-analyze-report-{index}.json`; never modifies source, never branches, never commits. | `MODE: ANALYZE` header → Analyze Mode Review. Never rejects for "no code changes". |
+| `plan` | _(none)_ | Plan-quality output; source must be untouched. | `MODE: PLAN` header → Plan Mode Review. Rejects if any source file was modified. |
+| `plan_only` | `PLAN_ONLY_MODE` | Writes a plan to `.claude-employee-plan-{index}.json` and stops; no branch, no commit, no push. | `MODE: PLAN_REVIEW` header → Plan Review Mode. Verdicts: `APPROVE_PLAN` / `REVISE_PLAN` / `REJECT_PLAN`. |
+
+#### Plan-review gate (`plan_only` only)
+
+`plan_only` introduces a pre-implementation gate between plan-writing and
+code:
+
+- **APPROVE_PLAN** → orchestrator enqueues a follow-up `full` run on the
+  same issue with the approved plan path passed in `QueueItem.context.approved_plan_path`.
+  The implementing teammate reads it as `APPROVED_PLAN` guidance.
+- **REVISE_PLAN** → the same teammate is re-spawned with the manager's
+  feedback and the prior plan path. Bounded by `STATION_PLAN_REVISION_MAX`
+  (default `2`) — once exhausted, the gate downgrades to a soft reject.
+- **REJECT_PLAN** → the planning thread closes with a comment; no
+  follow-up run is enqueued.
+
+Run statuses added to track the gate (additive — old code keeps working):
+`awaiting_plan_review`, `plan_approved`, `plan_rejected`. The dashboard
+surfaces the gate via a banner on Mission Control and the Agent Teams
+canvas.
+
+| Env var | Default | Description |
+|---------|---------|-------------|
+| `STATION_PLAN_REVISION_MAX` | `2` | Maximum REVISE_PLAN iterations before the gate auto-rejects. Read at gate-evaluation time. |
 
 ### Vision-driven issue bootstrap
 


### PR DESCRIPTION
## Summary
Wires the `full` / `analyze` / `plan` / `plan_only` project mode end-to-end into the Agent Teams orchestrator. The dropdown UI was previously dead — every selection ran the same `full` flow. Now:

- **Orchestrator** (`station_orchestrator.py`) reads `project.mode`, decorates the spawn prompt with `ANALYZE_MODE` / `PLAN_ONLY_MODE` blocks (or no extra block for `full`/`plan`), and propagates the mode to all webhook events.
- **Worker** (`agents/issue-worker.md`) honors mode blocks: analyze writes findings to `.claude-analyze-report-{index}.json` and stops; plan_only writes to `.claude-employee-plan-{index}.json` and stops before Step 4; otherwise proceeds normally.
- **Manager** (via `run-manager.sh`) emits matching `MODE: ANALYZE` / `PLAN` / `PLAN_REVIEW` headers in the review package and surfaces the analyze / plan_only artifacts inline so the manager has concrete material to score. Defense-in-depth: `dirty_files` check now also fires on `plan_only`.
- **Plan-review gate** (`agent/plan_review_gate.py` — new) is wired end-to-end. After a `plan_only` run, the gate parses the manager's plan verdicts and:
  - **APPROVE_PLAN** → POSTs a follow-up `full` run to `/api/queue` referencing the approved plan, then flips the run to `plan_approved`. Failed POST keeps the run at `awaiting_plan_review` for operator recovery — does not silently advance.
  - **REJECT_PLAN** / revisions exhausted → flips the run to `plan_rejected`, no follow-up.
  - **REVISE_PLAN within budget** → writes feedback to `.claude-plan-revision-feedback-{index}.json`; live re-spawn loop is a documented TODO.
  - Honors `STATION_DASHBOARD_URL`, `STATION_API_KEY` (Bearer on `/api/queue`), `STATION_WEBHOOK_SECRET` (`X-Webhook-Token` on `/api/webhook/run-event`), `STATION_PLAN_REVISION_MAX` (default 2).
- **Lifecycle handlers** (`run_lifecycle.py`) added for the three new states: `awaiting_plan_review`, `plan_approved`, `plan_rejected`. Webhook router registers them.
- **UI** — `MissionControl` and `AgentTeamsCanvas` show a plan-review banner reflecting the gate state. `ProjectDetail` adds inline help text under each mode option.
- **Docs** — `configuration.md` and `architecture.md` updated with the mode pipeline diagram, verdict-action table, and env var matrix.

Closes #266

## Outstanding TODO (documented in code + docs)
- **REVISE_PLAN re-spawn loop** is not yet wired into the live SDK session. Feedback is durably persisted so a follow-up run can consume it; the orchestrator does not yet re-inject it. APPROVE_PLAN and REJECT_PLAN paths are fully wired.

## Deployment-config to verify before live use (review notes)
- `STATION_DASHBOARD_URL` must be set in compose/systemd env (default `http://127.0.0.1:8420` won't reach the dashboard from a sibling container).
- `STATION_API_KEY` / `STATION_WEBHOOK_SECRET` must be present in the agent container's environment so the gate can authenticate.
- Verify `execute_verdicts` doesn't already close GitHub issues for `APPROVE_PLAN` verdicts — the gate runs after it (PHASE 3.5) and would enqueue a follow-up against an already-closed issue if so.

## Test plan
- [x] `pytest dashboard/backend/tests/` (957 passed, 1 skipped — +16 new tests for the gate pipeline, mode normalization, spawn-prompt branching, MODE-header emission, frontend-dropdown / backend parity)
- [x] Mode-normalization, spawn-prompt branching, gate verdict flows (APPROVE/REVISE/REJECT/exhausted/queue-fail/missing-file) all unit-tested
- [ ] Live: configure a project as `plan_only`, trigger a run, verify the manager receives `MODE: PLAN_REVIEW`, the gate enqueues a follow-up `full` run on APPROVE_PLAN, and the dashboard banner reflects the state transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)