### PR TITLE
fix(reaper): include vision-analyst in service_active determination

### DIFF
--- a/dashboard/backend/app/services/service_control.py
+++ b/dashboard/backend/app/services/service_control.py
@@ -116,25 +116,63 @@ async def get_agent_status() -> dict:
 
     In compose mode the agent has no timer (the launcher is always up), so
     ``timer_active`` is always False.
+
+    ``service_active`` is True when **any** child process the agent
+    container is responsible for is in flight — currently either
+    ``run-manager.sh`` (full orchestrator runs) or ``vision_analyst``
+    (Hook 3 vision-bootstrap). Without the second source, the stale-run
+    reaper saw ``service_active=False`` while a vision-analyst was
+    running, marked the in-flight Run row ``interrupted``, then the
+    analyst's terminal webhook flipped it back to ``completed`` minutes
+    later — producing the confusing ``interrupted → completed`` flicker
+    operators noticed.
     """
     if _mode() == "compose":
-        result = await _launcher_call("GET", "/status")
-        running = bool(result.get("running"))
+        run_status = await _launcher_call("GET", "/status")
+        analyst_status = await _launcher_call("GET", "/vision-analyst/status")
+        run_running = bool(run_status.get("running"))
+        analyst_running = bool(analyst_status.get("running"))
+        # ``pid`` semantically reports a single in-flight process; prefer
+        # the orchestrator's pid when both are running because the
+        # orchestrator is the more visible workload.
+        pid = run_status.get("pid") or analyst_status.get("pid")
+        # Surface the first non-success error so the dashboard can
+        # surface auth/network problems regardless of which endpoint
+        # failed.
+        error = None
+        if not run_status.get("success"):
+            error = run_status.get("error")
+        elif not analyst_status.get("success"):
+            error = analyst_status.get("error")
         return {
-            "service_active": running,
+            "service_active": run_running or analyst_running,
             "timer_active": False,
             "timer_next": None,
             "service_stdout": "",
             "timer_stdout": "",
-            "pid": result.get("pid"),
-            "error": None if result.get("success") else result.get("error"),
+            "pid": pid,
+            "error": error,
+            # Per-source breakdown — useful for the dashboard's UI when
+            # we want to differentiate "an orchestrator run is going" vs
+            # "a vision-bootstrap is going". Reaper only checks the
+            # combined ``service_active``.
+            "run_active": run_running,
+            "vision_analyst_active": analyst_running,
         }
     # systemd mode — normalise to the compose shape so callers don't have to
     # branch on deploy mode. The systemd path doesn't have a single pid (the
     # service can have a tree of children), and there's no async error to
-    # surface, so both default to None.
+    # surface, so both default to None. ``run_active`` mirrors
+    # ``service_active`` because systemd doesn't expose vision-analyst as
+    # a distinct unit; ``vision_analyst_active`` defaults False.
     result = await systemd_get_status()
-    return {**result, "pid": None, "error": None}
+    return {
+        **result,
+        "pid": None,
+        "error": None,
+        "run_active": bool(result.get("service_active")),
+        "vision_analyst_active": False,
+    }
 
 
 async def run_action(action: str, unit: str | None = None) -> dict:

--- a/dashboard/backend/tests/test_service_control.py
+++ b/dashboard/backend/tests/test_service_control.py
@@ -167,9 +167,33 @@ async def test_status_compose_translates_launcher_status(monkeypatch):
     from app.services import service_control
     with respx.mock() as mock:
         mock.get("http://agent:8421/status").respond(200, json={"running": True, "pid": 99, "exit_code": None})
+        mock.get("http://agent:8421/vision-analyst/status").respond(200, json={"running": False, "pid": None, "exit_code": None})
         result = await service_control.get_agent_status()
     assert result["service_active"] is True
     assert result["pid"] == 99
+    assert result["run_active"] is True
+    assert result["vision_analyst_active"] is False
+
+
+@pytest.mark.asyncio
+async def test_status_compose_active_when_only_vision_analyst_running(monkeypatch):
+    """Issue: vision-analyst runs are spawned as a sibling process and were
+    invisible to /status. The reaper saw service_active=False during a
+    vision-bootstrap and prematurely marked the run row 'interrupted'.
+    Now /vision-analyst/status is OR'd into service_active.
+    """
+    monkeypatch.setenv("STATION_DEPLOY_MODE", "compose")
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://agent:8421")
+    monkeypatch.delenv("STATION_LAUNCHER_TOKEN", raising=False)
+    from app.services import service_control
+    with respx.mock() as mock:
+        mock.get("http://agent:8421/status").respond(200, json={"running": False, "pid": None, "exit_code": None})
+        mock.get("http://agent:8421/vision-analyst/status").respond(200, json={"running": True, "pid": 42, "exit_code": None})
+        result = await service_control.get_agent_status()
+    assert result["service_active"] is True
+    assert result["pid"] == 42  # falls back to analyst's pid when no run-manager
+    assert result["run_active"] is False
+    assert result["vision_analyst_active"] is True
 
 
 @pytest.mark.asyncio
@@ -181,6 +205,7 @@ async def test_status_compose_when_unreachable_returns_inactive(monkeypatch):
     from app.services import service_control
     with respx.mock() as mock:
         mock.get("http://agent:8421/status").mock(side_effect=httpx.ConnectError("refused"))
+        mock.get("http://agent:8421/vision-analyst/status").mock(side_effect=httpx.ConnectError("refused"))
         result = await service_control.get_agent_status()
     assert result["service_active"] is False
     assert result.get("error")
@@ -188,11 +213,12 @@ async def test_status_compose_when_unreachable_returns_inactive(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_status_returns_same_keys_in_both_modes(monkeypatch):
-    """Drop-in substitution: callers should be able to read any of the 7
+    """Drop-in substitution: callers should be able to read any of the
     keys without branching on deploy mode."""
     expected_keys = {
         "service_active", "timer_active", "timer_next",
         "service_stdout", "timer_stdout", "pid", "error",
+        "run_active", "vision_analyst_active",
     }
 
     # Systemd mode
