### PR TITLE
fix(vision): seed labels on target repo before issue creation

### DIFF
--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -284,9 +284,62 @@ def _parse_proposal_list(raw: str) -> list:
     return value
 
 
+# Label names + colors the analyst needs on every target repo. The colors
+# are hex without the leading ``#`` per gh's ``label create --color`` API.
+# We create-or-skip these once at the start of each run; ``gh`` exits
+# non-zero when a label already exists which we treat as success.
+_REQUIRED_LABELS: tuple[tuple[str, str, str], ...] = (
+    ("vision-suggested", "0E8A16", "Issue proposed by Claude Station from the project vision"),
+    ("low",       "C2E0C6", "Priority: low"),
+    ("medium",    "FBCA04", "Priority: medium"),
+    ("high",      "D93F0B", "Priority: high"),
+    ("critical",  "B60205", "Priority: critical"),
+)
+
+
+def _ensure_labels(repo: str) -> None:
+    """Best-effort: create the labels the analyst attaches before any
+    ``gh issue create``.
+
+    Without this, the very first vision-bootstrap run on a fresh repo
+    fails every issue create with ``could not add label: 'vision-suggested'
+    not found`` and produces zero issues. Subsequent runs would work
+    only if an operator manually created the labels — undiscoverable.
+
+    All errors (already-exists, network blip, missing scope) are logged
+    at info/warning level and ignored.
+    """
+    for name, color, description in _REQUIRED_LABELS:
+        try:
+            result = subprocess.run(
+                ["gh", "label", "create", name,
+                 "--repo", repo,
+                 "--color", color,
+                 "--description", description],
+                capture_output=True, text=True, timeout=15,
+            )
+            if result.returncode == 0:
+                logger.info("Created label %s on %s", name, repo)
+            else:
+                # gh label create exits 1 when the label already exists.
+                # That's the common case — silence it unless something
+                # else is wrong.
+                stderr = result.stderr.strip()
+                if "already exists" in stderr:
+                    logger.debug("Label %s already exists on %s", name, repo)
+                else:
+                    logger.warning(
+                        "Could not create label %s on %s: %s",
+                        name, repo, stderr,
+                    )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            logger.warning("gh label create %s on %s failed: %s", name, repo, exc)
+
+
 def create_proposed_issues(repo: str, proposals: list[dict]) -> list[tuple[int, dict]]:
     """Create issues via `gh`. Returns list of (issue_number, proposal) tuples
     for the proposals that actually succeeded."""
+    _ensure_labels(repo)
     created: list[tuple[int, dict]] = []
     for p in proposals:
         labels = ["vision-suggested"]

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -95,6 +95,80 @@ def test_propose_gaps_tolerates_trailing_prose():
     assert len(proposals) == 1
 
 
