### PR TITLE
fix(vision): unblock claude CLI under root + report errors honestly

### DIFF
--- a/agent/launcher.py
+++ b/agent/launcher.py
@@ -12,8 +12,10 @@ default) — see :mod:`app.services.service_control` for the dispatch.
 
 from __future__ import annotations
 
+import glob
 import logging
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -63,6 +65,43 @@ def _fetch_gh_token() -> str | None:
 # without --workers; do not change that without reworking state to be shared.
 app = FastAPI(title="claude-agent-station launcher")
 _current: subprocess.Popen | None = None
+
+
+def _ensure_claude_config() -> None:
+    """Restore ``/root/.claude.json`` from a backup if missing.
+
+    The Claude Code CLI writes ``~/.claude.json`` itself on first run, but
+    when the host's ``~/.claude`` is bind-mounted into the container it can
+    arrive without that file (it lives outside the mounted directory on
+    the host). The CLI then refuses to start, printing a backup-restore
+    hint to stderr. The vision-analyst path was silently swallowing this
+    because the orchestrator was already root-blocked too (see
+    ``IS_SANDBOX`` in compose.yml).
+
+    We pick the newest ``backups/.claude.json.backup.*`` and copy it into
+    place. Idempotent: skipped when the file already exists.
+    """
+    target = Path("/root/.claude.json")
+    if target.exists():
+        return
+    backups = sorted(glob.glob("/root/.claude/backups/.claude.json.backup.*"))
+    if not backups:
+        logger.warning(
+            "launcher: /root/.claude.json missing and no backup found under "
+            "/root/.claude/backups — Claude CLI calls will fail. Mount the host's "
+            "Claude config or run ``claude`` once interactively to generate one.",
+        )
+        return
+    src = backups[-1]
+    try:
+        shutil.copy2(src, target)
+        os.chmod(target, 0o600)
+        logger.info("launcher: restored /root/.claude.json from %s", src)
+    except OSError as exc:
+        logger.warning("launcher: failed to restore /root/.claude.json: %s", exc)
+
+
+_ensure_claude_config()
 
 if not LAUNCHER_TOKEN:
     logger.warning(

--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -186,8 +186,26 @@ def format_proposal_body(body: str) -> str:
     return DISCLAIMER + body.strip() + "\n"
 
 
+class VisionAnalystError(RuntimeError):
+    """Raised when the analyst could not produce proposals due to a runtime
+    failure (model unreachable, response not JSON, etc).
+
+    Distinct from the model legitimately returning an empty list, which the
+    caller represents as ``[]``. Without this distinction
+    :func:`run_for_project` would report ``status=success`` with zero
+    proposals on every transient failure, hiding the failure from
+    operators.
+    """
+
+
 def propose_gaps(workspace: str, vision: dict, repo: str, model: str) -> list[dict]:
-    """Return a list of proposal dicts, capped at MAX_PROPOSALS. Empty on failure."""
+    """Return a list of proposal dicts, capped at MAX_PROPOSALS.
+
+    Returns ``[]`` when the model legitimately produced no proposals.
+    Raises :class:`VisionAnalystError` when the model call failed or its
+    output could not be parsed — caller should treat that as a run failure
+    rather than "no gaps".
+    """
     state = _gather_repo_state(workspace, repo)
 
     open_titles = [f"#{i['number']}: {i['title']}" for i in state["open_issues"]][:50]
@@ -209,19 +227,23 @@ def propose_gaps(workspace: str, vision: dict, repo: str, model: str) -> list[di
         raw = _call_model(prompt, model)
     except Exception as e:
         logger.error("vision_analyst model call failed: %s", e)
-        return []
+        raise VisionAnalystError(f"model call failed: {e}") from e
 
     raw = raw.strip()
     if raw.startswith("```"):
         raw = raw.split("\n", 1)[1] if "\n" in raw else raw
         raw = raw.rstrip("` \n")
+    if not raw:
+        raise VisionAnalystError("model returned empty response")
     try:
         proposals = json.loads(raw)
     except json.JSONDecodeError as e:
         logger.error("vision_analyst response not JSON: %s", e)
-        return []
+        raise VisionAnalystError(f"response not JSON: {e}") from e
     if not isinstance(proposals, list):
-        return []
+        raise VisionAnalystError(
+            f"model returned non-list JSON: {type(proposals).__name__}"
+        )
     return proposals[:MAX_PROPOSALS]
 
 
@@ -439,7 +461,11 @@ async def run_for_project(project_id: int) -> dict:
         return {"ok": False, "error": "no vision file at docs/vision.md"}
 
     model = os.environ.get("STATION_VISION_ANALYST_MODEL", "claude-sonnet-4-6")
-    proposals = propose_gaps(workspace, vision, repo, model)
+    try:
+        proposals = propose_gaps(workspace, vision, repo, model)
+    except VisionAnalystError as exc:
+        _finish("error", error=str(exc))
+        return {"ok": False, "error": str(exc)}
     if not proposals:
         _finish("success", vision_bootstrap_count=0, vision_bootstrap_proposals=[])
         return {"ok": True, "proposals": [], "created": []}

--- a/compose.yml
+++ b/compose.yml
@@ -118,6 +118,13 @@ services:
       # the dashboard side because the agent reaches the dashboard via the
       # compose service name.
       STATION_DASHBOARD_BASE_URL: http://dashboard:8420
+      # Claude Code CLI refuses ``--dangerously-skip-permissions`` under
+      # root unless ``IS_SANDBOX=1`` is set. The agent container runs as
+      # root and uses that flag for non-interactive ``claude --print``
+      # calls in vision_analyst and run-manager.sh. Setting this here
+      # documents the choice and unblocks those calls; tighten by running
+      # the container as a non-root user instead, when feasible.
+      IS_SANDBOX: "1"
     volumes:
       - station-data:/var/lib/claude-agent-station
       - station-logs:/var/log/claude-agent

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -1,7 +1,12 @@
 import json
 import pytest
 from unittest.mock import patch, MagicMock
-from agent.vision_analyst import propose_gaps, format_proposal_body, _ensure_workspace
+from agent.vision_analyst import (
+    propose_gaps,
+    format_proposal_body,
+    _ensure_workspace,
+    VisionAnalystError,
+)
 
 
 VISION = {"problem": "P", "users": "U", "end_state": "E", "non_goals": "N",
@@ -26,6 +31,40 @@ def test_propose_gaps_caps_at_5():
         with patch("agent.vision_analyst._call_model", return_value=huge):
             proposals = propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
     assert len(proposals) <= 5
+
+
+def test_propose_gaps_raises_when_model_call_fails():
+    """A failed CLI invocation must raise VisionAnalystError so the caller
+    can report a run failure rather than silently degrading to 'no gaps'."""
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", side_effect=RuntimeError("boom")):
+            with pytest.raises(VisionAnalystError, match="model call failed"):
+                propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+
+
+def test_propose_gaps_raises_on_empty_response():
+    """An empty stdout from the CLI is a runtime failure — not 'no gaps'."""
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", return_value=""):
+            with pytest.raises(VisionAnalystError, match="empty response"):
+                propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+
+
+def test_propose_gaps_raises_on_non_json_response():
+    """Garbage output from the CLI must surface as an error, not [] proposals."""
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", return_value="not json at all"):
+            with pytest.raises(VisionAnalystError, match="not JSON"):
+                propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+
+
+def test_propose_gaps_returns_empty_list_when_model_says_no_gaps():
+    """A legitimate empty list from the model is NOT an error — caller
+    should report success-with-zero-proposals."""
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", return_value="[]"):
+            proposals = propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+    assert proposals == []
 
 
 def test_format_proposal_body_includes_disclaimer():


### PR DESCRIPTION
## Summary
Vision-analyst runs were silently completing with 0 proposals. Run record showed \`status=completed, vision_bootstrap_count=0\`, but the model never actually ran. Two compounding runtime failures plus a misleading status report:

1. **\`--dangerously-skip-permissions cannot be used with root/sudo privileges\`** — agent container runs as root; CLI refuses the flag without \`IS_SANDBOX=1\`.
2. **\`/root/.claude.json\` missing** — the host's \`~/.claude\` is bind-mounted but the primary config file lives outside that directory on the host, so it doesn't arrive in the container. CLI exits early with a backup-restore hint.
3. **\`propose_gaps\` swallowed both errors into an empty list**, and \`run_for_project\` reported \`status=success\` with 0 proposals — operator saw "no gaps" when the model never even ran.

## Fixes
- **compose.yml**: \`IS_SANDBOX=1\` on the agent service so \`--dangerously-skip-permissions\` works under root.
- **agent/launcher.py**: on startup, restore \`/root/.claude.json\` from the newest \`/root/.claude/backups/.claude.json.backup.*\` if missing. Idempotent.
- **agent/vision_analyst.py**: new \`VisionAnalystError\` exception. \`propose_gaps\` raises on model failure / empty response / non-JSON / non-list. \`run_for_project\` catches and emits \`status=error\` with the underlying message instead of falsifying success. Legitimately-empty list from the model is still success.

## Test plan
- [x] \`pytest dashboard/backend/tests/\` (977 passed, 1 skipped — 4 new tests for the failure modes plus the legitimately-empty path)
- [x] Verified manually: \`docker compose exec -e IS_SANDBOX=1 agent claude --print --dangerously-skip-permissions ...\` now succeeds
- [ ] Live: rebuild, click "Re-run analyst", verify the model actually runs and produces proposals (or fails loudly with status=error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)