### PR TITLE
fix(orchestrator): keep prompt stream alive so hook callbacks succeed

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -70,10 +70,34 @@ class _StreamState:
     BATCH_INTERVAL: float = 15.0  # seconds between progress webhooks
 
 
-async def _user_prompt_stream(text: str):
+async def _user_prompt_stream(text: str, done_event: asyncio.Event | None = None):
     """Wrap a string prompt as the AsyncIterable form the SDK requires when
-    can_use_tool is supplied. Yields one user message then ends, matching
-    the dict shape the SDK uses internally for string prompts.
+    ``can_use_tool`` or ``hooks`` are supplied.
+
+    Yields one user message then **awaits ``done_event``** before returning.
+    Without that wait, the AsyncIterable would close as soon as the first
+    yield is consumed; the SDK transport then closes its stdin to the
+    bundled Claude CLI subprocess; subsequent tool calls trigger
+    PreToolUse / PostToolUse hooks which open a control_request back to
+    the Python side via the now-closed stdio stream. Result::
+
+        Error in hook callback hook_0: ... error: Stream closed
+            at sendRequest (.../cli.js:7552:133)
+
+    Symptom in production (run-20260509T142511Z): the lead spawned 3
+    teammates correctly, but every teammate tool call hit the closed
+    stream during PreToolUse — the audit hook couldn't write its row,
+    the CLI surfaced the failure, and teammates ended up not producing
+    any code or commits over a 13-minute run.
+
+    The fix is to keep the prompt stream alive for the full SDK
+    iteration. Caller passes an ``asyncio.Event`` and ``set()``s it in
+    a ``finally`` block once the ``async for message in query(...)``
+    loop has fully drained.
+
+    ``done_event=None`` keeps the original "yield-and-exit" behaviour
+    for a few legacy callers that don't use hooks; do NOT rely on
+    that path for any new code.
     """
     yield {
         "type": "user",
@@ -81,6 +105,8 @@ async def _user_prompt_stream(text: str):
         "message": {"role": "user", "content": text},
         "parent_tool_use_id": None,
     }
