### PR TITLE
feat(ui): clarify mode vs autonomy as two axes on project detail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ dashboard/frontend/dist/
 dashboard/frontend/screenshots/
 dashboard/frontend/test-results/
 test-results/
+.playwright-mcp/
+
+# Claude Code local project state
+.claude/
 
 # SQLite
 *.db

--- a/dashboard/frontend/src/pages/ProjectDetail.svelte
+++ b/dashboard/frontend/src/pages/ProjectDetail.svelte
@@ -3,7 +3,7 @@
   import { navigate } from '../lib/router.svelte';
   import { toastSuccess, toastError } from '../lib/toast.svelte';
   import { formatCompact, formatDuration } from '../lib/chart-utils';
-  import type { Project, Run } from '../lib/types';
+  import type { Project, Run, AutonomyLevel } from '../lib/types';
   import Toggle from '../components/forms/Toggle.svelte';
   import VisionTab from '../components/vision/VisionTab.svelte';
 
@@ -75,34 +75,76 @@
     </div>
 
     {#if activeTab === 'overview'}
-      <!-- Config -->
+      <!-- Work scope — what the agent is asked to do -->
+      <div class="glass rounded-lg p-4 space-y-3">
+        <div>
+          <h2 class="text-xs font-semibold text-secondary uppercase tracking-wider">Work scope</h2>
+          <p class="mt-1 text-[11px] leading-snug text-tertiary">
+            What the agent is asked to do on this project. Shapes the prompt teammates receive and the criteria the manager applies.
+          </p>
+        </div>
+        <div>
+          <label class="text-xs text-tertiary mb-1 block">Mode</label>
+          <select
+            value={project.mode}
+            onchange={(e) => { project!.mode = (e.target as HTMLSelectElement).value as any; save('mode', project!.mode); }}
+            class="w-full px-3 py-2 rounded-lg bg-void text-primary text-sm border border-border focus:border-border-focus outline-none"
+          >
+            <option value="full">Full — plan and implement</option>
+            <option value="analyze">Analyze — read-only investigation</option>
+            <option value="plan">Plan — plan-quality output, source untouched</option>
+            <option value="plan_only">Plan Only — write plan, stop, wait for approval</option>
+          </select>
+          <p class="mt-1 text-[11px] leading-snug text-tertiary">
+            {#if project.mode === 'full'}
+              Teammates write code, run tests, and push a feature branch for the manager to review.
+            {:else if project.mode === 'analyze'}
+              Teammates inspect code and write findings to a report file. No source changes, no branches, no commits.
+            {:else if project.mode === 'plan'}
+              Teammates produce inline-rich plans; the manager rejects any source modification.
+            {:else if project.mode === 'plan_only'}
+              Teammates write a plan and stop. The manager approves, requests revisions, or rejects before any code is written. An approved plan_only run schedules a follow-up <em>full</em> run that implements it.
+            {/if}
+          </p>
+        </div>
+      </div>
+
+      <!-- Execution policy — how freely the agent can act -->
+      <div class="glass rounded-lg p-4 space-y-3">
+        <div>
+          <h2 class="text-xs font-semibold text-secondary uppercase tracking-wider">Execution policy</h2>
+          <p class="mt-1 text-[11px] leading-snug text-tertiary">
+            How freely the agent can act on the work scope above. Independent of mode — applies to every tool call regardless of whether the run is implementing, planning, or analyzing.
+          </p>
+        </div>
+        <div>
+          <label class="text-xs text-tertiary mb-1 block">Autonomy level</label>
+          <select
+            value={project.autonomy_level ?? 'assisted'}
+            onchange={(e) => { project!.autonomy_level = (e.target as HTMLSelectElement).value as AutonomyLevel; save('autonomy_level', project!.autonomy_level); }}
+            class="w-full px-3 py-2 rounded-lg bg-void text-primary text-sm border border-border focus:border-border-focus outline-none"
+          >
+            <option value="manual">Manual — operator approves every edit and risky command</option>
+            <option value="assisted">Assisted — edits auto-allowed, destructive commands ask</option>
+            <option value="auto">Auto — only the always-deny list blocks the agent</option>
+          </select>
+          <p class="mt-1 text-[11px] leading-snug text-tertiary">
+            {#if project.autonomy_level === 'manual'}
+              Every <code>Edit</code> / <code>Write</code> and every destructive bash (<code>rm -rf</code>, force push, etc.) defers to the operator via the permission tray. Use for new or sensitive repos.
+            {:else if project.autonomy_level === 'auto'}
+              Mirrors Claude Code Auto Mode. Edits and most bash run without prompting; only the hard-coded always-deny list (push to <code>main</code>, fork bombs, <code>sudo</code>, etc.) is blocked.
+            {:else}
+              Edits auto-allowed; destructive bash patterns still defer to the operator. The default for established repos.
+            {/if}
+            Every decision is recorded to the autonomy audit, regardless of level.
+          </p>
+        </div>
+      </div>
+
+      <!-- Project basics -->
       <div class="glass rounded-lg p-4 space-y-4">
-        <h2 class="text-xs font-semibold text-secondary uppercase tracking-wider">Configuration</h2>
+        <h2 class="text-xs font-semibold text-secondary uppercase tracking-wider">Project basics</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label class="text-xs text-tertiary mb-1 block">Mode</label>
-            <select
-              value={project.mode}
-              onchange={(e) => { project!.mode = (e.target as HTMLSelectElement).value as any; save('mode', project!.mode); }}
-              class="w-full px-3 py-2 rounded-lg bg-void text-primary text-sm border border-border focus:border-border-focus outline-none"
-            >
-              <option value="full">Full</option>
-              <option value="analyze">Analyze</option>
-              <option value="plan">Plan</option>
-              <option value="plan_only">Plan Only</option>
-            </select>
-            <p class="mt-1 text-[11px] leading-snug text-tertiary">
-              {#if project.mode === 'full'}
-                Plan and implement: teammates write code, run tests, and push a feature branch for the manager to review.
-              {:else if project.mode === 'analyze'}
-                Read-only investigation: teammates inspect code and write findings to a report file. No source changes, no branches, no commits.
-              {:else if project.mode === 'plan'}
-                Plan-quality output, source untouched: teammates produce inline-rich plans; the manager rejects any source modification.
-              {:else if project.mode === 'plan_only'}
-                Pre-implementation gate: teammates write a plan and stop. The manager approves, requests revisions, or rejects before any code is written.
-              {/if}
-            </p>
-          </div>
           <div>
             <label class="text-xs text-tertiary mb-1 block">Priority</label>
             <select

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,7 +82,15 @@ sudo systemctl restart claude-agent.timer
 
 ## Autonomy levels
 
-Agent behavior is gated by a per-project autonomy-level setting. See [`adr/0001-autonomy-levels.md`](adr/0001-autonomy-levels.md) for the model and the level definitions. The default for new projects is `assisted`.
+Per-project setting that gates **how freely** the agent can act on its work. Independent of the [project mode](#project-mode) — applies to every tool call regardless of whether the run is implementing, planning, or analyzing. See [`adr/0001-autonomy-levels.md`](adr/0001-autonomy-levels.md) for the policy engine; this section just summarises what each level does.
+
+| Level | Edits (`Edit` / `Write`) | Destructive bash (`rm -rf`, force push, …) | Always-deny list (push to `main`, fork bombs, `sudo`, …) |
+|---|---|---|---|
+| `manual` | defer to operator | defer to operator | block |
+| `assisted` *(default)* | allow | defer to operator | block |
+| `auto` | allow | allow | block |
+
+Every decision — allow, defer, or block — is recorded to `agent_events` with `event_type='auto_mode_decision'` and surfaced on the Autonomy Audit page. The always-deny list is hard-coded in `agent/auto_mode.py` and cannot be overridden, even at `auto`.
 
 ## API key and webhook secret
 
@@ -97,6 +105,17 @@ Exempt from `STATION_API_KEY` auth (verified in `dashboard/backend/app/main.py`)
 ## Project config
 
 Each managed repository is one row in the `projects` table. The dashboard's Projects page is the easiest way to edit; the underlying schema (used by `POST /api/projects`) is:
+
+### Two orthogonal axes
+
+Projects carry two independent settings that are sometimes confused. They control different concerns and any combination is legal:
+
+| Axis | Values | What it controls | UI section |
+|------|--------|------------------|------------|
+| `mode` | `full`, `analyze`, `plan`, `plan_only` | **What** the agent is asked to do — implement, investigate, plan, or plan-then-pause. Shapes the teammate spawn prompt and the manager review criteria. | "Work scope" |
+| `autonomy_level` | `manual`, `assisted`, `auto` | **How freely** it can act — whether `Edit`/`Write` and destructive bash defer to the operator or run unattended. Applies to every tool call regardless of mode. | "Execution policy" |
+
+Examples: `analyze + auto` runs read-only investigation without any approval prompts; `full + manual` lets the agent implement but every file write needs operator confirmation; `plan_only + assisted` (the typical onboarding default) writes a plan that the manager and operator review before any code is written.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|


### PR DESCRIPTION
## Summary

Operator feedback: *"On top level of a project I can select assisted, manual or auto. In the settings of the project I can set plan_only, plan, analyze and full. It's a bit confusing."*

The two project settings control different concerns but were split across two pages with no shared framing — mode was editable only on `ProjectDetail`, `autonomy_level` only on the `ProjectsPage` cards — so they read like duplicate or competing controls.

The fix is **not** to merge them: they're genuinely orthogonal. `mode` shapes *what* the agent is asked to do (prompt + manager-review criteria); `autonomy_level` shapes *how freely* it can act (`can_use_tool` gates). Combinations like `analyze + auto` and `full + manual` are legitimate.

This PR groups both on `ProjectDetail.svelte`'s overview tab under labelled sections that name each axis's concern:

- **Work scope** (`mode`) — *"What the agent is asked to do"*
- **Execution policy** (`autonomy_level`) — *"How freely it can act"*
- **Project basics** — priority, branch, enabled toggle

Each option's dropdown label now carries a one-line summary (e.g. *"Manual — operator approves every edit and risky command"*), and the existing per-selection help paragraph stays underneath for the longer description.

`docs/configuration.md` gains:
- A "Two orthogonal axes" subsection at the top of Project config with a comparison matrix and three example combinations.
- A permissions table under Autonomy levels enumerating manual/assisted/auto inline (today the section just points to ADR-0001).

## Screenshot

Verified live on `http://localhost:5173/projects/1` (next-itsm) with `npm run dev` against the running dashboard backend. Three sections render cleanly with no console errors:

```
WORK SCOPE
  What the agent is asked to do on this project. Shapes the prompt
  teammates receive and the criteria the manager applies.
  [Plan Only — write plan, stop, wait for approval ▾]
  Teammates write a plan and stop. The manager approves, requests
  revisions, or rejects before any code is written. An approved
  plan_only run schedules a follow-up full run that implements it.

EXECUTION POLICY
  How freely the agent can act on the work scope above. Independent
  of mode — applies to every tool call regardless of whether the
  run is implementing, planning, or analyzing.
  [Assisted — edits auto-allowed, destructive commands ask ▾]
  Edits auto-allowed; destructive bash patterns still defer to the
  operator. The default for established repos. Every decision is
  recorded to the autonomy audit, regardless of level.

PROJECT BASICS
  Priority [High ▾]    Branch [main]    [●] Enabled
```

## Test plan

- [x] `npm run build` → 812 ms, no errors on changed files
- [x] Live render against running dashboard, project detail page loads three sections without console errors
- [ ] Sanity check: change autonomy on this page, confirm it round-trips via `PATCH /api/projects/{id}` and the inline selector on the Projects card view reflects the new value

## Out of scope

- The inline autonomy selector on `ProjectsPage` cards stays — it's a useful at-a-glance toggle for many projects. This PR just stops *requiring* you to leave the detail page to change it.
- A "preset picker" that hides both axes behind one combined dropdown was considered and rejected (loses combinations like `plan_only + auto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)