### PR TITLE
fix(orchestrator): add explicit MCP server types in ClaudeAgentOptions

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1428,10 +1428,12 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                         },
                         mcp_servers={
                             "playwright": {
+                                "type": "stdio",
                                 "command": "npx",
                                 "args": ["-y", "@playwright/mcp@latest"],
                             },
                             "ref": {
+                                "type": "http",
                                 "url": "https://api.ref.tools/mcp",
                             },
                         },


### PR DESCRIPTION
## Summary
PR #287 added \`type: http\` to \`.mcp.json\` — but the SDK doesn't read that file from this code path. It reads \`mcp_servers\` passed directly to \`ClaudeAgentOptions\` in \`agent/station_orchestrator.py\`. So every Agent Teams run since #269 still died at SDK initialisation:

\`\`\`
Error: Invalid MCP configuration:
mcpServers.ref: Does not adhere to MCP server configuration schema
\`\`\`

Confirmed live at \`run-20260509T111317Z\` — orchestrator died 1 second after the lead spawned.

## Fix
Add explicit \`type\` to both entries in the orchestrator's \`mcp_servers\` dict:
- \`playwright\`: \`type: stdio\`
- \`ref\`: \`type: http\`

## Test plan
- [ ] Live: trigger Agent Teams run, verify SDK initialises without the schema error and the lead actually starts processing issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)