@@ -217,6 +243,7 @@ async def test_status_returns_same_keys_in_both_modes(monkeypatch):
     monkeypatch.delenv("STATION_LAUNCHER_TOKEN", raising=False)
     with respx.mock() as mock:
         mock.get("http://agent:8421/status").respond(200, json={"running": True, "pid": 1, "exit_code": None})
+        mock.get("http://agent:8421/vision-analyst/status").respond(200, json={"running": False, "pid": None, "exit_code": None})
         compose_result = await service_control.get_agent_status()
     assert set(compose_result.keys()) == expected_keys
 
@@ -243,6 +270,7 @@ async def test_run_action_status_compose_unreachable_surfaces_as_failure(monkeyp
 
     with respx.mock() as mock:
         mock.get("http://agent:8421/status").mock(side_effect=httpx.ConnectError("refused"))
+        mock.get("http://agent:8421/vision-analyst/status").mock(side_effect=httpx.ConnectError("refused"))
         result = await service_control.run_action("status", "claude-agent.service")
 
     assert result["success"] is False
@@ -261,6 +289,7 @@ async def test_run_action_status_compose_reachable_inactive_is_success(monkeypat
 
     with respx.mock() as mock:
         mock.get("http://agent:8421/status").respond(200, json={"running": False, "pid": None, "exit_code": None})
+        mock.get("http://agent:8421/vision-analyst/status").respond(200, json={"running": False, "pid": None, "exit_code": None})
         result = await service_control.run_action("status", "claude-agent.service")
 
     assert result["success"] is True       # call succeeded


### PR DESCRIPTION
## Summary
Vision-bootstrap runs were flickering through \`interrupted → completed\` in the dashboard:

1. Operator clicks "Re-run analyst" — \`vision_analyst\` process spawned
2. Run row inserted as \`running\`/\`unknown\`
3. Reaper polls \`/api/agent/status\` every 15s → \`service_active=False\` (the launcher's \`/status\` only tracks \`run-manager.sh\` via \`_current\`; vision_analyst lives in \`_current_analyst\` and reports through a separate \`/vision-analyst/status\` endpoint)
4. Reaper sweeps the in-flight row → \`status=interrupted\`
5. ~1 minute later vision_analyst's terminal webhook lands → lifecycle handler updates row → \`status=completed\`

Operators saw the \`interrupted\` flicker and assumed the run had failed, sometimes triggering a duplicate while the original was still in flight.

## Fix
\`get_agent_status\` (compose path) now polls \`/vision-analyst/status\` in addition to \`/status\` and ORs the two \`running\` flags into \`service_active\`. Also exposes per-source fields \`run_active\` / \`vision_analyst_active\` for future UI use. Both fields are populated in systemd mode too (mirror of \`service_active\` / False) so the cross-mode key contract holds.

## Test plan
- [x] \`pytest dashboard/backend/tests/\` (985 passed, 1 skipped — 1 new test for the exact bug scenario, plus 4 updated existing tests)
- [ ] Live: trigger vision-bootstrap, watch the run record stay \`running\`/\`completed\` without flickering through \`interrupted\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)