### PR TITLE
fix(vision): drop model-suggested labels not seeded on repo

### DIFF
--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -341,12 +341,27 @@ def create_proposed_issues(repo: str, proposals: list[dict]) -> list[tuple[int, 
     for the proposals that actually succeeded."""
     _ensure_labels(repo)
     created: list[tuple[int, dict]] = []
+    # Only attach labels we actually create on the repo. The model's
+    # ``labels`` field often contains free-form suggestions like
+    # ``feature``, ``backend``, ``priority:high`` that don't exist on
+    # the target repo — ``gh issue create --label`` fails the whole
+    # call when ANY label is missing, so a single unknown label kills
+    # the issue. Drop unknowns rather than try to create them: the
+    # operator owns the project's label taxonomy, and silently adding
+    # whatever the model dreamed up would pollute it.
+    known = {name for name, _color, _desc in _REQUIRED_LABELS}
     for p in proposals:
         labels = ["vision-suggested"]
         priority = (p.get("priority") or "low").lower()
         if priority in ("low", "medium", "high", "critical"):
             labels.append(priority)
-        labels.extend([l for l in (p.get("labels") or []) if l != "vision-suggested"])
+        # Keep only labels that we explicitly seeded on the repo. The
+        # model's ``labels`` field is useful as soft hints (carried
+        # through in the proposal body if needed) but shouldn't gate
+        # issue creation.
+        for extra in (p.get("labels") or []):
+            if extra in known and extra not in labels:
+                labels.append(extra)
 
         body = format_proposal_body(p.get("body") or "")
         cmd = ["gh", "issue", "create", "--repo", repo,

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -136,6 +136,41 @@ def test_ensure_labels_swallows_already_exists():
         va._ensure_labels("owner/repo")
 
 
+def test_create_proposed_issues_drops_unknown_labels():
+    """Model's free-form labels (e.g. ``feature``, ``backend``) must NOT
+    be passed to ``gh issue create`` — gh fails the entire call when ANY
+    label is missing on the repo. Only seeded labels survive."""
+    from agent import vision_analyst as va
+
+    captured_labels: list[str] = []
+
+    def fake_run(cmd, *_a, **_kw):
+        if cmd[1] == "issue":
+            i = cmd.index("--label")
+            captured_labels.append(cmd[i + 1])
+        return type("R", (), {
+            "returncode": 0,
+            "stdout": "https://github.com/owner/repo/issues/1",
+            "stderr": "",
+        })()
+
+    with patch("agent.vision_analyst.subprocess.run", side_effect=fake_run):
+        va.create_proposed_issues(
+            "owner/repo",
+            [{"title": "T", "body": "B",
+              "labels": ["feature", "backend", "priority:high"],
+              "priority": "high"}],
+        )
+
+    assert len(captured_labels) == 1
+    label_set = set(captured_labels[0].split(","))
+    # Only the seeded labels survive.
+    assert label_set == {"vision-suggested", "high"}
+    # The model's free-form labels are dropped.
+    assert "feature" not in label_set
+    assert "backend" not in label_set
+
+
 def test_create_proposed_issues_calls_ensure_labels_first():
     """create_proposed_issues must call _ensure_labels before attempting
     issue creation, so a fresh repo gets its labels seeded.


### PR DESCRIPTION
## Summary
Follow-up to #282. After the labels were seeded, issue creation still failed because the model's response includes free-form labels (\`feature\`, \`backend\`, \`infrastructure\`, \`design\`) that don't exist on the repo. \`gh issue create --label\` fails the entire call when ANY label is missing, so one unknown label kills the issue.

## Fix
Filter the model's \`labels\` field through the analyst's seeded set (\`vision-suggested\` + \`low\`/\`medium\`/\`high\`/\`critical\`) before attaching. Free-form suggestions are dropped silently — auto-creating whatever the model dreams up would slowly pollute the operator's label taxonomy, and operators own that.

## Test plan
- [x] \`pytest dashboard/backend/tests/\` (984 passed, 1 skipped — 1 new test)
- [ ] Live: trigger Re-run analyst, verify issues are now actually created in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)