### PR TITLE
feat(plan-review): operator approve/reject buttons on the gate banner

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -597,3 +599,186 @@ async def message_run(
     run has already ended — previously messages were silently orphaned."""
     await _require_live_run(db, run_id)
     return await _queue_control(db, run_id, "message", {"text": payload.text})
+
+
+# ── Plan-review gate operator override (issue #266 follow-up) ─────────────
+
+
+_PLAN_REVIEW_AWAITING_STATES = ("awaiting_plan_review",)
+
+
+def _verdicts_path_for_run(run_id: str) -> Path:
+    """Return the manager-verdicts JSON path for a given ``run_id``.
+
+    The shell driver writes ``{LOG_DIR}/{run_id}-verdicts.json``
+    (run-manager.sh:1718). The same volume is mounted into the dashboard
+    container in compose mode, so we can read it directly.
+    """
+    log_dir = Path(os.environ.get("STATION_LOG_DIR", "/var/log/claude-agent"))
+    return log_dir / f"{run_id}-verdicts.json"
+
+
+def _build_followup_queue_item(
+    *,
+    project_repo: str,
+    issue_number: int | None,
+    plan_path: str | None,
+    parent_run_id: str,
+    employee_index: int | None = None,
+    operator_approved: bool = False,
+) -> dict:
+    """Build a QueueItem dict for a follow-up ``full`` run after a
+    plan_only run was approved.
+
+    Mirrors the shape ``agent.plan_review_gate.build_followup_queue_item``
+    produces, but doesn't import from agent/ — the plan-review gate
+    runs in the agent container; this runs in the dashboard backend
+    after operator action.
+    """
+    return {
+        "project_repo": project_repo,
+        "issue_number": issue_number,
+        "mode": "full",
+        "state": "pending",
+        "context": json.dumps({
+            "approved_plan_path": plan_path,
+            "from_plan_only_run": True,
+            "parent_run_id": parent_run_id,
+            "parent_employee_index": employee_index,
+            "approved_by_operator": operator_approved,
+        }),
+    }
+
+
+async def _require_plan_review_run(db: AsyncSession, run_id: str) -> Run:
+    """Resolve a plan_only run that's currently waiting on the gate.
+
+    Returns 404 when missing, 409 when the run isn't in the right
+    mode/state for an operator override.
+    """
+    result = await db.execute(select(Run).where(Run.run_id == run_id))
+    run = result.scalar_one_or_none()
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"run {run_id} not found")
+    if (run.mode or "").lower() != "plan_only":
+        raise HTTPException(
+            status_code=409,
+            detail=f"run {run_id} is mode={run.mode!r}, expected 'plan_only'",
+        )
+    if run.status not in _PLAN_REVIEW_AWAITING_STATES:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"run {run_id} is status={run.status!r}; operator override is only "
+                f"available while a plan_only run is awaiting_plan_review"
+            ),
+        )
+    return run
+
+
+@router.post("/{run_id}/plan/approve")
+async def operator_approve_plan(
+    run_id: str,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Operator override: approve the plan(s) from a plan_only run and
+    enqueue follow-up ``full`` run(s) to implement them.
+
+    Reads the manager-verdicts JSON to recover the per-employee
+    issue/plan mapping. For each entry the operator override treats
+    EVERY verdict as approved (regardless of what the manager said) —
+    the operator's word overrides the manager's. When the verdicts file
+    is missing or empty, the run is still marked ``plan_approved`` but
+    no follow-up runs are enqueued — the operator has signalled "stop
+    waiting" without binding the orchestrator to specific issues.
+
+    This is the override flow. The auto-approve path (manager's
+    ``APPROVE_PLAN`` verdict) lives in :mod:`agent.plan_review_gate`
+    and runs from inside the agent container after manager review.
+    """
+    run = await _require_plan_review_run(db, run_id)
+    project = await db.get(Project, run.project_id) if run.project_id else None
+    project_repo = project.repo if project else None
+
+    enqueued: list[dict] = []
+    verdicts_file = _verdicts_path_for_run(run_id)
+    if project_repo and verdicts_file.is_file():
+        try:
+            data = json.loads(verdicts_file.read_text())
+            entries = data.get("plan_verdicts") or []
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                payload = _build_followup_queue_item(
+                    project_repo=project_repo,
+                    issue_number=entry.get("issue_number"),
+                    plan_path=entry.get("plan_path"),
+                    parent_run_id=run_id,
+                    employee_index=entry.get("employee_index"),
+                    operator_approved=True,
+                )
+                qi = QueueItem(
+                    project_repo=payload["project_repo"],
+                    issue_number=payload["issue_number"],
+                    mode=payload["mode"],
+                    state=payload["state"],
+                    context=payload["context"],
+                )
+                db.add(qi)
+                await db.flush()
+                enqueued.append({
+                    "id": qi.id,
+                    "issue_number": qi.issue_number,
+                })
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.warning(
+                "Operator approve %s: could not parse verdicts file %s: %s",
+                run_id, verdicts_file, exc,
+            )
+
+    run.status = "plan_approved"
+    if not run.finished_at:
+        run.finished_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    await publish({
+        "type": "run_status",
+        "run_id": run_id,
+        "status": "plan_approved",
+        "operator_approved": True,
+    })
+
+    return {
+        "run_id": run_id,
+        "status": "plan_approved",
+        "enqueued": enqueued,
+        "verdicts_file_found": verdicts_file.is_file(),
+    }
+
+
+@router.post("/{run_id}/plan/reject")
+async def operator_reject_plan(
+    run_id: str,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Operator override: reject the plan(s) from a plan_only run.
+
+    Marks the run ``plan_rejected`` and emits a status webhook so the
+    UI banner updates. No follow-up runs are enqueued — operator owns
+    the next step (e.g. close the issue, edit the issue body, retrigger
+    in a different mode).
+    """
+    run = await _require_plan_review_run(db, run_id)
+    run.status = "plan_rejected"
+    if not run.finished_at:
+        run.finished_at = datetime.now(timezone.utc)
+    await db.commit()
+
+    await publish({
+        "type": "run_status",
+        "run_id": run_id,
+        "status": "plan_rejected",
+        "operator_rejected": True,
+    })
+
+    return {"run_id": run_id, "status": "plan_rejected"}

--- a/dashboard/backend/tests/test_plan_review_override.py
+++ b/dashboard/backend/tests/test_plan_review_override.py
@@ -1,0 +1,263 @@
+"""Operator override of the plan-review gate (issue #266 follow-up).
+
+The auto-gate (manager's APPROVE_PLAN verdict triggering an enqueue) lives
+in :mod:`agent.plan_review_gate`. The endpoints under test here run from
+the dashboard backend and let the operator force-approve or force-reject
+a plan_only run that's stuck at ``awaiting_plan_review``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import Base, async_session, engine
+from app.main import app
+from app.models import Project, QueueItem, Run, StationControl
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async with async_session() as session:
+        session.add(StationControl(id=1, global_pause=False))
+        await session.commit()
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest_asyncio.fixture
+async def awaiting_run(setup_db):
+    async with async_session() as session:
+        proj = Project(repo="x/y", priority="medium", mode="plan_only", branch="main")
+        session.add(proj)
+        await session.flush()
+        run = Run(
+            run_id="run-pr-001",
+            project_id=proj.id,
+            mode="plan_only",
+            status="awaiting_plan_review",
+            started_at=datetime.now(timezone.utc),
+        )
+        session.add(run)
+        await session.commit()
+        return run.run_id
+
+
+def _write_verdicts(tmp_path, run_id: str, plan_verdicts: list[dict]) -> str:
+    """Write a manager-verdicts JSON file at the path
+    ``run-manager.sh`` would have written and return the directory so
+    callers can monkeypatch ``STATION_LOG_DIR``."""
+    log_dir = tmp_path / "claude-agent"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / f"{run_id}-verdicts.json").write_text(json.dumps({
+        "run_id": run_id,
+        "verdicts": [],
+        "plan_verdicts": plan_verdicts,
+    }))
+    return str(log_dir)
+
+
+@pytest.mark.asyncio
+async def test_approve_unknown_run_returns_404(client):
+    resp = await client.post("/api/runs/does-not-exist/plan/approve")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_approve_rejects_full_mode_run(client, setup_db):
+    """Operator override is only valid for plan_only runs. A full-mode run
+    must be rejected with 409 — bypassing review for a run that wasn't
+    designed to gate would be confusing.
+    """
+    async with async_session() as session:
+        proj = Project(repo="x/y", priority="medium", mode="full", branch="main")
+        session.add(proj)
+        await session.flush()
+        run = Run(
+            run_id="run-full-001",
+            project_id=proj.id,
+            mode="full",
+            status="awaiting_plan_review",  # impossible state, but exercise the guard
+            started_at=datetime.now(timezone.utc),
+        )
+        session.add(run)
+        await session.commit()
+    resp = await client.post("/api/runs/run-full-001/plan/approve")
+    assert resp.status_code == 409
+    assert "plan_only" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_approve_rejects_run_in_terminal_state(client, awaiting_run):
+    """Once the gate has resolved (either auto-approved by manager or
+    rejected), operator override is no longer valid — the follow-up
+    queue item or rejection has already been recorded.
+    """
+    async with async_session() as session:
+        run = (
+            await session.execute(select(Run).where(Run.run_id == awaiting_run))
+        ).scalar_one()
+        run.status = "plan_approved"
+        await session.commit()
+    resp = await client.post(f"/api/runs/{awaiting_run}/plan/approve")
+    assert resp.status_code == 409
+    assert "awaiting_plan_review" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_approve_with_verdicts_file_enqueues_followup(
+    client, awaiting_run, tmp_path, monkeypatch
+):
+    """Happy path: operator approves a plan_only run that has a
+    manager-verdicts file. The endpoint reads the file, enqueues a
+    follow-up ``full`` QueueItem per plan entry (regardless of what the
+    manager said), and flips the run to ``plan_approved``.
+    """
+    log_dir = _write_verdicts(tmp_path, awaiting_run, [
+        {
+            "verdict": "REVISE_PLAN",  # manager said revise; operator overrides
+            "employee_index": 0,
+            "issue_number": 42,
+            "plan_path": "/ws/.claude-employee-plan-0.json",
+            "feedback": "needs more detail",
+        },
+        {
+            "verdict": "REJECT_PLAN",  # operator overrides REJECT too
+            "employee_index": 1,
+            "issue_number": 43,
+            "plan_path": "/ws/.claude-employee-plan-1.json",
+            "feedback": "no good",
+        },
+    ])
+    monkeypatch.setenv("STATION_LOG_DIR", log_dir)
+
+    resp = await client.post(f"/api/runs/{awaiting_run}/plan/approve")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "plan_approved"
+    assert body["verdicts_file_found"] is True
+    assert len(body["enqueued"]) == 2
+    assert {e["issue_number"] for e in body["enqueued"]} == {42, 43}
+
+    async with async_session() as session:
+        run = (
+            await session.execute(select(Run).where(Run.run_id == awaiting_run))
+        ).scalar_one()
+        assert run.status == "plan_approved"
+        assert run.finished_at is not None
+
+        items = (
+            await session.execute(
+                select(QueueItem).where(QueueItem.project_repo == "x/y")
+            )
+        ).scalars().all()
+        assert len(items) == 2
+        for qi in items:
+            assert qi.mode == "full"
+            assert qi.state == "pending"
+            ctx = json.loads(qi.context)
+            assert ctx["from_plan_only_run"] is True
+            assert ctx["approved_by_operator"] is True
+            assert ctx["parent_run_id"] == awaiting_run
+
+
+@pytest.mark.asyncio
+async def test_approve_without_verdicts_file_still_advances_run(
+    client, awaiting_run, tmp_path, monkeypatch
+):
+    """When the verdicts file is missing (manager didn't produce one),
+    the operator can still advance the run out of awaiting_plan_review
+    so the dashboard stops showing the gate banner. No follow-ups are
+    enqueued — the operator hasn't bound implementation to specific
+    issues, so we don't enqueue anything speculative.
+    """
+    monkeypatch.setenv("STATION_LOG_DIR", str(tmp_path / "empty-log-dir"))
+
+    resp = await client.post(f"/api/runs/{awaiting_run}/plan/approve")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "plan_approved"
+    assert body["verdicts_file_found"] is False
+    assert body["enqueued"] == []
+
+    async with async_session() as session:
+        items = (
+            await session.execute(select(QueueItem))
+        ).scalars().all()
+        assert items == []
+
+
+@pytest.mark.asyncio
+async def test_approve_with_malformed_verdicts_file_logs_and_advances(
+    client, awaiting_run, tmp_path, monkeypatch, caplog
+):
+    """Malformed JSON in the verdicts file must not block the operator
+    override — log a warning and proceed with the status flip."""
+    log_dir = tmp_path / "bad-log-dir"
+    log_dir.mkdir()
+    (log_dir / f"{awaiting_run}-verdicts.json").write_text("{not json")
+    monkeypatch.setenv("STATION_LOG_DIR", str(log_dir))
+
+    with caplog.at_level("WARNING"):
+        resp = await client.post(f"/api/runs/{awaiting_run}/plan/approve")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "plan_approved"
+    assert any("could not parse verdicts file" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_reject_unknown_run_returns_404(client):
+    resp = await client.post("/api/runs/does-not-exist/plan/reject")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reject_rejects_full_mode_run(client, setup_db):
+    async with async_session() as session:
+        proj = Project(repo="x/y", priority="medium", mode="full", branch="main")
+        session.add(proj)
+        await session.flush()
+        run = Run(
+            run_id="run-full-002",
+            project_id=proj.id,
+            mode="full",
+            status="awaiting_plan_review",
+            started_at=datetime.now(timezone.utc),
+        )
+        session.add(run)
+        await session.commit()
+    resp = await client.post("/api/runs/run-full-002/plan/reject")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_reject_flips_status_and_enqueues_nothing(client, awaiting_run):
+    resp = await client.post(f"/api/runs/{awaiting_run}/plan/reject")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "plan_rejected"
+
+    async with async_session() as session:
+        run = (
+            await session.execute(select(Run).where(Run.run_id == awaiting_run))
+        ).scalar_one()
+        assert run.status == "plan_rejected"
+        assert run.finished_at is not None
+        items = (
+            await session.execute(select(QueueItem))
+        ).scalars().all()
+        assert items == []

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -376,6 +376,27 @@ export const rejectPlan = (id: number) =>
 export const implementPlan = (id: number) =>
   requestWithToast<Plan>(`/api/plans/${id}/implement`, { method: 'POST' });
 
+// --- Plan-review gate operator override (issue #266 follow-up) ---
+
+export interface PlanReviewApproveResult {
+  run_id: string;
+  status: 'plan_approved';
+  enqueued: { id: number; issue_number: number | null }[];
+  verdicts_file_found: boolean;
+}
+
+export const operatorApproveRunPlan = (runId: string) =>
+  requestWithToast<PlanReviewApproveResult>(
+    `/api/runs/${encodeURIComponent(runId)}/plan/approve`,
+    { method: 'POST' },
+  );
+
+export const operatorRejectRunPlan = (runId: string) =>
+  requestWithToast<{ run_id: string; status: 'plan_rejected' }>(
+    `/api/runs/${encodeURIComponent(runId)}/plan/reject`,
+    { method: 'POST' },
+  );
+
 // --- Logs ---
 
 export const searchLogs = (q: string, runId?: string, limit?: number) =>

--- a/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
+++ b/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { agentPresence } from '../lib/agent-presence.svelte';
-  import { getCoordinatorTasks, getCoordinatorMessages, triggerRun, getActiveEmployees } from '../lib/api';
+  import { getCoordinatorTasks, getCoordinatorMessages, triggerRun, getActiveEmployees, operatorApproveRunPlan, operatorRejectRunPlan } from '../lib/api';
   import { addToast } from '../lib/toast.svelte';
   import { formatTokens, formatDuration, timeAgo } from '../lib/format';
   import type { CoordinatorTask, CoordinatorMessage, ActiveEmployee } from '../lib/types';
@@ -30,6 +30,41 @@
       ? (activeRun.status as string)
       : null
   );
+
+  // Plan-review gate operator override (issue #266 follow-up).
+  let planActionInFlight = $state<'approve' | 'reject' | null>(null);
+
+  async function approveCanvasRunPlan() {
+    if (!latestRunId || planActionInFlight) return;
+    planActionInFlight = 'approve';
+    try {
+      const result = await operatorApproveRunPlan(latestRunId);
+      const n = result.enqueued.length;
+      addToast(
+        'success',
+        n > 0
+          ? `Plan approved — ${n} follow-up run${n === 1 ? '' : 's'} enqueued`
+          : 'Plan approved (no follow-up enqueued — verdicts file missing)',
+      );
+    } catch {
+      // requestWithToast already surfaced the error toast.
+    } finally {
+      planActionInFlight = null;
+    }
+  }
+
+  async function rejectCanvasRunPlan() {
+    if (!latestRunId || planActionInFlight) return;
+    planActionInFlight = 'reject';
+    try {
+      await operatorRejectRunPlan(latestRunId);
+      addToast('success', 'Plan rejected');
+    } catch {
+      // toast already shown
+    } finally {
+      planActionInFlight = null;
+    }
+  }
 
   // Fetch coordinator data
   $effect(() => {
@@ -173,17 +208,41 @@
 {:else}
   {#if planReviewStatus}
     <div
-      style="position: fixed; top: 54px; left: 0; right: 0; padding: 8px 16px; font-size: 12px; z-index: 2; color: white; background: {planReviewStatus === 'plan_approved' ? '#16a34a' : planReviewStatus === 'plan_rejected' ? '#dc2626' : '#d97706'};"
+      style="position: fixed; top: 54px; left: 0; right: 0; padding: 8px 16px; font-size: 12px; z-index: 2; color: white; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; background: {planReviewStatus === 'plan_approved' ? '#16a34a' : planReviewStatus === 'plan_rejected' ? '#dc2626' : '#d97706'};"
       data-testid="plan-review-banner"
     >
+      <span style="flex: 1; min-width: 0;">
+        {#if planReviewStatus === 'awaiting_plan_review'}
+          <strong>Plan awaiting review.</strong> The teammate wrote a plan; approve to enqueue a follow-up <code style="font-family: monospace;">full</code> run, or reject to stop here.
+        {:else if planReviewStatus === 'plan_reviewing'}
+          <strong>Manager reviewing plan…</strong>
+        {:else if planReviewStatus === 'plan_approved'}
+          <strong>Plan approved.</strong> A follow-up full run has been enqueued.
+        {:else if planReviewStatus === 'plan_rejected'}
+          <strong>Plan rejected.</strong> No follow-up run will be queued.
+        {/if}
+      </span>
       {#if planReviewStatus === 'awaiting_plan_review'}
-        <strong>Plan awaiting review.</strong> The teammate has written a plan; the manager will approve, request revisions, or reject it before any code is written.
-      {:else if planReviewStatus === 'plan_reviewing'}
-        <strong>Manager reviewing plan…</strong>
-      {:else if planReviewStatus === 'plan_approved'}
-        <strong>Plan approved.</strong> A follow-up full run has been enqueued.
-      {:else if planReviewStatus === 'plan_rejected'}
-        <strong>Plan rejected.</strong> No follow-up run will be queued.
+        <span style="display: flex; gap: 8px;">
+          <button
+            type="button"
+            onclick={approveCanvasRunPlan}
+            disabled={planActionInFlight !== null}
+            style="padding: 2px 8px; border-radius: 4px; background: rgba(255,255,255,0.2); color: white; font-size: 11px; font-weight: 600; border: none; cursor: pointer; opacity: {planActionInFlight ? 0.5 : 1};"
+            data-testid="plan-review-approve-btn"
+          >
+            {planActionInFlight === 'approve' ? 'Approving…' : 'Approve'}
+          </button>
+          <button
+            type="button"
+            onclick={rejectCanvasRunPlan}
+            disabled={planActionInFlight !== null}
+            style="padding: 2px 8px; border-radius: 4px; background: rgba(255,255,255,0.2); color: white; font-size: 11px; font-weight: 600; border: none; cursor: pointer; opacity: {planActionInFlight ? 0.5 : 1};"
+            data-testid="plan-review-reject-btn"
+          >
+            {planActionInFlight === 'reject' ? 'Rejecting…' : 'Reject'}
+          </button>
+        </span>
       {/if}
     </div>
   {/if}

--- a/dashboard/frontend/src/pages/MissionControl.svelte
+++ b/dashboard/frontend/src/pages/MissionControl.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { agentPresence } from '../lib/agent-presence.svelte';
-  import { messageRun, triggerRun } from '../lib/api';
+  import { messageRun, triggerRun, operatorApproveRunPlan, operatorRejectRunPlan } from '../lib/api';
   import { addToast } from '../lib/toast.svelte';
   import { formatTokens, timeAgo } from '../lib/format';
   import AgentActivityFeed from '../components/agents/AgentActivityFeed.svelte';
@@ -33,6 +33,43 @@
       ? (currentRun.status as string)
       : null
   );
+
+  // Plan-review gate operator override (issue #266 follow-up).
+  // ``planActionInFlight`` doubles as a busy flag and a label hint for
+  // the button rendering 'Approving…' / 'Rejecting…'.
+  let planActionInFlight = $state<'approve' | 'reject' | null>(null);
+
+  async function approveCurrentRunPlan() {
+    if (!currentRunId || planActionInFlight) return;
+    planActionInFlight = 'approve';
+    try {
+      const result = await operatorApproveRunPlan(currentRunId);
+      const n = result.enqueued.length;
+      addToast(
+        'success',
+        n > 0
+          ? `Plan approved — ${n} follow-up run${n === 1 ? '' : 's'} enqueued`
+          : 'Plan approved (no follow-up enqueued — verdicts file missing)',
+      );
+    } catch {
+      // requestWithToast already surfaced the error toast.
+    } finally {
+      planActionInFlight = null;
+    }
+  }
+
+  async function rejectCurrentRunPlan() {
+    if (!currentRunId || planActionInFlight) return;
+    planActionInFlight = 'reject';
+    try {
+      await operatorRejectRunPlan(currentRunId);
+      addToast('success', 'Plan rejected');
+    } catch {
+      // toast already shown
+    } finally {
+      planActionInFlight = null;
+    }
+  }
 
   // Operator message input — goes straight to the agent's next turn.
   let messageText = $state('');
@@ -152,21 +189,45 @@
   <!-- Plan-review gate banner (issue #266) -->
   {#if planReviewStatus}
     <div
-      class="px-4 py-2 text-xs border-b border-border"
+      class="px-4 py-2 text-xs border-b border-border flex items-center gap-3 flex-wrap"
       class:bg-amber-500={planReviewStatus === 'awaiting_plan_review' || planReviewStatus === 'plan_reviewing'}
       class:bg-green-600={planReviewStatus === 'plan_approved'}
       class:bg-red-600={planReviewStatus === 'plan_rejected'}
       class:text-white={true}
       data-testid="plan-review-banner"
     >
+      <span class="flex-1 min-w-0">
+        {#if planReviewStatus === 'awaiting_plan_review'}
+          <strong>Plan awaiting review.</strong> The teammate wrote an implementation plan; approve to enqueue a follow-up <code class="font-mono">full</code> run, or reject to stop here.
+        {:else if planReviewStatus === 'plan_reviewing'}
+          <strong>Manager reviewing plan…</strong>
+        {:else if planReviewStatus === 'plan_approved'}
+          <strong>Plan approved.</strong> A follow-up full run has been enqueued.
+        {:else if planReviewStatus === 'plan_rejected'}
+          <strong>Plan rejected.</strong> No follow-up run will be queued.
+        {/if}
+      </span>
       {#if planReviewStatus === 'awaiting_plan_review'}
-        <strong>Plan awaiting review.</strong> The teammate has written an implementation plan; the manager will approve, request revisions, or reject it before any code is written.
-      {:else if planReviewStatus === 'plan_reviewing'}
-        <strong>Manager reviewing plan…</strong>
-      {:else if planReviewStatus === 'plan_approved'}
-        <strong>Plan approved.</strong> A follow-up full run has been enqueued to implement the approved plan.
-      {:else if planReviewStatus === 'plan_rejected'}
-        <strong>Plan rejected.</strong> No follow-up run will be queued. See the manager verdict for reasoning.
+        <span class="flex gap-2">
+          <button
+            type="button"
+            onclick={approveCurrentRunPlan}
+            disabled={planActionInFlight}
+            class="px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-white text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            data-testid="plan-review-approve-btn"
+          >
+            {planActionInFlight === 'approve' ? 'Approving…' : 'Approve'}
+          </button>
+          <button
+            type="button"
+            onclick={rejectCurrentRunPlan}
+            disabled={planActionInFlight}
+            class="px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-white text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            data-testid="plan-review-reject-btn"
+          >
+            {planActionInFlight === 'reject' ? 'Rejecting…' : 'Reject'}
+          </button>
+        </span>
       {/if}
     </div>
   {/if}


### PR DESCRIPTION
## Summary
PR #266 wired the plan-review gate end-to-end via the manager's auto-verdict, but operators had no way to override it. Once a plan_only run landed in \`awaiting_plan_review\` (manager said REVISE, budget exhausted, missing verdict, queue POST failed, etc), the only recovery was direct DB edit.

This PR adds two operator-override endpoints + buttons on the gate banner.

## Backend
- \`POST /api/runs/{run_id}/plan/approve\` — reads \`{LOG_DIR}/{run_id}-verdicts.json\`, enqueues a follow-up \`full\` QueueItem per \`plan_verdicts\` entry (operator's word overrides whatever the manager said), flips Run to \`plan_approved\`, sets \`finished_at\`. Missing/malformed file → status flip only, no QueueItems.
- \`POST /api/runs/{run_id}/plan/reject\` — status flip only, no enqueue.
- Both 404 / 409 (mode != plan_only) / 409 (not in awaiting_plan_review).

## Frontend
- \`operatorApproveRunPlan\` / \`operatorRejectRunPlan\` API wrappers in \`api.ts\`.
- \`MissionControl\` and \`AgentTeamsCanvas\` plan-review banners now render Approve / Reject buttons when status is \`awaiting_plan_review\`. Busy state shows "Approving…" / "Rejecting…". Success toast reports how many follow-ups were enqueued.

The auto-gate flow (manager APPROVE_PLAN → automatic enqueue) in \`agent.plan_review_gate\` is unchanged — these endpoints are the operator override on top of it.

## Test plan
- [x] \`pytest dashboard/backend/tests/\` — 994 passed, 1 skipped (9 new cases)
- [x] \`tsc --noEmit\` clean
- [ ] Live: trigger a plan_only run, wait for \`awaiting_plan_review\`, click Approve, verify a follow-up full QueueItem is enqueued

🤖 Generated with [Claude Code](https://claude.com/claude-code)