### PR TITLE
fix(sdk): bump CLAUDE_CODE_STREAM_CLOSE_TIMEOUT to 30 minutes

### DIFF
--- a/agent/launcher.py
+++ b/agent/launcher.py
@@ -181,6 +181,20 @@ def trigger(x_launcher_token: str | None = Header(default=None)) -> dict:
     if gh_token:
         env["GH_TOKEN"] = gh_token
 
+    # Bump the SDK's stream-close timeout from the 60s default. After the
+    # bundled CLI emits its first ResultMessage the SDK begins a countdown
+    # before closing stdin; once stdin closes, every PreToolUse /
+    # PostToolUse hook callback the CLI tries to make to the Python side
+    # raises ``Error: Stream closed`` (cli.js:7552 sendRequest).
+    # Production hit this ~1-2 minutes into a long Agent Teams session
+    # — teammates' tool calls were still happening but their hooks
+    # silently failed, so audit_log rows stopped being written and
+    # teammates produced no commits. 30 minutes is generous enough for
+    # multi-issue Agent Teams runs without leaving stdin open
+    # indefinitely. Operators can override via the env if they need
+    # longer.
+    env.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", "1800000")
+
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_path = LOG_DIR / "launcher.out"
     log_fh = log_path.open("ab")

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -70,34 +70,15 @@ class _StreamState:
     BATCH_INTERVAL: float = 15.0  # seconds between progress webhooks
 
 
