### PR TITLE
feat(ui): migrate Mission Control to Pro design system

### DIFF
--- a/dashboard/frontend/src/pages/MissionControl.svelte
+++ b/dashboard/frontend/src/pages/MissionControl.svelte
@@ -12,31 +12,26 @@
   // row was queued forever and the agent never saw it. The header still
   // shows latestRunId for context, but interventions require a live run.
   let currentRunId = $derived(agentPresence.activeRuns[0]?.run_id ?? '');
-  let headerRunId = $derived(
-    currentRunId || agentPresence.latestRunId || ''
-  );
+  let headerRunId = $derived(currentRunId || agentPresence.latestRunId || '');
   let currentRun = $derived(
-    agentPresence.activeRuns.find((r) => r.run_id === currentRunId) ?? null
+    agentPresence.activeRuns.find((r) => r.run_id === currentRunId) ?? null,
   );
   let isLive = $derived(agentPresence.activeRuns.length > 0);
   let runPaused = $derived(!!agentPresence.pausedRuns[currentRunId]);
   let pendingDecisions = $derived(agentPresence.pendingDecisionCount);
+
   // Issue #266: surface the plan-review gate so operators can see when a
   // plan_only run is waiting on the manager (or has been approved/rejected).
   let planReviewStatus = $derived<string | null>(
-    currentRun && (
-      currentRun.status === 'awaiting_plan_review' ||
-      currentRun.status === 'plan_approved' ||
-      currentRun.status === 'plan_rejected' ||
-      currentRun.status === 'plan_reviewing'
-    )
+    currentRun &&
+      (currentRun.status === 'awaiting_plan_review' ||
+        currentRun.status === 'plan_approved' ||
+        currentRun.status === 'plan_rejected' ||
+        currentRun.status === 'plan_reviewing')
       ? (currentRun.status as string)
-      : null
+      : null,
   );
 
-  // Plan-review gate operator override (issue #266 follow-up).
-  // ``planActionInFlight`` doubles as a busy flag and a label hint for
-  // the button rendering 'Approving…' / 'Rejecting…'.
   let planActionInFlight = $state<'approve' | 'reject' | null>(null);
 
   async function approveCurrentRunPlan() {
@@ -88,9 +83,6 @@
       addToast('success', 'Message queued for the agent');
       messageText = '';
     } catch (e) {
-      // Backend returns 409 with a clear detail when the run has finished
-      // between the UI's activeRuns refresh and the click. Surface that
-      // exact string so the operator knows their message was NOT delivered.
       const raw = e instanceof Error ? e.message : 'Send failed';
       const friendly = raw.startsWith('409:')
         ? raw.slice(4).trim() || 'Run is no longer active — message not delivered'
@@ -119,110 +111,104 @@
   }
 </script>
 
