### PR TITLE
fix(orchestrator): tell lead approved plans need no re-approval

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -720,23 +720,56 @@ def build_team_prompt(
     if approved_plan_paths:
         plan_lines = "\n".join(f"  - `{p}`" for p in approved_plan_paths)
         approved_plan_section = f"""
-## Approved plans from a prior plan_only run
+## Approved plans from a prior plan_only run (READ FIRST)
 
-The team is implementing work that was previously planned in a
-``plan_only`` run and approved (either by the manager's auto-verdict
-or via operator override on the dashboard). Each teammate **must**
-read its matching plan file from the list below before writing code,
-treat it as the agreed approach, and only deviate when an explicit
-issue requirement contradicts it (in which case raise it on the team
-chat first).
+The {len(approved_plan_paths)} plan files listed below were produced by an
+earlier ``plan_only`` run and have **already** been approved (manager
+auto-verdict or operator override on the dashboard). Plan approval is
+DONE — this run is implementation only. Do **not** wait for plan
+submissions, do not gate teammates on a plan-review signal, do not
+poll for "plan approval requests". The plans exist on disk:
 
-The plan files (one per pre-existing employee index):
 {plan_lines}
 
-When you decompose tasks, route each issue to the teammate that wrote
-its plan when possible — they have the most context. If you re-route,
-the new teammate should still read the corresponding plan file as
-guidance.
+Each teammate must read its matching plan file (`.claude-employee-plan-<index>.json`)
+as `APPROVED_PLAN` guidance before writing code, treat it as the agreed
+approach, and only deviate when an explicit issue requirement contradicts
+it (raise on the team chat first). When you decompose tasks, route each
+issue to the teammate that wrote its plan when possible — they have the
+most context.
+"""
+
+    repo_short = repo.split("/")[-1]
+    run_id_short = run_id[:8]
+    if approved_plan_paths:
+        workflow_section = f"""## Your Workflow (IMPLEMENTATION — plans pre-approved)
+
+1. **Create a team** called "{repo_short}-{run_id_short}".
+2. **Read every approved plan file** listed above so you know what each teammate signed up to build.
+3. **Spawn exactly 3 specialized teammates** (backend, frontend, qa) using the
+   `issue-worker` agent type. Tell each teammate which plan file to load as
+   `APPROVED_PLAN` guidance and which worktree to `cd` into. Spawn each role
+   ONCE — do not respawn extra teammates whose only purpose is to wait or poll.
+4. **Skip plan approval** — teammates implement straight from their approved
+   plan; do not block on a "plan submitted" or "plan approved" signal.
+5. **Actively monitor** teammates until each has written
+   `.claude-employee-report-<index>.json` or 20 minutes elapse (see monitoring rules below).
+6. After teammates finish, **synthesize a final JSON summary**.
+"""
+    else:
+        workflow_section = f"""## Your Workflow
+
+1. **Create a team** called "{repo_short}-{run_id_short}"
+2. **Analyze all issues** and decompose them into granular tasks (research, implement, test, review)
+3. **Create tasks** on the shared task list with dependencies and specialization tags
+4. **Spawn 3 specialized teammates** using the `issue-worker` agent type:
+   - **Backend specialist** — Python/FastAPI, database, API changes
+   - **Frontend specialist** — Svelte/TypeScript, UI components, CSS
+   - **QA specialist** — writes tests, validates implementations, runs linters
+5. **Require plan approval** before any teammate starts implementation
+6. Review plans — reject if they conflict with another teammate's work
+7. **Actively monitor** teammates until ALL tasks are completed (see monitoring rules)
+8. After all work is done, **synthesize a final JSON summary**
 """
 
     vision_section = ""
@@ -779,19 +812,8 @@ plan does not violate the non-goals or anti-patterns below. If it does:
 
     return f"""You are the lead of an agent team implementing GitHub issues for **{repo}**.
 {mode_instruction}
-## Your Workflow
-
-1. **Create a team** called "{repo.split('/')[-1]}-{run_id[:8]}"
-2. **Analyze all issues** and decompose them into granular tasks (research, implement, test, review)
-3. **Create tasks** on the shared task list with dependencies and specialization tags
-4. **Spawn 3 specialized teammates** using the `issue-worker` agent type:
-   - **Backend specialist** — Python/FastAPI, database, API changes
-   - **Frontend specialist** — Svelte/TypeScript, UI components, CSS
-   - **QA specialist** — writes tests, validates implementations, runs linters
-5. **Require plan approval** before any teammate starts implementation
-6. Review plans — reject if they conflict with another teammate's work
-7. **Actively monitor** teammates until ALL tasks are completed (see monitoring rules)
-8. After all work is done, **synthesize a final JSON summary**
+{approved_plan_section}
+{workflow_section}
 
 ## Narration (MANDATORY — ends operator silence)
 
@@ -844,7 +866,10 @@ After spawning teammates, you MUST actively monitor their progress using tool ca
 **NEVER end your turn while any teammate is still working.**
 
 Follow this monitoring loop:
-1. After spawning all teammates, run: `sleep 60` (Bash tool)
+1. After spawning all teammates, run **`sleep 60`** via the **Bash tool**.
+   Do **NOT** spawn a teammate just to wait — the Task tool is for real
+   implementation work, never for sleep proxies. Spawning a teammate with a
+   description like "Wait 3 minutes then check progress" is a bug; use Bash sleep instead.
 2. Check for completed reports: `find {workspace} -name ".claude-employee-report*.json" -type f 2>/dev/null`
 3. For each report found, read it and record the status
 4. If any teammate has not yet reported, **go back to step 1**
@@ -853,7 +878,8 @@ Follow this monitoring loop:
    - 20 minutes have elapsed since spawning (timeout for remaining)
 
 **Why this matters**: If you say "I'm waiting" and end your turn, the session terminates
-and your teammates lose their work. You must keep making tool calls to stay alive.
+and your teammates lose their work. You must keep making tool calls to stay alive —
+but those tool calls should be Bash sleeps and report-file polls, not new Task spawns.
 
 ## Rules
 
@@ -874,7 +900,6 @@ and your teammates lose their work. You must keep making tool calls to stay aliv
 - Workspace: {workspace}
 - Base branch: `{base_branch}` (teammates must branch FROM this)
 - GH_TOKEN is available for GitHub CLI operations
-{approved_plan_section}
 {vision_section}
 {mode_block}"""
 

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -1557,6 +1557,54 @@ def test_build_team_prompt_omits_approved_plans_section_when_none():
     assert "Approved plans from a prior plan_only run" not in prompt
 
 
+def test_build_team_prompt_approved_plans_swaps_workflow_to_implementation_only():
+    """Regression: run-20260509T183351Z burned ~43 min spawning
+    "Wait for plan submissions" teammates because the workflow still said
+    "Require plan approval before any teammate starts implementation".
+    With approved_plan_paths, the lead must see an implementation-only
+    workflow that explicitly tells it not to wait for plan approval."""
+    prompt = station_orchestrator.build_team_prompt(
+        repo="x/y",
+        issues=[{"number": 13, "title": "T", "body": "B", "labels": []}],
+        config={},
+        run_id="run-x",
+        workspace="/ws",
+        worktree_paths={"backend": "/ws-b"},
+        project_mode="full",
+        approved_plan_paths=["/ws/.claude-employee-plan-0.json"],
+    )
+    assert "IMPLEMENTATION — plans pre-approved" in prompt
+    assert "Skip plan approval" in prompt
+    assert "Require plan approval" not in prompt
+    # Approved-plan section must precede the workflow so the lead reads
+    # it first (it's now part of the same instruction surface, not a
+    # footer the lead may skim past).
+    assert prompt.index("Approved plans from a prior plan_only run") < prompt.index(
+        "Your Workflow"
+    )
+
+
+def test_build_team_prompt_bans_spawn_as_sleep_proxy():
+    """Regression for the same run: the lead used Task spawn as a sleep
+    primitive ("Wait 3 min then check progress" teammates). Active
+    Monitoring must explicitly forbid that pattern in both branches."""
+    base_kwargs = dict(
+        repo="x/y",
+        issues=[{"number": 13, "title": "T", "body": "B", "labels": []}],
+        config={},
+        run_id="run-x",
+        workspace="/ws",
+        worktree_paths={"backend": "/ws-b"},
+        project_mode="full",
+    )
+    for paths in (None, ["/ws/.claude-employee-plan-0.json"]):
+        prompt = station_orchestrator.build_team_prompt(
+            **base_kwargs, approved_plan_paths=paths
+        )
+        assert "Do **NOT** spawn a teammate just to wait" in prompt
+        assert "sleep proxies" in prompt
+
+
 # --- Prompt stream + stream-close timeout (Stream-closed regression) -------
 
 


### PR DESCRIPTION
## Summary

Run `run-20260509T183351Z` (project `laboef1900/next-itsm`) dispatched three role specialists at 18:36 and they shipped real work — ~5 000 LOC across `feat/issue-13-14-backend-20260509`, `feat/issue-13-frontend-20260509`, `feat/issue-13-14-qa-20260509`. But the lead then spent **43 minutes** spawning twelve teammates whose only purpose was to wait, e.g.:

```
18:42:58 spawned brefepdln  desc=Wait for plan submissions
18:50:29 spawned bp21076k2  desc=Wait 3 more minutes for plan approval requests
18:53:10 spawned bd8f5awok  desc=Wait 5 minutes - opus model planning takes longer
19:02:54 spawned b52jrhvw4  desc=Wait 3 min then check all worktrees for progress
```

Manager review never fired (no `…-manager.stream.jsonl`, no `…-verdicts.json`, no PR). Queue items #1/#2 are still `state='claimed'`. From the dashboard's POV "nothing happened" — but three branches sit on origin unmerged.

Two prompt bugs caused this:

1. **`Your Workflow` step 5** said "Require plan approval before any teammate starts implementation" even when the orchestrator had already drained queue items with pre-approved plan files. The lead obediently waited.

   Fix: split `Your Workflow` into two variants. With `approved_plan_paths`, the lead gets an implementation-only 6-step flow that explicitly says **"Skip plan approval — plans pre-approved"**. The approved-plan section also moves from the bottom of the prompt to next to the workflow so the lead reads it before deciding what to do.

2. **`Active Monitoring` step 1** told the lead to `sleep 60` via Bash but didn't forbid the alternative. The lead used the Task spawn tool as a sleep primitive instead.

   Fix: harden Active Monitoring step 1 — *"Do **NOT** spawn a teammate just to wait — the Task tool is for real implementation work, never for sleep proxies. Spawning a teammate with a description like 'Wait 3 minutes then check progress' is a bug; use Bash sleep instead."*

Adds two regression tests covering the workflow swap + ordering and the spawn-as-sleep ban in both branches.

This PR does not address the secondary issue of the manager-review phase failing to run when teammates have committed work. That needs its own change in `run-manager.sh` / dashboard backstop logic.

## Test plan

- [x] `pytest tests/test_orchestrator_wiring.py -k build_team_prompt -q` → 8 passed (6 existing + 2 new)
- [x] `pytest tests/test_team_prompt_webhook_url.py tests/test_orchestrator_wiring.py -q` → 89 passed
- [ ] Trigger a plan_only → operator-approve → full run on `next-itsm` and confirm the lead spawns three role specialists, monitors with Bash sleep, and exits cleanly into manager review

🤖 Generated with [Claude Code](https://claude.com/claude-code)