+def test_ensure_labels_invokes_gh_for_each_required_label():
+    """_ensure_labels must call ``gh label create`` for the full required
+    set (vision-suggested + 4 priority labels). Without this, the very
+    first analyst run on a fresh repo fails every issue create."""
+    from agent import vision_analyst as va
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *_a, **_kw):
+        calls.append(list(cmd))
+        return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    with patch("agent.vision_analyst.subprocess.run", side_effect=fake_run):
+        va._ensure_labels("owner/repo")
+
+    # 5 labels expected: vision-suggested + low/medium/high/critical
+    assert len(calls) == 5
+    label_names = [cmd[3] for cmd in calls]  # ["gh", "label", "create", <name>, ...]
+    assert label_names == ["vision-suggested", "low", "medium", "high", "critical"]
+    for cmd in calls:
+        assert "--repo" in cmd
+        assert cmd[cmd.index("--repo") + 1] == "owner/repo"
+        assert "--color" in cmd
+
+
+def test_ensure_labels_swallows_already_exists():
+    """gh exits 1 when a label already exists — _ensure_labels must
+    treat that as success and not log warnings."""
+    from agent import vision_analyst as va
+
+    def fake_run(_cmd, *_a, **_kw):
+        return type("R", (), {
+            "returncode": 1, "stdout": "",
+            "stderr": "label 'vision-suggested' already exists in 'owner/repo'",
+        })()
+
+    with patch("agent.vision_analyst.subprocess.run", side_effect=fake_run):
+        # Must NOT raise — already-exists is the common case.
+        va._ensure_labels("owner/repo")
+
+
+def test_create_proposed_issues_calls_ensure_labels_first():
+    """create_proposed_issues must call _ensure_labels before attempting
+    issue creation, so a fresh repo gets its labels seeded.
+    """
+    from agent import vision_analyst as va
+
+    call_log: list[str] = []
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[1] == "label":
+            call_log.append(f"label:{cmd[3]}")
+        elif cmd[1] == "issue":
+            call_log.append("issue:create")
+        return type("R", (), {
+            "returncode": 0,
+            "stdout": "https://github.com/owner/repo/issues/42",
+            "stderr": "",
+        })()
+
+    with patch("agent.vision_analyst.subprocess.run", side_effect=fake_run):
+        va.create_proposed_issues(
+            "owner/repo",
+            [{"title": "T", "body": "B", "labels": [], "priority": "low"}],
+        )
+
+    # All 5 label-creates must precede the first issue:create.
+    label_calls = [c for c in call_log if c.startswith("label:")]
+    issue_calls = [c for c in call_log if c.startswith("issue:")]
+    assert len(label_calls) == 5
+    assert len(issue_calls) == 1
+    assert call_log.index("issue:create") > call_log.index("label:critical")
+
+
 def test_propose_gaps_raises_when_no_array_present():
     """Pure prose with no JSON array at all must surface as an error."""
     with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
@@ -426,15 +500,19 @@ def test_create_proposed_issues_pairs_failures_correctly(monkeypatch):
         {"title": "Proposal C (will succeed)", "body": "z", "priority": "low"},
     ]
 
-    call_count = [0]
+    issue_call_count = [0]
 
     def fake_run(cmd, *a, **kw):
-        call_count[0] += 1
-        # First call (Proposal A) fails
-        if call_count[0] == 1:
+        # Skip label-create calls — _ensure_labels runs them upfront and
+        # they're not what this test exercises. Treat them as success.
+        if len(cmd) > 1 and cmd[1] == "label":
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        issue_call_count[0] += 1
+        # First *issue create* (Proposal A) fails
+        if issue_call_count[0] == 1:
             return type("R", (), {"returncode": 1, "stdout": "", "stderr": "gh boom"})()
         # Subsequent calls succeed; URL ends with the issue number
-        n = 100 + call_count[0]
+        n = 100 + issue_call_count[0]
         return type("R", (), {
             "returncode": 0,
             "stdout": f"https://github.com/x/y/issues/{n}\n",


### PR DESCRIPTION
## Summary
Follow-up to #281. After the model now runs and the parser tolerates prose, the analyst started actually trying to create issues — and immediately failed with:

\`\`\`
gh issue create failed: could not add label: 'vision-suggested' not found
\`\`\`

The analyst hard-codes \`vision-suggested\` plus a priority label on every proposal. \`gh issue create --label\` exits non-zero when a label doesn't exist on the repo, so first-run on a fresh repo produces zero issues — operator has to manually create the labels first, undocumented.

## Fix
Add \`_ensure_labels(repo)\`: best-effort \`gh label create\` for the 5 labels the analyst depends on (\`vision-suggested\` + \`low\`/\`medium\`/\`high\`/\`critical\`). Already-exists is silenced as the common case; other failures log a warning and proceed. \`create_proposed_issues\` calls it once at batch start.

## Test plan
- [x] \`pytest dashboard/backend/tests/\` (983 passed, 1 skipped — 3 new tests + 1 updated for the discriminating fake_run)
- [ ] Live: rebuild agent, trigger Re-run analyst on a repo without the labels, verify issues are now created

🤖 Generated with [Claude Code](https://claude.com/claude-code)