### PR TITLE
fix(ui): re-run analyst button + naive-utc timestamp parsing

### DIFF
--- a/dashboard/frontend/src/components/vision/VisionTab.svelte
+++ b/dashboard/frontend/src/components/vision/VisionTab.svelte
@@ -53,11 +53,6 @@
     }
   }
 
-  function rerunAnalyst() {
-    fetch(`/api/projects/${project.id}/vision/find-gaps`, { method: 'POST' })
-      .then(r => { if (!r.ok) console.warn('vision-analyst rerun failed', r.status); });
-  }
-
   const githubBaseUrl = $derived(
     `https://github.com/${project.repo}/blob/${project.branch || 'main'}/docs/vision.md`,
   );
@@ -79,7 +74,15 @@
     {/if}
   </span>
   <span class="flex-1"></span>
-  <button type="button" class="btn btn-ghost btn-sm text-xs" onclick={rerunAnalyst}>Re-run analyst</button>
+  <button
+    type="button"
+    class="btn btn-ghost btn-sm text-xs"
+    onclick={findGaps}
+    disabled={findingGaps}
+    data-testid="vision-rerun-analyst-btn"
+  >
+    {findingGaps ? 'Starting…' : 'Re-run analyst'}
+  </button>
   <a class="btn btn-ghost btn-sm text-xs"
      href={githubProposalsUrl}
      target="_blank" rel="noopener">View on GitHub →</a>

--- a/dashboard/frontend/src/lib/format.test.ts
+++ b/dashboard/frontend/src/lib/format.test.ts
@@ -123,6 +123,25 @@ describe('timeAgo', () => {
     const future = new Date(now.getTime() + 60_000).toISOString();
     expect(timeAgo(future)).toBe('just now');
   });
+
+  it('treats naive ISO strings (no Z, no offset) as UTC', () => {
+    // Backend stores datetime.utcnow() which serializes without a timezone
+    // marker. Without explicit UTC handling, JS parses "2026-05-08T11:59:30"
+    // as local time, so an operator in CEST sees the run as 2 hours older
+    // than it actually is. Issue debug: original report was "runs 2h back".
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-08T12:00:00Z'));
+    // 30 seconds ago in UTC, no timezone marker.
+    expect(timeAgo('2026-05-08T11:59:30')).toBe('30s ago');
+    expect(timeAgo('2026-05-08T11:59:30.000')).toBe('30s ago');
+  });
+
+  it('respects explicit timezone markers when present', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-08T12:00:00Z'));
+    expect(timeAgo('2026-05-08T11:59:30Z')).toBe('30s ago');
+    expect(timeAgo('2026-05-08T13:59:30+02:00')).toBe('30s ago');
+  });
 });
 
 import { formatRunMode, formatSkipReason } from './format';

--- a/dashboard/frontend/src/lib/format.ts
+++ b/dashboard/frontend/src/lib/format.ts
@@ -2,10 +2,29 @@
 // Formatting Utilities
 // ============================================
 
+/**
+ * Parse a backend timestamp into a Date in UTC.
+ *
+ * The backend stores naive ISO strings (e.g. ``2026-05-09T08:35:48.315``)
+ * because SQLAlchemy's default ``DateTime`` column is timezone-naive and
+ * the code uses ``datetime.utcnow()``. Per ECMAScript, ISO date-time
+ * strings without a timezone marker are parsed as **local time** —
+ * which means a UTC value gets shifted by the operator's offset,
+ * making "2 minutes ago" render as "2 hours ago" in CEST.
+ *
+ * This helper appends ``Z`` when no timezone marker is present so the
+ * Date constructor reads the string as UTC. Strings already carrying a
+ * marker (``...Z`` or ``...+HH:MM``) pass through unchanged.
+ */
+function parseServerDate(dateStr: string): Date {
+  const hasTz = dateStr.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(dateStr);
+  return new Date(hasTz ? dateStr : dateStr + 'Z');
+}
+
 /** Relative time string from a date string or null */
 export function timeAgo(dateStr: string | null): string {
   if (!dateStr) return 'never';
-  const date = new Date(dateStr);
+  const date = parseServerDate(dateStr);
   const now = Date.now();
   const diff = now - date.getTime();
 
@@ -71,7 +90,7 @@ export function formatPercent(n: number | null): string {
 /** Format a date string to locale string */
 export function formatDate(dateStr: string | null): string {
   if (!dateStr) return '-';
-  return new Date(dateStr).toLocaleString();
+  return parseServerDate(dateStr).toLocaleString();
 }
 
 /** @deprecated Use formatTokens instead. Kept for historical data display. */


### PR DESCRIPTION
## Summary
Two unrelated UI bugs surfaced together:

### 1. "Re-run analyst" button silently 401s
\`VisionTab.svelte\`'s \`rerunAnalyst()\` used raw \`fetch()\` instead of the auth-aware \`api.ts\` wrapper. With dashboard auth on (post #278) the bearer token never gets attached → 401 → \`console.warn\` → operator sees no UI feedback. The component already had a properly-routed \`findGaps()\`. Just point the button at it; add a disabled state with "Starting…" label.

### 2. Run timestamps showing "2h ago" for CEST operators
Backend stores \`datetime.utcnow()\` which serializes as naive ISO (\`2026-05-09T08:35:48.315\` — no \`Z\`). Per ECMAScript, ISO date-time strings without a timezone marker are parsed as **local time**. So a UTC value shifts by the operator's offset (UTC+2 in CEST), making "30 seconds ago" render as "2h ago".

Add \`parseServerDate\` helper that appends \`Z\` when no timezone marker is present. Strings already carrying \`Z\` or \`+HH:MM\` pass through unchanged. Used by \`timeAgo\` and \`formatDate\`.

The proper long-term fix is making the backend write timezone-aware UTC datetimes (\`datetime.now(timezone.utc)\`) so the \`Z\` ends up on the wire — but that's a wider refactor. This frontend-only fix is correct either way (the helper becomes a no-op once the backend serializes with explicit UTC).

## Test plan
- [x] \`vitest run format.test.ts\` (29 passed — 2 new cases for naive-ISO-as-UTC and explicit-tz-passthrough)
- [ ] Live: rebuild dashboard, click Re-run analyst, verify modal of "Gap analysis started" toast appears AND new run timestamps show "Xs ago" / "Xm ago", not "2h ago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)