### PR TITLE
fix(run-manager): include dashboard backend in PYTHONPATH override

### DIFF
--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -2585,7 +2585,14 @@ for item in data.get('items', []):
     local agent_dir
     agent_dir="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-    PYTHONPATH="$agent_dir/.." python3 -m agent.station_orchestrator \
+    # PYTHONPATH must include both the agent root (so ``import agent``
+    # resolves) AND the dashboard backend (so the orchestrator's queue
+    # consumer can ``from app.database import async_session`` —
+    # introduced in #290 to drain pending QueueItems from approved
+    # plan_only runs). Dropping the latter silently disables the queue
+    # drain with a ModuleNotFoundError after ``Processing project:``,
+    # leaving operators with a "trigger has no effect" symptom.
+    PYTHONPATH="$agent_dir/..:$agent_dir/../dashboard/backend" python3 -m agent.station_orchestrator \
         --config "$CONFIG_FILE" \
         --run-id "$RUN_ID" \
         --workspaces-dir "$WORKSPACES_DIR"


### PR DESCRIPTION
## Summary
PR #290 added \`from app.database import async_session\` to \`station_orchestrator.claim_pending_queue_items\` so the orchestrator can drain pending QueueItems. It worked in tests + the vision-analyst path, but broke under \`run-manager.sh\`.

\`run-manager.sh:2588\` overrides PYTHONPATH to just \`$agent_dir/..\` (= \`/app\`), dropping \`/app/dashboard/backend\` where \`app.database\` lives. So the orchestrator hits the queue-claim call after \`Processing project:\`, dies with:

\`\`\`
ModuleNotFoundError: No module named 'app'
\`\`\`

Result: every Agent Teams trigger silently no-opped after #290 landed — the dashboard showed a started run, run-manager.sh logged "Processing project:", then the Python process died before reaching the SDK boot.

## Fix
Add \`/app/dashboard/backend\` to the PYTHONPATH override. Comment explains why so this doesn't regress on the next run-manager edit.

## Test plan
- [ ] Live: trigger Agent Teams run, verify orchestrator gets past \`Processing project:\`, drains the 2 pending QueueItems, and starts the SDK lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)