### PR TITLE
fix(run-detail): handle multiple queue items per run

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -216,11 +216,19 @@ async def get_run_full_context(run_id: str, db: AsyncSession = Depends(get_db)):
     )
     messages = msgs_result.scalars().all()
 
-    # 4. Fetch related queue item (by run_id)
+    # 4. Fetch related queue items (by run_id). Issue #290 wired the
+    # orchestrator to drain multiple QueueItems per run when a plan_only
+    # run was approved, so ``scalar_one_or_none()`` here would 500 with
+    # ``MultipleResultsFound`` for any post-#290 run that drained more
+    # than one item. ``queue_item`` is kept as the first row for old
+    # consumers; ``queue_items`` exposes the full list.
     queue_result = await db.execute(
-        select(QueueItem).where(QueueItem.run_id == run_id)
+        select(QueueItem)
+        .where(QueueItem.run_id == run_id)
+        .order_by(QueueItem.id.asc())
     )
-    queue_item = queue_result.scalar_one_or_none()
+    queue_items = list(queue_result.scalars().all())
+    queue_item = queue_items[0] if queue_items else None
 
     # 5. Fetch related plan (by implementation_run_id or run_id)
     plan_result = await db.execute(
@@ -281,6 +289,7 @@ async def get_run_full_context(run_id: str, db: AsyncSession = Depends(get_db)):
         coordinator_tasks=[CoordinatorTaskOut.model_validate(t) for t in tasks],
         coordinator_messages=[CoordinatorMessageOut.model_validate(m) for m in messages],
         queue_item=QueueItemOut.model_validate(queue_item) if queue_item else None,
+        queue_items=[QueueItemOut.model_validate(q) for q in queue_items],
         plan=PlanOut.model_validate(plan) if plan else None,
         project_repo=project_repo,
         intelligence_decisions=[AgentEventOut.model_validate(e) for e in intel_events],

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -551,7 +551,12 @@ class RunFullContext(BaseModel):
     run: RunOut
     coordinator_tasks: list[CoordinatorTaskOut] = []
     coordinator_messages: list[CoordinatorMessageOut] = []
+    # ``queue_item`` is the first matching row for backwards-compat with
+    # callers that expected exactly-one. ``queue_items`` is the full
+    # list — required since #290 wired the orchestrator to drain
+    # multiple QueueItems per run from the plan-review gate.
     queue_item: QueueItemOut | None = None
+    queue_items: list[QueueItemOut] = []
     plan: PlanOut | None = None
     project_repo: str | None = None
     intelligence_decisions: list[AgentEventOut] = []

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -283,3 +283,43 @@ async def test_get_run_full_context_not_found(client):
     """GET /api/runs/{run_id}/full returns 404 for unknown run."""
     resp = await client.get("/api/runs/nonexistent-run/full")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_run_full_context_multiple_queue_items(client):
+    """Issue #290 wired the orchestrator to drain multiple QueueItems
+    per run. The endpoint must return them as a list — previously it
+    used ``scalar_one_or_none()`` which 500'd with MultipleResultsFound
+    for any drained run, breaking the run-detail UI completely.
+    """
+    from datetime import datetime, timezone
+
+    from app.database import async_session
+    from app.models import QueueItem, Run
+
+    async with async_session() as s:
+        s.add(Run(
+            run_id="run-multi-q-001",
+            status="running",
+            started_at=datetime.now(timezone.utc),
+        ))
+        s.add_all([
+            QueueItem(project_repo="x/y", issue_number=42, mode="full",
+                      state="claimed", run_id="run-multi-q-001"),
+            QueueItem(project_repo="x/y", issue_number=43, mode="full",
+                      state="claimed", run_id="run-multi-q-001"),
+            QueueItem(project_repo="x/y", issue_number=44, mode="full",
+                      state="claimed", run_id="run-multi-q-001"),
+        ])
+        await s.commit()
+
+    resp = await client.get("/api/runs/run-multi-q-001/full")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert "queue_items" in data
+    assert len(data["queue_items"]) == 3
+    issue_numbers = sorted(qi["issue_number"] for qi in data["queue_items"])
+    assert issue_numbers == [42, 43, 44]
+    # Backwards-compat: ``queue_item`` is the first item (by id), not None
+    assert data["queue_item"] is not None
+    assert data["queue_item"]["issue_number"] == 42

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -121,7 +121,11 @@ export interface RunFullContext {
   run: Run;
   coordinator_tasks: CoordinatorTask[];
   coordinator_messages: CoordinatorMessage[];
+  /** First matching queue item (kept for backwards compat). */
   queue_item: QueueItem | null;
+  /** Full list — required since #290 wired the orchestrator to drain
+   *  multiple QueueItems per run from the plan-review gate. */
+  queue_items?: QueueItem[];
   plan: Plan | null;
   project_repo: string | null;
   intelligence_decisions: AgentEvent[];

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -283,7 +283,27 @@
             </div>
           {/if}
 
-          {#if ctx?.queue_item}
+          {#if ctx?.queue_items && ctx.queue_items.length > 0}
+            <div class="card p-5 space-y-2">
+              <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">
+                Queue Items ({ctx.queue_items.length})
+              </h3>
+              <div class="space-y-2">
+                {#each ctx.queue_items as qi}
+                  <div class="text-xs space-y-1 text-secondary font-mono border-t border-border first:border-t-0 pt-2 first:pt-0">
+                    <div class="flex items-center gap-2">
+                      <span>#{qi.issue_number ?? '–'}</span>
+                      <span class="badge badge-{qi.state}">{qi.state}</span>
+                      <span class="text-tertiary">{qi.mode ?? '–'}</span>
+                    </div>
+                    {#if qi.issue_title}
+                      <div class="text-secondary">{qi.issue_title}</div>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
+            </div>
+          {:else if ctx?.queue_item}
             <div class="card p-5 space-y-2">
               <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">Queue Item</h3>
               <div class="text-xs space-y-1 text-secondary font-mono">


### PR DESCRIPTION
## Summary
PR #290 wired the orchestrator to drain multiple QueueItems per run (one per issue). The \`GET /api/runs/{run_id}/full\` endpoint still used \`scalar_one_or_none()\` for the QueueItem lookup, so any post-#290 run with 2+ queue items 500'd with \`MultipleResultsFound\`. The frontend caught the rejection and rendered the run-detail page with no data — that's the "nearly no information when clicking a run" symptom.

## Fix
- Schema: \`RunFullContext.queue_items: list[QueueItemOut]\` is the new primary field. \`queue_item\` is preserved as the first row for backwards compat.
- Endpoint: orders by id and returns the full list.
- Frontend: RunDetail.svelte renders \`queue_items\` when populated, with a per-row issue number / state / mode breakdown.

## Test plan
- [x] \`pytest dashboard/backend/tests/test_runs.py\` — 18 pass (1 new test seeding 3 queue items and asserting 200 + correct shape)
- [ ] Live: open the latest run detail page in the dashboard, verify all populated fields render

🤖 Generated with [Claude Code](https://claude.com/claude-code)