-<div class="flex flex-col h-full min-h-0">
-  <!-- Header strip -->
-  <div class="flex items-center gap-4 px-4 py-3 border-b border-border bg-surface-1 shrink-0">
-    <div class="flex flex-col">
-      <div class="text-xs uppercase tracking-wider text-secondary font-semibold">Mission Control</div>
-      <div class="text-sm font-mono text-primary" data-testid="mc-run-id">
+<div class="mc-shell">
+  <!-- Header strip — Pro -->
+  <header class="mc-head">
+    <div class="mc-head-left">
+      <span class="mc-title">Mission Control <span class="sep">·</span> OP-7</span>
+      <span class="mc-runid mono" data-testid="mc-run-id">
         {#if currentRunId}
           {currentRunId}
         {:else if headerRunId}
-          <span class="text-secondary">{headerRunId}</span>
-          <span class="ml-1 text-[10px] uppercase text-accent-yellow">(ended — read-only)</span>
+          <span class="muted">{headerRunId}</span>
+          <span class="ended">(ended — read-only)</span>
         {:else}
-          no active run
+          <span class="muted">no active run</span>
         {/if}
-      </div>
+      </span>
     </div>
 
-    <div class="flex items-center gap-3 ml-6 text-xs">
-      <div class="flex items-center gap-1">
-        <span class="w-2 h-2 rounded-full {isLive ? 'bg-approve animate-pulse' : 'bg-border'}"></span>
-        <span class="text-primary font-medium">{isLive ? 'live' : 'idle'}</span>
-      </div>
+    <div class="mc-head-meta mono">
+      <span class="live-pair">
+        <span class="dot {isLive ? 'go live' : 'idle'}"></span>
+        <span class="strong">{isLive ? 'live' : 'idle'}</span>
+      </span>
       {#if currentRun}
-        <div class="text-secondary">·</div>
-        <div class="text-secondary">phase: <span class="text-primary font-medium">{agentPresence.phase}</span></div>
-        <div class="text-secondary">·</div>
-        <div class="text-secondary">
-          tokens: <span class="text-primary font-medium">{formatTokens(currentRun.tokens_total ?? agentPresence.tokensBurned ?? 0)}</span>
-        </div>
+        <span class="sep">·</span>
+        <span>phase: <b>{agentPresence.phase}</b></span>
+        <span class="sep">·</span>
+        <span>tokens: <b>{formatTokens(currentRun.tokens_total ?? agentPresence.tokensBurned ?? 0)}</b></span>
         {#if currentRun.started_at}
-          <div class="text-secondary">·</div>
-          <div class="text-secondary">started: <span class="text-primary font-medium">{timeAgo(currentRun.started_at)}</span></div>
+          <span class="sep">·</span>
+          <span>started: <b>{timeAgo(currentRun.started_at)}</b></span>
         {/if}
         {#if currentRun.turns != null}
-          <div class="text-secondary">·</div>
-          <div class="text-secondary">turns: <span class="text-primary font-medium">{currentRun.turns}</span></div>
+          <span class="sep">·</span>
+          <span>turns: <b>{currentRun.turns}</b></span>
         {/if}
       {/if}
       {#if runPaused}
-        <span class="px-2 py-0.5 rounded bg-accent-yellow/20 text-accent-yellow text-[10px] uppercase">paused</span>
+        <span class="badge caution">paused</span>
       {/if}
       {#if agentPresence.globalPause}
-        <span class="px-2 py-0.5 rounded bg-reject/20 text-reject text-[10px] uppercase">global pause</span>
+        <span class="badge abort">global pause</span>
       {/if}
       {#if pendingDecisions > 0}
-        <span class="px-2 py-0.5 rounded bg-accent-blue/20 text-accent-blue text-[10px] uppercase">
-          {pendingDecisions} pending decisions
-        </span>
+        <span class="badge data">{pendingDecisions} pending</span>
       {/if}
     </div>
 
-    <div class="flex-1"></div>
-
     {#if !isLive}
-      <button
-        type="button"
-        onclick={handleTrigger}
-        class="px-3 py-1.5 rounded text-xs font-medium bg-accent-blue/20 text-accent-blue hover:bg-accent-blue/30"
-      >
-        Trigger run
-      </button>
+      <button type="button" class="trigger-btn" onclick={handleTrigger}>Trigger run</button>
     {/if}
-  </div>
+  </header>
 
-  <!-- Intervention bar -->
+  <!-- Intervention bar (kept as-is; styled by its own component) -->
   <InterventionBar runId={currentRunId} />
 
-  <!-- Plan-review gate banner (issue #266) -->
+  <!-- Plan-review banner — Pro -->
   {#if planReviewStatus}
     <div
-      class="px-4 py-2 text-xs border-b border-border flex items-center gap-3 flex-wrap"
-      class:bg-amber-500={planReviewStatus === 'awaiting_plan_review' || planReviewStatus === 'plan_reviewing'}
-      class:bg-green-600={planReviewStatus === 'plan_approved'}
-      class:bg-red-600={planReviewStatus === 'plan_rejected'}
-      class:text-white={true}
+      class="plan-banner"
+      class:awaiting={planReviewStatus === 'awaiting_plan_review' || planReviewStatus === 'plan_reviewing'}
+      class:approved={planReviewStatus === 'plan_approved'}
+      class:rejected={planReviewStatus === 'plan_rejected'}
       data-testid="plan-review-banner"
     >
-      <span class="flex-1 min-w-0">
+      <span class="lev">
+        {#if planReviewStatus === 'awaiting_plan_review'}Plan Awaiting Review
+        {:else if planReviewStatus === 'plan_reviewing'}Manager Reviewing
+        {:else if planReviewStatus === 'plan_approved'}Plan Approved
+        {:else if planReviewStatus === 'plan_rejected'}Plan Rejected
+        {/if}
+      </span>
+      <span class="body">
         {#if planReviewStatus === 'awaiting_plan_review'}
-          <strong>Plan awaiting review.</strong> The teammate wrote an implementation plan; approve to enqueue a follow-up <code class="font-mono">full</code> run, or reject to stop here.
+          The teammate wrote an implementation plan; <b>approve</b> to enqueue a follow-up <code class="mono">full</code> run, or <b>reject</b> to stop here.
         {:else if planReviewStatus === 'plan_reviewing'}
-          <strong>Manager reviewing plan…</strong>
+          Manager reviewing plan…
         {:else if planReviewStatus === 'plan_approved'}
-          <strong>Plan approved.</strong> A follow-up full run has been enqueued.
+          A follow-up full run has been enqueued.
         {:else if planReviewStatus === 'plan_rejected'}
-          <strong>Plan rejected.</strong> No follow-up run will be queued.
+          No follow-up run will be queued.
         {/if}
       </span>
       {#if planReviewStatus === 'awaiting_plan_review'}
-        <span class="flex gap-2">
+        <span class="actions">
           <button
             type="button"
+            class="banner-btn approve"
             onclick={approveCurrentRunPlan}
-            disabled={planActionInFlight}
-            class="px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-white text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            disabled={planActionInFlight !== null}
             data-testid="plan-review-approve-btn"
           >
             {planActionInFlight === 'approve' ? 'Approving…' : 'Approve'}
           </button>
           <button
             type="button"
+            class="banner-btn reject"
             onclick={rejectCurrentRunPlan}
-            disabled={planActionInFlight}
-            class="px-2 py-0.5 rounded bg-white/20 hover:bg-white/30 text-white text-xs font-semibold disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            disabled={planActionInFlight !== null}
             data-testid="plan-review-reject-btn"
           >
             {planActionInFlight === 'reject' ? 'Rejecting…' : 'Reject'}
@@ -232,80 +218,316 @@
     </div>
   {/if}
 
-  <!-- Main content -->
-  <div class="flex-1 min-h-0 grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-0">
-    <!-- Activity / thinking feed -->
-    <div class="relative flex flex-col min-h-0 border-r border-border">
-      <div class="px-3 py-2 border-b border-border text-xs uppercase tracking-wider text-primary font-semibold bg-surface-0">
-        Activity — tools, thinking, messages
+  <!-- Main grid -->
+  <div class="mc-main">
+    <!-- Console: live activity feed -->
+    <section class="console">
+      <div class="section-head">
+        <span>Agent Activity <span class="sep-light">·</span> Live</span>
+        <span class="section-head-right mono">
+          {#if isLive}<span class="dot go live"></span>streaming{:else}<span class="dot idle"></span>idle{/if}
+        </span>
       </div>
-      <div class="flex-1 min-h-0 p-2">
+      <div class="feed-wrap">
         {#if agentPresence.conversationLog.length === 0 && !isLive}
-          <div class="flex items-center justify-center h-full text-secondary text-sm">
-            Idle. Trigger a run to see live agent activity here.
-          </div>
+          <div class="empty-feed">Idle. Trigger a run to see live agent activity here.</div>
         {:else}
           <AgentActivityFeed maxEntries={200} />
         {/if}
       </div>
-    </div>
+    </section>
 
-    <!-- Side panel: operator message -->
-    <aside class="flex flex-col min-h-0 bg-surface-1">
-      <div class="px-3 py-2 border-b border-border text-xs uppercase tracking-wider text-primary font-semibold">
-        Send message to agent
-      </div>
-      <div class="flex flex-col gap-2 p-3">
-        <textarea
-          bind:value={messageText}
-          onkeydown={handleMessageKey}
-          placeholder={currentRunId
-            ? 'Type a message — the agent picks it up within ~1s. Ctrl/⌘+Enter to send.'
-            : 'No live run. Trigger the agent (header button) to start a run, then send.'}
-          rows="5"
-          data-testid="mc-message-input"
-          class="bg-surface-0 text-primary text-sm px-3 py-2 rounded border border-border
-                 focus:border-border-focus outline-none placeholder:text-secondary font-mono resize-y
-                 disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={sending || !currentRunId}
-        ></textarea>
-        <div class="flex items-center justify-between">
-          <span class="text-[11px] text-secondary">
-            {#if currentRunId}
-              Delivered within ~1s (polled independently of SDK stream).
-            {:else}
-              Messages require a live run — the orchestrator must be active to receive them.
-            {/if}
+    <!-- Side rail: TX + agents -->
+    <aside class="aside">
+      <section>
+        <div class="section-head">
+          <span>TX <span class="sep-light">·</span> Send to Agent</span>
+          <span class="section-head-right mono">
+            {currentRunId ? 'SSE open · ~1s' : 'no live run'}
           </span>
-          <button
-            type="button"
-            onclick={handleSend}
-            data-testid="mc-send-btn"
-            disabled={sending || !messageText.trim() || !currentRunId}
-            title={currentRunId ? 'Send message to the running agent' : 'No live run — message would be lost'}
-            class="px-3 py-1.5 rounded text-xs font-semibold bg-accent-blue/25 text-accent-blue
-                   hover:bg-accent-blue/40 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            {sending ? '…' : 'Send'}
-          </button>
         </div>
-      </div>
-
-      <div class="px-3 py-2 border-t border-border text-xs uppercase tracking-wider text-primary font-semibold mt-2">
-        Agents
-      </div>
-      <div class="flex flex-col gap-1 p-3 text-xs">
-        {#each agentPresence.agents as agent}
-          <div class="flex items-center gap-2">
-            <span class="w-2 h-2 rounded-full" style="background: {agent.color}"></span>
-            <span class="text-primary font-medium">{agent.name}</span>
-            <span class="text-secondary">·</span>
-            <span class="text-secondary">{agent.status}</span>
+        <div class="tx">
+          <div class="tx-prompt mono">
+            <span class="caret">&gt;</span><span>operator@station ~ </span>
           </div>
-        {:else}
-          <span class="text-secondary italic">No active agents</span>
-        {/each}
-      </div>
+          <textarea
+            bind:value={messageText}
+            onkeydown={handleMessageKey}
+            placeholder={currentRunId
+              ? 'Type a message — agent picks it up within ~1s. Ctrl/⌘+Enter to send.'
+              : 'No live run. Trigger the agent (header button) to start a run, then send.'}
+            rows="4"
+            data-testid="mc-message-input"
+            disabled={sending || !currentRunId}
+          ></textarea>
+          <div class="tx-row">
+            <span class="hint mono">
+              {#if currentRunId}
+                <b>⌘+Enter</b> send · delivered within ~1s
+              {:else}
+                Messages require a live run.
+              {/if}
+            </span>
+            <button
+              type="button"
+              class="send-btn"
+              onclick={handleSend}
+              data-testid="mc-send-btn"
+              disabled={sending || !messageText.trim() || !currentRunId}
+              title={currentRunId ? 'Send message to the running agent' : 'No live run — message would be lost'}
+            >
+              {sending ? '…' : 'Send'}
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div class="section-head">
+          <span>Agents</span>
+          <span class="section-head-right mono">{agentPresence.agents.length} linked</span>
+        </div>
+        <div class="agents">
+          {#each agentPresence.agents as agent}
+            <div class="agent-row mono">
+              <span class="dot" style="background: {agent.color}"></span>
+              <span class="name">{agent.name}</span>
+              <span class="muted sep">·</span>
+              <span class="muted">{agent.status}</span>
+            </div>
+          {:else}
+            <div class="empty-mini mono">No active agents.</div>
+          {/each}
+        </div>
+      </section>
     </aside>
   </div>
 </div>
+
+<style>
+  .mc-shell {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--pro-sans);
+  }
+
+  /* ── Header strip ──────────────────────────────────── */
+  .mc-head {
+    display: flex; align-items: center; gap: 18px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--rule);
+    background: var(--paper);
+    flex-shrink: 0;
+  }
+  .mc-head-left { display: flex; flex-direction: column; gap: 3px; }
+  .mc-title {
+    font-family: var(--pro-sans);
+    font-weight: 700; font-size: 11px;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink);
+  }
+  .mc-title .sep { color: var(--ash); margin: 0 4px; }
+  .mc-runid {
+    font-family: var(--pro-mono);
+    font-size: 12px;
+    color: var(--ink);
+  }
+  .mc-runid .muted { color: var(--graphite); }
+  .mc-runid .ended { color: var(--caution); font-size: 9px; text-transform: uppercase; letter-spacing: 0.14em; margin-left: 6px; }
+
+  .mc-head-meta {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    margin-left: 14px;
+    font-family: var(--pro-mono);
+    font-size: 11px;
+    color: var(--graphite);
+  }
+  .mc-head-meta b { color: var(--ink); font-weight: 500; }
+  .mc-head-meta .strong { color: var(--ink); font-weight: 500; }
+  .mc-head-meta .sep { color: var(--ash); }
+  .live-pair { display: inline-flex; align-items: center; gap: 6px; }
+
+  .badge {
+    font-family: var(--pro-sans);
+    font-size: 9px; font-weight: 700;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    padding: 2px 6px;
+    border: 1px solid currentColor;
+  }
+  .badge.caution { color: var(--caution); }
+  .badge.abort   { color: var(--abort); }
+  .badge.data    { color: var(--data); }
+
+  .trigger-btn {
+    margin-left: auto;
+    font-family: var(--pro-sans);
+    font-weight: 700; font-size: 10px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    background: transparent; color: var(--data);
+    border: 1px solid color-mix(in oklab, var(--data) 50%, transparent);
+    padding: 5px 12px; cursor: pointer; height: 28px;
+  }
+  .trigger-btn:hover {
+    background: color-mix(in oklab, var(--data) 12%, var(--paper));
+  }
+
+  /* ── Dot ───────────────────────────────────────────── */
+  .dot {
+    display: inline-block; width: 7px; height: 7px;
+    background: var(--ash); margin-right: 5px; transform: translateY(-1px);
+  }
+  .dot.go { background: var(--go); }
+  .dot.idle { background: var(--ash); }
+  .dot.live { animation: livedot 1.6s steps(2) infinite; }
+  @keyframes livedot { 50% { opacity: .35; } }
+
+  /* ── Plan-review banner ───────────────────────────── */
+  .plan-banner {
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--rule);
+    border-left: 3px solid var(--caution);
+    background: color-mix(in oklab, var(--caution) 12%, var(--paper));
+    font-family: var(--pro-mono);
+    font-size: 12px;
+    color: var(--ink);
+    display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+    flex-shrink: 0;
+  }
+  .plan-banner.approved { border-left-color: var(--go); background: color-mix(in oklab, var(--go) 10%, var(--paper)); }
+  .plan-banner.rejected { border-left-color: var(--abort); background: color-mix(in oklab, var(--abort) 10%, var(--paper)); }
+  .plan-banner .lev {
+    font-family: var(--pro-sans); font-weight: 700;
+    font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--caution);
+  }
+  .plan-banner.approved .lev { color: var(--go); }
+  .plan-banner.rejected .lev { color: var(--abort); }
+  .plan-banner .body { flex: 1; min-width: 0; }
+  .plan-banner .body b { color: var(--ink); font-weight: 500; }
+  .plan-banner .actions { display: flex; gap: 6px; }
+  .banner-btn {
+    font-family: var(--pro-sans);
+    font-weight: 700; font-size: 10px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    background: transparent; color: var(--ink);
+    border: 1px solid var(--rule-2);
+    padding: 3px 10px; cursor: pointer;
+  }
+  .banner-btn:hover:not(:disabled) { background: var(--paper-2); }
+  .banner-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+  .banner-btn.approve { color: var(--go); border-color: color-mix(in oklab, var(--go) 50%, transparent); }
+  .banner-btn.reject  { color: var(--abort); border-color: color-mix(in oklab, var(--abort) 50%, transparent); }
+
+  /* ── Main grid ─────────────────────────────────────── */
+  .mc-main {
+    flex: 1; min-height: 0;
+    display: grid;
+    grid-template-columns: 1fr 360px;
+  }
+  .console {
+    display: flex; flex-direction: column; min-height: 0;
+    border-right: 1px solid var(--rule);
+  }
+  .aside { display: flex; flex-direction: column; min-height: 0; background: var(--paper); }
+  .aside > section + section { border-top: 1px solid var(--rule); }
+
+  /* ── Section head ─────────────────────────────────── */
+  .section-head {
+    height: 30px;
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0 14px;
+    font-family: var(--pro-sans);
+    font-size: 10px; font-weight: 700;
+    letter-spacing: 0.2em; text-transform: uppercase;
+    color: var(--ash);
+    background: var(--paper-2);
+    border-bottom: 1px solid var(--rule);
+    flex-shrink: 0;
+  }
+  .section-head .sep-light { color: var(--ash); }
+  .section-head-right {
+    color: var(--graphite); font-family: var(--pro-mono); font-size: 10px;
+    letter-spacing: 0; text-transform: none;
+    display: flex; gap: 6px; align-items: center;
+  }
+
+  /* ── Feed area ─────────────────────────────────────── */
+  .feed-wrap {
+    flex: 1; min-height: 0;
+    padding: 4px 0;
+    background: var(--paper);
+  }
+  .empty-feed {
+    height: 100%;
+    display: grid; place-items: center;
+    color: var(--ash);
+    font-family: var(--pro-mono);
+    font-size: 12px;
+    padding: 20px;
+  }
+
+  /* ── TX panel ──────────────────────────────────────── */
+  .tx { padding: 12px 14px; display: flex; flex-direction: column; gap: 8px; }
+  .tx-prompt {
+    font-family: var(--pro-mono); font-size: 11px; color: var(--graphite);
+    display: flex; align-items: baseline; gap: 8px;
+  }
+  .tx-prompt .caret { color: var(--ink); font-weight: 700; }
+  .tx textarea {
+    font-family: var(--pro-mono);
+    font-size: 12px; line-height: 1.4;
+    background: var(--paper-2);
+    color: var(--ink);
+    border: 1px solid var(--rule-2);
+    padding: 10px 12px;
+    resize: vertical;
+    min-height: 84px;
+    outline: none;
+    width: 100%;
+  }
+  .tx textarea:focus { border-color: var(--ink); }
+  .tx textarea::placeholder { color: var(--ash); font-style: italic; }
+  .tx textarea:disabled { opacity: 0.5; cursor: not-allowed; }
+
+  .tx-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+  .hint { font-family: var(--pro-mono); font-size: 10px; color: var(--ash); }
+  .hint b { color: var(--graphite); font-weight: 500; }
+
+  .send-btn {
+    font-family: var(--pro-sans);
+    font-weight: 700; font-size: 10px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    background: var(--data); color: var(--paper);
+    border: 1px solid var(--data);
+    padding: 6px 14px; cursor: pointer; height: 28px;
+  }
+  .send-btn:hover:not(:disabled) { filter: brightness(1.08); }
+  .send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+  /* ── Agents roster ─────────────────────────────────── */
+  .agents { padding: 6px 0 8px; }
+  .agent-row {
+    display: flex; align-items: center; gap: 8px;
+    padding: 5px 14px;
+    font-family: var(--pro-mono); font-size: 12px;
+  }
+  .agent-row:hover { background: var(--paper-2); }
+  .agent-row .name { color: var(--ink); }
+  .agent-row .muted { color: var(--graphite); }
+  .agent-row .sep { color: var(--ash); }
+  .empty-mini {
+    padding: 12px 14px;
+    color: var(--ash); font-style: italic;
+    font-family: var(--pro-mono); font-size: 12px;
+  }
+
+  @media (max-width: 1100px) {
+    .mc-main { grid-template-columns: 1fr; }
+    .console { border-right: none; }
+    .aside { border-top: 1px solid var(--rule); }
+  }
+</style>


### PR DESCRIPTION
## Summary

Restyle the operator's live console using the new paper/ink token system. **Behavior, data flow, intervention semantics, plan-review gate logic, and SSE wiring are unchanged** — this is a typography and chrome change only.

Stacked on **#300** (foundation).

## What changed

* **Header strip** — Bricolage Grotesque caps for the title + JetBrains Mono for telemetry. Live indicator uses the new paper/ink dot system. Same status badges (paused / global pause / pending decisions), but as outlined pills instead of saturated tints.
* **TX panel** reads as a real terminal prompt (`> operator@station ~`) with a mono textarea. `⌘+Enter` still sends; same `messageRun(currentRunId, text)` call.
* **Plan-review banner** uses outlined caution/go/abort variants — no more white-on-saturated tile that fought against the rest of the surface.
* **Activity feed** (`AgentActivityFeed`) and **InterventionBar** are unchanged — they'll get their own PRs so this one stays reviewable. The page composes them as before.

## What's preserved

* Every data-testid: `mc-run-id`, `mc-message-input`, `mc-send-btn`, `plan-review-banner`, `plan-review-approve-btn`, `plan-review-reject-btn`.
* Plan-review gate state machine (awaiting / reviewing / approved / rejected) and the `operatorApproveRunPlan` / `operatorRejectRunPlan` calls.
* Pause / global-pause / pending-decisions surfacing.
* Trigger-run fallback when no live run.
* `agentPresence` integration — same `currentRunId`/`currentRun`/`isLive`/`runPaused`/`pendingDecisions` derivations.

## Test plan

- [x] `npm run build` succeeds; CSS gains 0.8 KB gzipped
- [ ] Manual: load Mission Control with a live run, confirm activity feed streams, intervention buttons work
- [ ] Manual: load with no live run, confirm "no active run" + Trigger button shown
- [ ] Manual: trip a `plan_only` → `awaiting_plan_review` state and verify Approve/Reject still wire correctly

## Follow-ups (each its own PR)

1. Run Detail
2. Queue Board
3. Fleet (was Agent Teams)
4. Projects + Project Detail
5. Settings (folds Audit in)
6. Dispatch (replaces CommandCenter, drops RunsPage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)