### PR TITLE
fix(mcp): add explicit type=http to Ref MCP server entry

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -5,6 +5,7 @@
       "args": ["-y", "@playwright/mcp@latest"]
     },
     "ref": {
+      "type": "http",
       "url": "https://api.ref.tools/mcp"
     }
   }


### PR DESCRIPTION
## Summary
Discovered while investigating "Agent Teams run shows in UI but nothing happens." Every orchestrator run since #269 (Ref MCP support) has been dying at SDK initialisation:

\`\`\`
Error: Invalid MCP configuration:
mcpServers.ref: Does not adhere to MCP server configuration schema
\`\`\`

The bundled Claude Code CLI accepts \`{ "url": "..." }\` for remote MCP servers, but the Claude Agent SDK validates against a strict schema that requires an explicit \`type\` field for HTTP/SSE transports. The orchestrator failed at \`query.initialize()\`, cleaned up worktrees, posted \`status=completed\` webhook → dashboard showed green runs that did zero work.

## Fix
Add \`"type": "http"\` to the Ref entry in \`.mcp.json\`.

## Test plan
- [ ] Live: trigger an Agent Teams run, verify the SDK initialises without the MCP schema error and the run actually progresses past startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)