-async def _user_prompt_stream(text: str, done_event: asyncio.Event | None = None):
+async def _user_prompt_stream(text: str):
     """Wrap a string prompt as the AsyncIterable form the SDK requires when
     ``can_use_tool`` or ``hooks`` are supplied.
 
-    Yields one user message then **awaits ``done_event``** before returning.
-    Without that wait, the AsyncIterable would close as soon as the first
-    yield is consumed; the SDK transport then closes its stdin to the
-    bundled Claude CLI subprocess; subsequent tool calls trigger
-    PreToolUse / PostToolUse hooks which open a control_request back to
-    the Python side via the now-closed stdio stream. Result::
-
-        Error in hook callback hook_0: ... error: Stream closed
-            at sendRequest (.../cli.js:7552:133)
-
-    Symptom in production (run-20260509T142511Z): the lead spawned 3
-    teammates correctly, but every teammate tool call hit the closed
-    stream during PreToolUse — the audit hook couldn't write its row,
-    the CLI surfaced the failure, and teammates ended up not producing
-    any code or commits over a 13-minute run.
-
-    The fix is to keep the prompt stream alive for the full SDK
-    iteration. Caller passes an ``asyncio.Event`` and ``set()``s it in
-    a ``finally`` block once the ``async for message in query(...)``
-    loop has fully drained.
-
-    ``done_event=None`` keeps the original "yield-and-exit" behaviour
-    for a few legacy callers that don't use hooks; do NOT rely on
-    that path for any new code.
+    Yields one user message then ends. The SDK is designed for this shape
+    and handles stdin lifetime itself via ``_first_result_event`` and the
+    ``CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`` env var (in ms; 60s default).
+    Long Agent Teams sessions need that timeout bumped; see
+    :mod:`agent.launcher` where it's set on the orchestrator subprocess.
     """
     yield {
         "type": "user",
@@ -105,8 +86,6 @@ async def _user_prompt_stream(text: str, done_event: asyncio.Event | None = None
         "message": {"role": "user", "content": text},
         "parent_tool_use_id": None,
     }
-    if done_event is not None:
-        await done_event.wait()
 
 
 SKIP_LABELS = frozenset({
@@ -1720,55 +1699,35 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                         options.resume = session_id
                         options.continue_conversation = True
 
-                    # ``prompt_done`` keeps the SDK's input stream alive
-                    # for the full duration of the ``async for`` below.
-                    # See ``_user_prompt_stream`` for the rationale —
-                    # without this gate, every PreToolUse / PostToolUse
-                    # hook callback hits ``Error: Stream closed`` because
-                    # the SDK transport closes stdin as soon as the
-                    # AsyncIterable is exhausted, and hooks need
-                    # bidirectional control_request comms after that.
-                    prompt_done = asyncio.Event()
-                    try:
-                        async for message in query(
-                            prompt=_user_prompt_stream(prompt, prompt_done),
-                            options=options,
-                        ):
-                            # Capture session_id for resume
-                            sid = getattr(message, "session_id", None)
-                            if sid:
-                                session_id = sid
+                    async for message in query(prompt=_user_prompt_stream(prompt), options=options):
+                        # Capture session_id for resume
+                        sid = getattr(message, "session_id", None)
+                        if sid:
+                            session_id = sid
 
-                            # Only send orchestrator_start webhook on the very first init
-                            if isinstance(message, SystemMessage) and getattr(message, "subtype", "") == "init":
-                                if not first_init_sent:
-                                    post_webhook(config, "orchestrator_start", {
-                                        "run_id": f"run-{run_id}",
-                                        "mode": project_mode,
-                                    })
-                                    first_init_sent = True
+                        # Only send orchestrator_start webhook on the very first init
+                        if isinstance(message, SystemMessage) and getattr(message, "subtype", "") == "init":
+                            if not first_init_sent:
+                                post_webhook(config, "orchestrator_start", {
+                                    "run_id": f"run-{run_id}",
+                                    "mode": project_mode,
+                                })
+                                first_init_sent = True
 
-                            handle_stream_event(message, config, run_id, log_file=log_file, state=stream_state)
+                        handle_stream_event(message, config, run_id, log_file=log_file, state=stream_state)
 
-                            # The background control poll task is already running;
-                            # we only need to check the stop flag here to break
-                            # out of the stream loop as soon as it latches.
-                            if control_flags["stop"]:
-                                logger.info("Stop requested; breaking SDK stream")
-                                break
+                        # The background control poll task is already running;
+                        # we only need to check the stop flag here to break
+                        # out of the stream loop as soon as it latches.
+                        if control_flags["stop"]:
+                            logger.info("Stop requested; breaking SDK stream")
+                            break
 
-                            # Check result for completion
-                            if isinstance(message, ResultMessage):
-                                result_text = getattr(message, "result", "")
-                                if _is_work_complete(result_text):
-                                    work_complete = True
-                    finally:
-                        # Release the prompt-stream gate so its generator
-                        # can return cleanly. This is a no-op for the
-                        # SDK-side stream (already drained by ``async for``
-                        # exiting), but it lets ``_user_prompt_stream``'s
-                        # background task finish so we don't leak it.
-                        prompt_done.set()
+                        # Check result for completion
+                        if isinstance(message, ResultMessage):
+                            result_text = getattr(message, "result", "")
+                            if _is_work_complete(result_text):
+                                work_complete = True
 
                     if control_flags["stop"]:
                         raise OrchestratorStopRequested()

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -1557,54 +1557,46 @@ def test_build_team_prompt_omits_approved_plans_section_when_none():
     assert "Approved plans from a prior plan_only run" not in prompt
 
 
-# --- Prompt stream stays open for hooks (Stream-closed regression) ---------
+# --- Prompt stream + stream-close timeout (Stream-closed regression) -------
 
 
 @pytest.mark.asyncio
-async def test_user_prompt_stream_yields_then_blocks_on_done_event():
-    """Without ``done_event``, _user_prompt_stream yields once and exits —
-    the SDK transport closes its stdin to the bundled CLI subprocess as
-    soon as the AsyncIterable is drained. Subsequent PreToolUse /
-    PostToolUse hook callbacks then hit ``Error: Stream closed`` because
-    the CLI's ``sendRequest`` for control_request finds inputClosed=True.
-
-    The ``done_event`` form keeps the generator alive until the caller
-    explicitly signals completion, mirroring the SDK's expectation that
-    the input stream stays open for the duration of the conversation.
+async def test_user_prompt_stream_yields_one_message_and_exits():
+    """``_user_prompt_stream`` yields exactly one user message, then
+    StopAsyncIteration. The SDK is responsible for keeping stdin open
+    long enough for hooks via its ``CLAUDE_CODE_STREAM_CLOSE_TIMEOUT``
+    env var (set on the orchestrator subprocess by ``agent.launcher``).
     """
-    import asyncio
-    from agent import station_orchestrator as so
-
-    done = asyncio.Event()
-    gen = so._user_prompt_stream("hello world", done)
-    first = await gen.__anext__()
-    assert first["type"] == "user"
-    assert first["message"]["content"] == "hello world"
-
-    # Without done.set(), the generator must NOT advance — the next
-    # ``__anext__()`` should block indefinitely. We give it a short
-    # window and assert that no second value materialises.
-    second_task = asyncio.create_task(gen.__anext__())
-    try:
-        await asyncio.wait_for(asyncio.shield(second_task), timeout=0.2)
-        pytest.fail("generator returned a second value — done_event gate not honoured")
-    except asyncio.TimeoutError:
-        pass  # expected — gate is doing its job
-
-    # Releasing the gate must let the generator complete (StopAsyncIteration).
-    done.set()
-    with pytest.raises(StopAsyncIteration):
-        await asyncio.wait_for(second_task, timeout=1.0)
-
-
-@pytest.mark.asyncio
-async def test_user_prompt_stream_legacy_no_event_still_works():
-    """Legacy callers (without hooks/can_use_tool) can pass no event;
-    the generator yields once and exits. Don't break that path."""
     from agent import station_orchestrator as so
 
     items = []
-    async for msg in so._user_prompt_stream("legacy"):
+    async for msg in so._user_prompt_stream("hello world"):
         items.append(msg)
     assert len(items) == 1
-    assert items[0]["message"]["content"] == "legacy"
+    assert items[0]["type"] == "user"
+    assert items[0]["message"]["content"] == "hello world"
+
+
+def test_launcher_sets_stream_close_timeout_in_run_env():
+    """Regression guard: the launcher must inject
+    ``CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`` into the orchestrator
+    subprocess env so post-first-result hook callbacks don't hit
+    ``Error: Stream closed``. Source-level assertion — we don't boot
+    the launcher in tests.
+
+    Background: the SDK closes stdin ~60s after the first ResultMessage
+    by default (CLAUDE_CODE_STREAM_CLOSE_TIMEOUT=60000ms). After stdin
+    closes, every PreToolUse / PostToolUse hook callback raises
+    ``Error: Stream closed`` because the CLI's sendRequest finds
+    inputClosed=True. Long Agent Teams runs hit this within minutes —
+    the run keeps producing tool calls but every audit hook silently
+    fails. Bumping the timeout via env var is the supported escape.
+    """
+    import inspect
+    from agent import launcher
+
+    src = inspect.getsource(launcher)
+    assert 'CLAUDE_CODE_STREAM_CLOSE_TIMEOUT' in src, (
+        "agent.launcher.trigger() must set CLAUDE_CODE_STREAM_CLOSE_TIMEOUT "
+        "in the run-manager subprocess env"
+    )


### PR DESCRIPTION
## Summary
Reverts the manual \`done_event\` gate from PR #294 and replaces it with the SDK's supported \`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT\` env var.

## Why #294 was wrong
PR #294 made \`_user_prompt_stream\` await an asyncio.Event before returning. That introduced a deadlock — the SDK's \`stream_input\` task blocked in \`async for message in stream:\` waiting for our generator's next yield, never reaching \`wait_for_result_and_end_input()\`. The orchestrator process kept running after the lead's session finished; bash's run-manager never reached manager review → no verdicts file → no PRs.

Production symptom (run-20260509T145533Z): teammates wrote real code (Next.js + Prisma scaffold, REST API, 23 unit tests, 3 branches pushed), but no PR opened, queue items stuck in 'claimed', dashboard reported 'completed' while orchestrator was still alive.

## Actual cause
The SDK has the right machinery — \`Query._stream_close_timeout\` defaults to 60s, configurable via \`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT\` (ms). After the first ResultMessage the SDK starts a countdown before closing stdin. Once stdin closes, every PreToolUse/PostToolUse hook sendRequest raises \`Error: Stream closed\` (cli.js:7552). 60s is fine for short calls; Agent Teams runs go 10+ minutes.

## Fix
- \`_user_prompt_stream\` reverted to yield-once-and-exit.
- \`agent.launcher.trigger()\` sets \`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT=1800000\` (30 min) on the orchestrator subprocess env via \`env.setdefault(...)\` so deployments can override.

## Test plan
- [x] \`pytest dashboard/backend/tests/test_orchestrator_wiring.py\` — 83 pass (2 updated tests for the reverted shape + env var guard)
- [ ] Live: trigger Agent Teams run, verify orchestrator exits cleanly after lead finishes, bash reaches PHASE 2 manager review, PRs get created

🤖 Generated with [Claude Code](https://claude.com/claude-code)