+    if done_event is not None:
+        await done_event.wait()
 
 
 SKIP_LABELS = frozenset({
@@ -1694,35 +1720,55 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                         options.resume = session_id
                         options.continue_conversation = True
 
-                    async for message in query(prompt=_user_prompt_stream(prompt), options=options):
-                        # Capture session_id for resume
-                        sid = getattr(message, "session_id", None)
-                        if sid:
-                            session_id = sid
+                    # ``prompt_done`` keeps the SDK's input stream alive
+                    # for the full duration of the ``async for`` below.
+                    # See ``_user_prompt_stream`` for the rationale —
+                    # without this gate, every PreToolUse / PostToolUse
+                    # hook callback hits ``Error: Stream closed`` because
+                    # the SDK transport closes stdin as soon as the
+                    # AsyncIterable is exhausted, and hooks need
+                    # bidirectional control_request comms after that.
+                    prompt_done = asyncio.Event()
+                    try:
+                        async for message in query(
+                            prompt=_user_prompt_stream(prompt, prompt_done),
+                            options=options,
+                        ):
+                            # Capture session_id for resume
+                            sid = getattr(message, "session_id", None)
+                            if sid:
+                                session_id = sid
 
-                        # Only send orchestrator_start webhook on the very first init
-                        if isinstance(message, SystemMessage) and getattr(message, "subtype", "") == "init":
-                            if not first_init_sent:
-                                post_webhook(config, "orchestrator_start", {
-                                    "run_id": f"run-{run_id}",
-                                    "mode": project_mode,
-                                })
-                                first_init_sent = True
+                            # Only send orchestrator_start webhook on the very first init
+                            if isinstance(message, SystemMessage) and getattr(message, "subtype", "") == "init":
+                                if not first_init_sent:
+                                    post_webhook(config, "orchestrator_start", {
+                                        "run_id": f"run-{run_id}",
+                                        "mode": project_mode,
+                                    })
+                                    first_init_sent = True
 
-                        handle_stream_event(message, config, run_id, log_file=log_file, state=stream_state)
+                            handle_stream_event(message, config, run_id, log_file=log_file, state=stream_state)
 
-                        # The background control poll task is already running;
-                        # we only need to check the stop flag here to break
-                        # out of the stream loop as soon as it latches.
-                        if control_flags["stop"]:
-                            logger.info("Stop requested; breaking SDK stream")
-                            break
+                            # The background control poll task is already running;
+                            # we only need to check the stop flag here to break
+                            # out of the stream loop as soon as it latches.
+                            if control_flags["stop"]:
+                                logger.info("Stop requested; breaking SDK stream")
+                                break
 
-                        # Check result for completion
-                        if isinstance(message, ResultMessage):
-                            result_text = getattr(message, "result", "")
-                            if _is_work_complete(result_text):
-                                work_complete = True
+                            # Check result for completion
+                            if isinstance(message, ResultMessage):
+                                result_text = getattr(message, "result", "")
+                                if _is_work_complete(result_text):
+                                    work_complete = True
+                    finally:
+                        # Release the prompt-stream gate so its generator
+                        # can return cleanly. This is a no-op for the
+                        # SDK-side stream (already drained by ``async for``
+                        # exiting), but it lets ``_user_prompt_stream``'s
+                        # background task finish so we don't leak it.
+                        prompt_done.set()
 
                     if control_flags["stop"]:
                         raise OrchestratorStopRequested()

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -1555,3 +1555,56 @@ def test_build_team_prompt_omits_approved_plans_section_when_none():
         project_mode="full",
     )
     assert "Approved plans from a prior plan_only run" not in prompt
+
+
+# --- Prompt stream stays open for hooks (Stream-closed regression) ---------
+
+
+@pytest.mark.asyncio
+async def test_user_prompt_stream_yields_then_blocks_on_done_event():
+    """Without ``done_event``, _user_prompt_stream yields once and exits —
+    the SDK transport closes its stdin to the bundled CLI subprocess as
+    soon as the AsyncIterable is drained. Subsequent PreToolUse /
+    PostToolUse hook callbacks then hit ``Error: Stream closed`` because
+    the CLI's ``sendRequest`` for control_request finds inputClosed=True.
+
+    The ``done_event`` form keeps the generator alive until the caller
+    explicitly signals completion, mirroring the SDK's expectation that
+    the input stream stays open for the duration of the conversation.
+    """
+    import asyncio
+    from agent import station_orchestrator as so
+
+    done = asyncio.Event()
+    gen = so._user_prompt_stream("hello world", done)
+    first = await gen.__anext__()
+    assert first["type"] == "user"
+    assert first["message"]["content"] == "hello world"
+
+    # Without done.set(), the generator must NOT advance — the next
+    # ``__anext__()`` should block indefinitely. We give it a short
+    # window and assert that no second value materialises.
+    second_task = asyncio.create_task(gen.__anext__())
+    try:
+        await asyncio.wait_for(asyncio.shield(second_task), timeout=0.2)
+        pytest.fail("generator returned a second value — done_event gate not honoured")
+    except asyncio.TimeoutError:
+        pass  # expected — gate is doing its job
+
+    # Releasing the gate must let the generator complete (StopAsyncIteration).
+    done.set()
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(second_task, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_user_prompt_stream_legacy_no_event_still_works():
+    """Legacy callers (without hooks/can_use_tool) can pass no event;
+    the generator yields once and exits. Don't break that path."""
+    from agent import station_orchestrator as so
+
+    items = []
+    async for msg in so._user_prompt_stream("legacy"):
+        items.append(msg)
+    assert len(items) == 1
+    assert items[0]["message"]["content"] == "legacy"


### PR DESCRIPTION
## Summary
Agent Teams runs were producing zero code commits. Lead spawned teammates correctly but every teammate tool call hit:

\`\`\`
Error in hook callback hook_0: ... error: Stream closed
    at sendRequest (.../cli.js:7552:133)
\`\`\`

Audit hook rows weren't being written, PreToolUse / PostToolUse hooks couldn't deliver verdicts to the CLI, and after 13 minutes of degraded operation the run "completed" with empty worktrees on all three teammates (run-20260509T142511Z).

## Root cause
\`_user_prompt_stream(text)\` yielded one user message and exited. The SDK's subprocess_cli transport interprets the exhausted AsyncIterable as "no more input" and closes its stdin pipe to the bundled CLI. But the CLI's hook system uses bidirectional control_request comms over that same stdio stream — every PreToolUse / PostToolUse callback fires a sendRequest back to the Python side. With \`inputClosed=True\`, every such request raises \`Error: Stream closed\`.

## Fix
\`_user_prompt_stream\` now accepts an \`asyncio.Event\` and awaits it after yielding the initial message. Caller wraps the \`async for message in query(...)\` in a \`try/finally\` and \`set()\`s the event in the finally to release the generator cleanly.

## Test plan
- [x] \`pytest dashboard/backend/tests/\` — 83 passed in test_orchestrator_wiring (2 new cases for the gate behaviour and the legacy no-event path)
- [ ] Live: trigger Agent Teams run, verify teammates actually write files, branches get created, commits pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)