### PR TITLE
fix(queue-board): respect backend's limit=100 cap

### DIFF
--- a/dashboard/frontend/src/pages/QueueBoard.svelte
+++ b/dashboard/frontend/src/pages/QueueBoard.svelte
@@ -34,8 +34,14 @@
   let allEmpty = $derived(columns.every(c => c.items.length === 0));
 
   async function loadData() {
+    // ``limit=100`` matches the backend cap on /api/queue (Pydantic
+    // ``Query(le=100)``). Asking for more makes the request 422 and
+    // — because Promise.allSettled swallows the rejection — the board
+    // silently shows "Queue is empty" even when there are pending
+    // items, while the KPI card (which uses getQueueStats) shows the
+    // real count. If we ever need >100, raise the backend cap first.
     const [qRes, sRes, bRes] = await Promise.allSettled([
-      listQueue({ limit: 200 }),
+      listQueue({ limit: 100 }),
       getQueueStats(),
       getBackpressure(),
     ]);


### PR DESCRIPTION
## Summary
\`QueueBoard.svelte\` calls \`listQueue({limit: 200})\` but the backend caps \`limit\` at 100 (\`Query(le=100)\` on \`/api/queue\`). The 422 response made the request reject, \`Promise.allSettled\` swallowed it, and the board silently rendered the empty state.

The KPI card on the Overview uses \`getQueueStats()\` (a different endpoint, no limit param), so it correctly showed the count for data the board claimed didn't exist. User saw "Queue: 2" on the Overview but "Queue is empty" on the page.

## Fix
Drop to \`limit: 100\`. Comment explains the cap so this doesn't regress.

## Test plan
- [ ] Live: open the Queue page, verify the 2 pending items render in the Waiting column

🤖 Generated with [Claude Code](https://claude.com/claude-code)