### PR TITLE
fix(run-manager): use run-effective mode for review package, not config

### DIFF
--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -658,6 +658,39 @@ get_project_field() {
     json_get "$CONFIG_FILE" "projects.$index.$field"
 }
 
+# Resolve the *effective* mode for a project's run.
+#
+# The project's static config mode (manager-config.json:projects[i].mode) is
+# only authoritative when the orchestrator hasn't drained queue items that
+# override it. An approved-plan follow-up run drains queue items with
+# mode=full, but the project's configured mode may still be plan_only.
+# Without resolving this, the manager review is built against PLAN_REVIEW
+# criteria and auto-rejects every implementing teammate as "MODE MISMATCH"
+# (run-20260509T183351Z incident).
+#
+# The orchestrator drops a workspace-local marker file (.claude-run-mode)
+# with the run's effective mode. Prefer it; fall back to the static config.
+# Garbage in the marker silently falls back too.
+#
+# Args: $1 = workspace path, $2 = project index in CONFIG_FILE.
+resolve_run_mode() {
+    local workspace="$1" index="$2"
+    local mode=""
+    local marker="$workspace/.claude-run-mode"
+    if [ -f "$marker" ]; then
+        mode=$(head -c 32 "$marker" 2>/dev/null | tr -d '[:space:]')
+        case "$mode" in
+            full|analyze|plan|plan_only) ;;
+            *) mode="" ;;
+        esac
+    fi
+    if [ -z "$mode" ]; then
+        mode=$(get_project_field "$index" "mode" 2>/dev/null || echo "full")
+    fi
+    [ -z "$mode" ] && mode="full"
+    printf '%s' "$mode"
+}
+
 # Extract repo name from "owner/repo" -> "repo"
 repo_name() {
     echo "$1" | cut -d'/' -f2
@@ -1510,14 +1543,14 @@ collect_employee_reports() {
         echo "## Project: $repo" >> "$review_package"
         echo "" >> "$review_package"
 
-        # Detect project mode from config and emit the matching MODE header.
+        # Detect the run's effective mode and emit the matching MODE header.
         # The manager prompt (agent/prompts/manager.md:23-33) keys its
         # review-criteria branching off these exact headers — keep them in
-        # lockstep with that contract. Issue #266: cover all four modes,
-        # not just analyze.
+        # lockstep with that contract. Issue #266: cover all four modes.
+        # See resolve_run_mode for why this prefers a per-run marker over
+        # the static project config.
         local project_mode
-        project_mode=$(get_project_field "$i" "mode" 2>/dev/null || echo "full")
-        [ -z "$project_mode" ] && project_mode="full"
+        project_mode=$(resolve_run_mode "$workspace" "$i")
         if [ "$project_mode" = "analyze" ]; then
             echo "MODE: ANALYZE" >> "$review_package"
             echo "" >> "$review_package"

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1508,6 +1508,23 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
             len(issues), repo, [f"#{i['number']}" for i in issues],
         )
 
+        # Persist the run's effective mode so run-manager.sh's review-package
+        # builder uses it instead of the static project config. Without this
+        # marker, an approved-plan follow-up run (drained queue items with
+        # mode=full) gets reviewed under the project's configured mode
+        # (often plan_only) and the manager auto-rejects every teammate as
+        # "MODE MISMATCH — you wrote code in plan mode". Run-manager reads
+        # this file in collect_employee_reports and falls back to the static
+        # config only if the marker is absent or unreadable.
+        try:
+            with open(os.path.join(workspace, ".claude-run-mode"), "w") as f:
+                f.write(project_mode)
+        except OSError as exc:
+            logger.warning(
+                "could not write .claude-run-mode marker for %s: %s",
+                repo, exc,
+            )
+
         # Determine base branch for worktrees
         integration = config.get("integration", {})
         base_branch = integration.get("dev_branch", "autonomous/dev")

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -70,6 +70,21 @@ async def test_wired_policy_allows_read_at_all_levels(tmp_path):
         assert isinstance(decision, PermissionResultAllow)
 
 
+def test_orchestrator_writes_run_mode_marker():
+    """Regression for run-20260509T183351Z: run-manager.sh's review-package
+    builder needs the *effective* run mode (e.g. ``full`` when implementing
+    from approved plans), not the project's static config mode (e.g.
+    ``plan_only``). Pin the marker write in the orchestrator source so it
+    can't be silently dropped — the bash side reads it via resolve_run_mode."""
+    source = inspect.getsource(station_orchestrator)
+    assert ".claude-run-mode" in source, (
+        "orchestrator must write a per-run mode marker to the workspace"
+    )
+    # Marker must be written from the project iteration so it picks up the
+    # post-queue-drain mode, not the pre-drain config mode.
+    assert "f.write(project_mode)" in source
+
+
 def test_orchestrator_options_block_contains_can_use_tool():
     """The source must wire can_use_tool=make_audited_policy(...) into
     ClaudeAgentOptions — otherwise the policy + audit never run.

--- a/dashboard/backend/tests/test_run_manager_helpers.py
+++ b/dashboard/backend/tests/test_run_manager_helpers.py
@@ -45,6 +45,65 @@ def _run_helper(snippet: str, *, env_overrides: dict[str, str] | None = None) ->
     return result.returncode, result.stdout.strip(), result.stderr.strip()
 
 
+def _resolve_run_mode(workspace: str, project_index: int, *, config_mode: str) -> str:
+    """Source run-manager.sh and call resolve_run_mode against a fake config.
+
+    We synthesize a one-project manager-config.json with the requested static
+    mode so the helper's fallback path has something to read.
+    """
+    cfg_dir = Path(workspace).parent
+    cfg = cfg_dir / "manager-config.json"
+    cfg.write_text(
+        f'{{"projects":[{{"repo":"x/y","mode":"{config_mode}"}}]}}'
+    )
+    cmd = (
+        f"export STATION_CONFIG='{cfg}'; "
+        f"source '{RUN_MANAGER}' 2>/dev/null || true; "
+        f"resolve_run_mode '{workspace}' {project_index}"
+    )
+    out = subprocess.run(
+        ["bash", "-c", cmd], capture_output=True, text=True, timeout=10,
+    )
+    return out.stdout.strip()
+
+
+def test_resolve_run_mode_uses_marker_when_present(tmp_path):
+    """Regression for run-20260509T183351Z: an approved-plan follow-up run
+    drained queue items with mode=full, but the project's static config
+    still said plan_only. Without the per-run marker, the manager review
+    was built against PLAN_REVIEW criteria and auto-rejected every
+    implementing teammate as "MODE MISMATCH"."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".claude-run-mode").write_text("full")
+    assert _resolve_run_mode(str(ws), 0, config_mode="plan_only") == "full"
+
+
+def test_resolve_run_mode_falls_back_to_config_when_marker_absent(tmp_path):
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    assert _resolve_run_mode(str(ws), 0, config_mode="plan_only") == "plan_only"
+
+
+def test_resolve_run_mode_rejects_garbage_marker_and_falls_back(tmp_path):
+    """A marker that doesn't name one of the four valid modes must be
+    treated as absent, not propagated. Otherwise a corrupt write could
+    silently change review behavior."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".claude-run-mode").write_text("rm -rf /\nplan_only")
+    assert _resolve_run_mode(str(ws), 0, config_mode="analyze") == "analyze"
+
+
+def test_resolve_run_mode_strips_trailing_whitespace(tmp_path):
+    """The orchestrator writes the mode without a trailing newline, but a
+    human or future code path might add one. Be tolerant."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".claude-run-mode").write_text("full\n")
+    assert _resolve_run_mode(str(ws), 0, config_mode="plan_only") == "full"
+
+
 def test_rate_limit_allows_first_call(tmp_path):
     """With no lockfile, auto_draft_rate_limit_allowed returns 0 (allow)."""
     rc, _, _ = _run_helper(


### PR DESCRIPTION
## Summary

In run `run-20260509T183351Z` three teammates correctly implemented two approved plans (~5 000 LOC, three feature branches pushed to origin). The manager then auto-rejected every one with the same verdict:

> *"REJECT_PLAN — The project is configured for PLAN_REVIEW mode, but you submitted a full code implementation (mode: full)… Discard or stash the committed implementation."*

The teammates weren't wrong. The review package was. `collect_employee_reports` read the project's **static config mode** (`plan_only` in `manager-config.json`) instead of the run's **effective mode**. The orchestrator had already switched the run to `full` after draining 2 queue items with `mode=full` (the standard approved-plan follow-up path), but bash and Python disagreed about what the run was, and bash won the contract that drives the manager prompt.

This is what got pinned to `verdicts.json` for that run:

```
"verdict": "REJECT_PLAN",
"feedback": "MODE MISMATCH: ... project is configured for PLAN_REVIEW mode (pre-implementation plan gate), but you submitted a full code implementation..."
```

No PR ever opened, queue items still `state='claimed'`, three feature branches sitting on origin unmerged.

## Fix

- `agent/station_orchestrator.py`: after eligibility is decided, drop `.claude-run-mode` in the workspace with the run's effective mode.
- `agent/scripts/run-manager.sh`: new helper `resolve_run_mode "$workspace" "$index"` prefers the marker and falls back to the static config (or `"full"`) when absent or garbage. `collect_employee_reports`' inline mode-derivation block collapses to a one-line helper call.

## Tests

- 4 new bash helper tests (`resolve_run_mode` precedence): marker present / absent / garbage / trailing whitespace.
- 1 source-level guard pinning the orchestrator's marker write so it can't be silently dropped.
- All 92 prompt + helper tests pass.

## Relationship to PR #296

Independent. #296 fixes the lead's 43-min wait loop (it kept spawning "Wait for plan submissions" teammates). This PR fixes the *manager-side* failure that turned the teammates' actual work into REJECT_PLAN verdicts. Both bugs hit the same run.

## Test plan

- [x] `pytest tests/test_run_manager_helpers.py tests/test_orchestrator_wiring.py -q` → 92 passed
- [x] `bash -n agent/scripts/run-manager.sh` → syntax clean
- [ ] Trigger a fresh approved-plan follow-up run on `next-itsm` and confirm: marker file appears, review package emits `MODE: FULL`, manager reviews under full-mode criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)