### PR TITLE
fix(vision): fetch fresh installation token before workspace refresh

### DIFF
--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -254,25 +254,75 @@ def create_proposed_issues(repo: str, proposals: list[dict]) -> list[tuple[int, 
     return created
 
 
+def _fetch_gh_token() -> str | None:
+    """Fetch a fresh GitHub auth secret from the dashboard's token endpoint.
+
+    Mirrors what ``run-manager.sh:ensure_gh_token`` does for the orchestrator
+    path: GET ``${STATION_DASHBOARD_BASE_URL}/api/github/app/token`` with the
+    ``X-Launcher-Token`` header. Returns ``None`` when the dashboard is
+    unreachable or no GitHub auth is configured — caller falls back to
+    whatever was previously baked into the workspace remote URL.
+
+    Returning ``None`` means the workspace's existing remote URL is the only
+    credential available; that's expected on first install (before the App is
+    set up) but will fail any subsequent ``git fetch`` once the embedded
+    installation token expires (~1 hour).
+    """
+    base = os.environ.get("STATION_DASHBOARD_BASE_URL", "http://localhost:8420").rstrip("/")
+    launcher = os.environ.get("STATION_LAUNCHER_TOKEN", "").strip()
+    headers = {"X-Launcher-Token": launcher} if launcher else {}
+    url = f"{base}/api/github/app/token"
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            resp = client.get(url, headers=headers)
+        if 200 <= resp.status_code < 300:
+            try:
+                body = resp.json()
+            except ValueError:
+                logger.warning("github auth endpoint returned non-JSON response")
+                return None
+            tok = body.get("token") if isinstance(body, dict) else None
+            if tok:
+                return str(tok)
+            logger.warning("github auth endpoint returned no credential")
+            return None
+        logger.warning(
+            "github auth endpoint returned HTTP %d", resp.status_code,
+        )
+    except httpx.RequestError as exc:
+        logger.warning("github auth endpoint unreachable: %s", type(exc).__name__)
+    return None
+
+
 def _ensure_workspace(workspace: str, repo: str, branch: str = "main") -> bool:
     """Clone the repo into workspace if not already present, then refresh
     the checkout to the tip of ``branch``.
 
+    Authentication: an installation token is fetched fresh on each call from
+    the dashboard's ``/api/github/app/token`` endpoint and used both as
+    ``GH_TOKEN`` (for ``gh repo clone``) and via remote-URL rotation (for
+    ``git fetch``/``reset``). Without this, the workspace's embedded
+    ``x-access-token:ghs_...@github.com`` URL becomes stale within an hour
+    and every refresh after the first run fails 401.
+
     The refresh is best-effort: if ``git fetch`` or ``git reset --hard`` fails
     we still return ``True`` so the caller can attempt to read whatever is on
     disk. ``load_vision`` will surface a clear error if the file is missing.
-
-    Logs each git step so operators can ``grep`` worker output for stale-
-    workspace symptoms without inspecting the volume.
     """
     parent = os.path.dirname(workspace)
     name = os.path.basename(workspace)
+    gh_token = _fetch_gh_token()
+    subprocess_env: dict[str, str] | None = None
+    if gh_token:
+        subprocess_env = {**os.environ, "GH_TOKEN": gh_token}
+
     if not os.path.isdir(os.path.join(workspace, ".git")):
         os.makedirs(parent, exist_ok=True)
         try:
             clone = subprocess.run(
                 ["gh", "repo", "clone", repo, name],
                 cwd=parent, capture_output=True, text=True, timeout=120,
+                env=subprocess_env,
             )
         except subprocess.TimeoutExpired:
             logger.warning("gh repo clone %s timed out", repo)
@@ -283,6 +333,25 @@ def _ensure_workspace(workspace: str, repo: str, branch: str = "main") -> bool:
                 repo, clone.stderr.strip(),
             )
             return False
+
+    # Rotate the remote URL with the fresh token so subsequent ``git`` ops
+    # authenticate. Without this, a clone made hours ago retains an expired
+    # ``ghs_...`` token in its origin URL.
+    if gh_token:
+        new_url = f"https://x-access-token:{gh_token}@github.com/{repo}.git"
+        try:
+            rotate = subprocess.run(
+                ["git", "-C", workspace, "remote", "set-url", "origin", new_url],
+                capture_output=True, text=True, timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("git remote set-url in %s timed out", workspace)
+            rotate = None
+        if rotate is not None and rotate.returncode != 0:
+            logger.warning(
+                "git remote set-url in %s failed: %s",
+                workspace, rotate.stderr.strip(),
+            )
 
     # Refresh the existing checkout to the tip of the configured branch.
     try:

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -109,11 +109,13 @@ def test_ensure_workspace_refreshes_existing_clone_with_branch(monkeypatch, tmp_
         return _ok()
 
     monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    monkeypatch.setattr("agent.vision_analyst._fetch_gh_token", lambda: None)
 
     ok = _ensure_workspace(str(workspace), "owner/repo", "develop")
     assert ok is True
 
-    # Two calls: fetch then reset --hard. No clone (git dir already present).
+    # Two calls: fetch then reset --hard. No clone (git dir already present),
+    # no remote-URL rotation (no token available).
     assert len(calls) == 2
     fetch_cmd = calls[0]
     reset_cmd = calls[1]
@@ -139,6 +141,7 @@ def test_ensure_workspace_defaults_to_main(monkeypatch, tmp_path):
         return _ok()
 
     monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    monkeypatch.setattr("agent.vision_analyst._fetch_gh_token", lambda: None)
     ok = _ensure_workspace(str(workspace), "owner/repo")
     assert ok is True
     assert calls[0][-1] == "main"
@@ -157,6 +160,7 @@ def test_ensure_workspace_returns_true_when_fetch_fails(monkeypatch, tmp_path, c
         return _fail("network down")
 
     monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    monkeypatch.setattr("agent.vision_analyst._fetch_gh_token", lambda: None)
     with caplog.at_level("WARNING"):
         ok = _ensure_workspace(str(workspace), "owner/repo", "main")
     assert ok is True
@@ -176,6 +180,7 @@ def test_ensure_workspace_clones_when_missing_then_refreshes(monkeypatch, tmp_pa
         return _ok()
 
     monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    monkeypatch.setattr("agent.vision_analyst._fetch_gh_token", lambda: None)
     ok = _ensure_workspace(str(workspace), "owner/repo", "main")
     assert ok is True
     # clone, fetch, reset
@@ -183,6 +188,156 @@ def test_ensure_workspace_clones_when_missing_then_refreshes(monkeypatch, tmp_pa
     assert calls[0][:3] == ["gh", "repo", "clone"]
     assert calls[1][:5] == ["git", "-C", str(workspace), "fetch", "--depth"]
     assert calls[2][:5] == ["git", "-C", str(workspace), "reset", "--hard"]
+
+
+def test_ensure_workspace_rotates_remote_url_when_token_available(monkeypatch, tmp_path):
+    """With a fresh installation token, _ensure_workspace must rotate the
+    workspace's origin URL so subsequent ``git`` ops authenticate. Without
+    this, a stale ``ghs_...`` token in the URL fails 401 after ~1 hour."""
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / ".git").mkdir()
+
+    calls: list[list[str]] = []
+    captured_envs: list[dict | None] = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(list(cmd))
+        captured_envs.append(kw.get("env"))
+        return _ok()
+
+    monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "agent.vision_analyst._fetch_gh_token", lambda: "ghs_FRESHTOKEN",
+    )
+
+    ok = _ensure_workspace(str(workspace), "owner/repo", "main")
+    assert ok is True
+
+    # remote-set-url, fetch, reset
+    assert len(calls) == 3
+    assert calls[0][:5] == ["git", "-C", str(workspace), "remote", "set-url"]
+    assert calls[0][-1] == "https://x-access-token:ghs_FRESHTOKEN@github.com/owner/repo.git"
+    assert calls[1][:5] == ["git", "-C", str(workspace), "fetch", "--depth"]
+    assert calls[2][:5] == ["git", "-C", str(workspace), "reset", "--hard"]
+
+
+def test_ensure_workspace_passes_token_to_clone_env(monkeypatch, tmp_path):
+    """When cloning fresh, GH_TOKEN must be set in the subprocess env so
+    ``gh repo clone`` can authenticate against private repos."""
+    workspace = tmp_path / "repo"
+    # No .git — exercises the clone path.
+
+    calls: list[list[str]] = []
+    captured_envs: list[dict | None] = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(list(cmd))
+        captured_envs.append(kw.get("env"))
+        return _ok()
+
+    monkeypatch.setattr("agent.vision_analyst.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "agent.vision_analyst._fetch_gh_token", lambda: "ghs_CLONEKEY",
+    )
+
+    ok = _ensure_workspace(str(workspace), "owner/repo", "main")
+    assert ok is True
+
+    # The clone is the first call. Its env must carry GH_TOKEN.
+    clone_env = captured_envs[0]
+    assert clone_env is not None, "clone subprocess should have env override"
+    assert clone_env.get("GH_TOKEN") == "ghs_CLONEKEY"
+
+
+def test_fetch_gh_token_returns_token_on_success(monkeypatch):
+    """The token endpoint returns ``{"token": "...", "source": "app"}`` on
+    success. _fetch_gh_token must return the token string."""
+    from agent import vision_analyst as va
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"token": "ghs_FROMSERVER", "source": "app"}
+
+    class _Client:
+        def __init__(self, *_a, **_kw): ...
+        def __enter__(self): return self
+        def __exit__(self, *_a): return False
+        def get(self, _url, headers=None):
+            return _Resp()
+
+    monkeypatch.setattr(va.httpx, "Client", _Client)
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "x")
+    assert va._fetch_gh_token() == "ghs_FROMSERVER"
+
+
+def test_fetch_gh_token_returns_none_on_404(monkeypatch, caplog):
+    """When the dashboard has no GitHub auth configured the endpoint
+    returns 404; _fetch_gh_token must return None and log a warning."""
+    from agent import vision_analyst as va
+
+    class _Resp:
+        status_code = 404
+        text = '{"detail":"No GitHub auth configured"}'
+
+    class _Client:
+        def __init__(self, *_a, **_kw): ...
+        def __enter__(self): return self
+        def __exit__(self, *_a): return False
+        def get(self, _url, headers=None):
+            return _Resp()
+
+    monkeypatch.setattr(va.httpx, "Client", _Client)
+    with caplog.at_level("WARNING"):
+        assert va._fetch_gh_token() is None
+    assert any("HTTP 404" in rec.message for rec in caplog.records)
+
+
+def test_fetch_gh_token_returns_none_on_network_error(monkeypatch, caplog):
+    """RequestError (e.g. dashboard unreachable) must be swallowed —
+    callers fall back to whatever credential was previously baked into
+    the workspace."""
+    from agent import vision_analyst as va
+
+    class _Client:
+        def __init__(self, *_a, **_kw): ...
+        def __enter__(self): return self
+        def __exit__(self, *_a): return False
+        def get(self, _url, headers=None):
+            raise va.httpx.ConnectError("dashboard unreachable")
+
+    monkeypatch.setattr(va.httpx, "Client", _Client)
+    with caplog.at_level("WARNING"):
+        assert va._fetch_gh_token() is None
+    assert any("unreachable" in rec.message for rec in caplog.records)
+
+
+def test_fetch_gh_token_passes_launcher_header(monkeypatch):
+    """Endpoint is launcher-token-gated; _fetch_gh_token must pass the
+    X-Launcher-Token header from STATION_LAUNCHER_TOKEN."""
+    from agent import vision_analyst as va
+
+    captured_headers: list[dict] = []
+
+    class _Resp:
+        status_code = 200
+        def json(self):
+            return {"token": "t"}
+
+    class _Client:
+        def __init__(self, *_a, **_kw): ...
+        def __enter__(self): return self
+        def __exit__(self, *_a): return False
+        def get(self, _url, headers=None):
+            captured_headers.append(headers or {})
+            return _Resp()
+
+    monkeypatch.setattr(va.httpx, "Client", _Client)
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "secret-shared-value")
+    va._fetch_gh_token()
+    assert captured_headers[0].get("X-Launcher-Token") == "secret-shared-value"
 
 
 def test_create_proposed_issues_pairs_failures_correctly(monkeypatch):


### PR DESCRIPTION
## Summary
Follow-up to #273 (issue #271). After that PR landed, vision-bootstrap runs were still failing — but now with `git fetch ... Authentication failed` instead of `no vision file at docs/vision.md`. The new fetch was firing; what it lacked was a valid credential.

Root cause: the workspace's origin URL has a `ghs_...` installation token embedded from the original `gh repo clone`. Those tokens expire in ~1 hour. `_ensure_workspace`'s new git ops authenticate via that URL — once expired, every refresh fails 401.

The orchestrator path (`run-manager.sh:ensure_gh_token`) already handles this: it fetches a fresh token from the dashboard's `/api/github/app/token` endpoint and exports it as `GH_TOKEN`. The vision-bootstrap path went straight from the dashboard endpoint into `_ensure_workspace` with no token refresh.

## Fix
- New `_fetch_gh_token()` helper: GETs `${STATION_DASHBOARD_BASE_URL}/api/github/app/token` with the `X-Launcher-Token` header (matches what the run-manager already does). Returns the fresh token on 200, `None` on any error.
- `_ensure_workspace` now fetches a fresh token at the start of each call. When available:
  - Sets `GH_TOKEN` in the subprocess env for `gh repo clone` (private repos).
  - Rotates the workspace's origin URL with the fresh `https://x-access-token:<token>@github.com/<repo>.git` form so subsequent `git fetch` / `git reset --hard` authenticate.
- When the token endpoint is unreachable (no GitHub auth configured yet, dashboard briefly down), falls back to whatever credential was already in the URL — preserves previous behavior on first install.
- Log messages carefully avoid logging the token itself.

## Test plan
- [x] `pytest dashboard/backend/tests/` (973 passed, 1 skipped — 6 new tests covering token fetch happy path / 4xx / network error / launcher-header propagation; remote-URL rotation; clone-env handling)
- [ ] Live: rebuild + restart agent container, click "Re-run analyst" on the Vision tab, verify successful run reading the current `docs/vision.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)