### PR TITLE
fix(vision): parse JSON-array responses with leading/trailing prose

### DIFF
--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -236,15 +236,52 @@ def propose_gaps(workspace: str, vision: dict, repo: str, model: str) -> list[di
     if not raw:
         raise VisionAnalystError("model returned empty response")
     try:
-        proposals = json.loads(raw)
+        proposals = _parse_proposal_list(raw)
     except json.JSONDecodeError as e:
-        logger.error("vision_analyst response not JSON: %s", e)
+        # Log a truncated preview so operators can see what the model
+        # actually produced without dumping kilobytes of prose into the log.
+        logger.error(
+            "vision_analyst response not JSON: %s | preview=%r",
+            e, raw[:300],
+        )
         raise VisionAnalystError(f"response not JSON: {e}") from e
     if not isinstance(proposals, list):
         raise VisionAnalystError(
             f"model returned non-list JSON: {type(proposals).__name__}"
         )
     return proposals[:MAX_PROPOSALS]
+
+
+def _parse_proposal_list(raw: str) -> list:
+    """Parse a JSON array out of the model's output.
+
+    Handles the common ways Claude's free-form output deviates from a
+    strict JSON document:
+
+    - Strict ``[...]`` payload — happy path.
+    - Trailing prose after the array (``[...]\\n\\nNote: ...``) — the
+      :func:`json.JSONDecoder.raw_decode` API returns the array and we
+      ignore the trailing characters.
+    - Leading prose before the array (``Here are the proposals:\\n[...]``)
+      — locate the first ``[`` and start parsing there.
+
+    Raises :class:`json.JSONDecodeError` when neither shape produces a
+    valid array — caller wraps it in :class:`VisionAnalystError` and
+    surfaces an operator-visible run failure.
+    """
+    decoder = json.JSONDecoder()
+    # Try raw_decode at offset 0 first — handles strict + trailing-prose.
+    try:
+        value, _ = decoder.raw_decode(raw)
+        return value
+    except json.JSONDecodeError:
+        pass
+    # Fall back to leading-prose: skip to the first ``[`` and retry.
+    bracket = raw.find("[")
+    if bracket == -1:
+        raise json.JSONDecodeError("no '[' found in response", raw, 0)
+    value, _ = decoder.raw_decode(raw[bracket:])
+    return value
 
 
 def create_proposed_issues(repo: str, proposals: list[dict]) -> list[tuple[int, dict]]:

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -67,6 +67,42 @@ def test_propose_gaps_returns_empty_list_when_model_says_no_gaps():
     assert proposals == []
 
 
+def test_propose_gaps_tolerates_leading_prose():
+    """Claude sometimes prefixes the JSON with explanatory prose despite
+    the prompt's 'Output ONLY a JSON array' instruction. The parser must
+    locate the first '[' and extract the array."""
+    fake = (
+        "Here are 1 proposal:\n\n"
+        + json.dumps([{"title": "Add CI smoke", "body": "x", "labels": [], "priority": "low"}])
+    )
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", return_value=fake):
+            proposals = propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+    assert len(proposals) == 1
+    assert proposals[0]["title"] == "Add CI smoke"
+
+
+def test_propose_gaps_tolerates_trailing_prose():
+    """Trailing prose after a valid JSON array — raw_decode reads the
+    array and ignores everything after the closing bracket."""
+    fake = (
+        json.dumps([{"title": "T", "body": "B", "labels": [], "priority": "low"}])
+        + "\n\nNote: I prioritized the user-impacting items first."
+    )
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", return_value=fake):
+            proposals = propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+    assert len(proposals) == 1
+
+
+def test_propose_gaps_raises_when_no_array_present():
+    """Pure prose with no JSON array at all must surface as an error."""
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", return_value="Sorry, I cannot help with this request."):
+            with pytest.raises(VisionAnalystError, match="not JSON"):
+                propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+
+
 def test_format_proposal_body_includes_disclaimer():
     body = format_proposal_body("The feature explanation.")
     assert "Proposed by Claude Station" in body


### PR DESCRIPTION
## Summary
Follow-up to PR #280. After fixing the Claude CLI runtime, the model now actually runs — but vision-analyst was still failing because Claude occasionally adds prose around the JSON despite the prompt's "Output ONLY a JSON array" instruction.

Observed live (run \`run-vb-...\` 08:21:08 → 08:22:07): \`response not JSON: Expecting ',' delimiter: line 4 column 664 (char 751)\` — model produced a valid JSON array followed by trailing prose, strict \`json.loads\` rejected it.

## Fix
Replace \`json.loads\` with \`_parse_proposal_list\` that uses \`json.JSONDecoder.raw_decode\` to:
- Read a JSON array at offset 0 and ignore trailing prose (most common case).
- Fall back to locating the first \`[\` and retrying — handles leading prose ("Here are the proposals: [...]").
- Re-raise \`JSONDecodeError\` when no array can be found, preserving the existing \`VisionAnalystError\` contract.

The error logger now also includes a 300-char preview of the raw response so operators can see what the model produced without dumping kilobytes into logs.

## Test plan
- [x] \`pytest dashboard/backend/tests/test_vision_analyst.py\` — 22 passed (3 new cases: leading-prose, trailing-prose, pure-prose)
- [ ] Live: rebuild agent, click "Re-run analyst", verify proposals are now created (or fail with a clear error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)