### PR TITLE
feat(ui): migrate Projects + Project Detail to Pro design

### DIFF
--- a/dashboard/frontend/src/pages/ProjectDetail.svelte
+++ b/dashboard/frontend/src/pages/ProjectDetail.svelte
@@ -52,23 +52,28 @@
   }
 </script>
 
-<div class="space-y-6 animate-fade-in-up max-w-3xl">
+<div class="space-y-6 animate-fade-in-up max-w-3xl project-detail-pro">
   {#if loading}
     <div class="text-sm text-tertiary">Loading...</div>
   {:else if !project}
     <div class="text-sm text-tertiary">Project not found</div>
   {:else}
-    <div class="flex items-center justify-between">
-      <h1 class="text-lg font-semibold text-primary">{project.repo}</h1>
-      <button onclick={handleDelete} class="text-xs text-reject hover:text-reject/80 transition-colors">Delete</button>
+    <div class="pd-crumb">
+      <a href="/projects">← Projects</a>
+      <span class="sep">/</span>
+      <b>{project.repo}</b>
+    </div>
+    <div class="pd-page-head">
+      <h1 class="pd-title mono">{project.repo}</h1>
+      <button onclick={handleDelete} class="pd-delete-btn">Delete</button>
     </div>
 
-    <!-- Tab strip -->
-    <div class="flex gap-1" style="border-bottom: 1px solid var(--color-border);">
+    <!-- Tab strip (Pro) -->
+    <div class="pd-tabs">
       {#each ['overview', 'vision', 'runs'] as t}
         <button
-          class="px-4 py-2.5 text-xs font-medium capitalize transition-colors cursor-pointer"
-          style="{activeTab === t ? 'color: var(--color-primary); border-bottom: 2px solid var(--color-violet);' : 'color: var(--color-tertiary); border-bottom: 2px solid transparent;'}"
+          class="pd-tab"
+          class:active={activeTab === t}
           onclick={() => activeTab = t as 'overview' | 'vision' | 'runs'}
         >{t}</button>
       {/each}
@@ -201,3 +206,74 @@
     {/if}
   {/if}
 </div>
+
+<style>
+  .project-detail-pro :global(.pd-crumb) {
+    display: flex; align-items: center; gap: 10px;
+    font-family: var(--pro-mono); font-size: 11px;
+    color: var(--graphite);
+    padding-bottom: 4px;
+  }
+  .project-detail-pro :global(.pd-crumb a) {
+    color: var(--graphite); text-decoration: none;
+  }
+  .project-detail-pro :global(.pd-crumb a:hover) { color: var(--ink); }
+  .project-detail-pro :global(.pd-crumb b) { color: var(--ink); font-weight: 500; }
+  .project-detail-pro :global(.pd-crumb .sep) { color: var(--ash); }
+
+  .project-detail-pro :global(.pd-page-head) {
+    display: flex; align-items: center; justify-content: space-between;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .project-detail-pro :global(.pd-title) {
+    margin: 0;
+    font-family: var(--pro-mono);
+    font-size: 18px; font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    word-break: break-all;
+  }
+  .project-detail-pro :global(.pd-delete-btn) {
+    font-family: var(--pro-sans);
+    font-weight: 700; font-size: 10px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    background: transparent; color: var(--abort);
+    border: 1px solid color-mix(in oklab, var(--abort) 50%, transparent);
+    padding: 4px 10px; cursor: pointer; height: 24px;
+  }
+  .project-detail-pro :global(.pd-delete-btn:hover) {
+    background: color-mix(in oklab, var(--abort) 12%, var(--paper));
+  }
+
+  .project-detail-pro :global(.pd-tabs) {
+    display: flex; gap: 0;
+    border-bottom: 1px solid var(--rule);
+  }
+  .project-detail-pro :global(.pd-tab) {
+    font-family: var(--pro-sans);
+    font-size: 11px; font-weight: 700;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--graphite);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 10px 14px;
+    cursor: pointer;
+  }
+  .project-detail-pro :global(.pd-tab:hover) { color: var(--ink); }
+  .project-detail-pro :global(.pd-tab.active) {
+    color: var(--ink);
+    border-bottom-color: var(--ink);
+  }
+
+  /* Flatten glassmorphic .glass cards */
+  .project-detail-pro :global(.glass) {
+    background: var(--paper-2) !important;
+    border: 1px solid var(--rule) !important;
+    border-radius: 0 !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    box-shadow: none !important;
+  }
+</style>

--- a/dashboard/frontend/src/pages/ProjectsPage.svelte
+++ b/dashboard/frontend/src/pages/ProjectsPage.svelte
@@ -152,10 +152,11 @@
   }
 </script>
 
-<div class="space-y-4 animate-fade-in">
-  <div class="flex items-center justify-between">
-    <h1 class="font-heading text-xl">Projects</h1>
-    <button onclick={openCreateModal} class="btn btn-primary btn-sm">
+<div class="space-y-4 animate-fade-in projects-pro">
+  <div class="pp-page-head">
+    <h1 class="pp-title">Projects</h1>
+    <span class="pp-meta">{projects.length} project{projects.length === 1 ? '' : 's'}</span>
+    <button onclick={openCreateModal} class="pp-add-btn">
       + Add Project
     </button>
   </div>
@@ -336,3 +337,50 @@
     </div>
   {/if}
 </Modal>
+
+
+<style>
+  /* Pro restyle for the page chrome */
+  .projects-pro :global(.pp-page-head) {
+    display: flex; align-items: center; gap: 14px;
+    padding: 6px 0 10px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .projects-pro :global(.pp-title) {
+    margin: 0;
+    font-family: var(--pro-sans);
+    font-size: 14px; font-weight: 700;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink);
+  }
+  .projects-pro :global(.pp-meta) {
+    font-family: var(--pro-mono);
+    font-size: 11px; color: var(--graphite);
+  }
+  .projects-pro :global(.pp-add-btn) {
+    margin-left: auto;
+    font-family: var(--pro-sans);
+    font-weight: 700; font-size: 10px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    background: var(--ink); color: var(--paper);
+    border: 1px solid var(--ink);
+    padding: 5px 11px; cursor: pointer; height: 26px;
+  }
+  .projects-pro :global(.pp-add-btn:hover) { filter: brightness(1.1); }
+
+  /* Flatten card glassmorphism on project tiles */
+  .projects-pro :global(.card) {
+    background: var(--paper-2) !important;
+    border: 1px solid var(--rule) !important;
+    border-radius: 0 !important;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    box-shadow: none !important;
+    transition: border-color 200ms ease, transform 0ms !important;
+  }
+  .projects-pro :global(.card:hover) {
+    border-color: var(--rule-2) !important;
+    transform: none !important;
+    box-shadow: none !important;
+  }
+</style>


### PR DESCRIPTION
## Summary

Pro restyle of both project pages: page chrome, tab strips, and flattening of the `.glass` / `.card` glassmorphic surfaces. Functional behavior (toggle enabled, autonomy selector, mode switcher, delete, runs list, vision-tab embed) is unchanged.

Stacked on **#304** (Fleet cards).

## What changed — `ProjectsPage`

* Page header is a stencil-cap `Projects` + project count + paper-on-ink **Add Project** button.
* Project tiles flatten to `paper-2` surface + hairline border. Hover raises border opacity (no shadow / transform / scale).
* Modal create-project wizard untouched.

## What changed — `ProjectDetail`

* New breadcrumb strip (`← Projects / repo`).
* Page header: repo name in `JetBrains Mono` 18 px (was 18 px sans). Delete button is now an outlined abort-red pill instead of an inline text link, harder to misclick.
* Tabs: ink underline on active (was violet pill). `overview` / `vision` / `runs` unchanged structurally.
* All `.glass` cards on the page flatten to `paper-2` + hairline.

## Test plan

- [x] `npm run build` succeeds; CSS gains 0.4 KB gzipped (14 → 14.3 KB)
- [ ] Manual: toggle enable on a project — confirm switch still works, badge color updates
- [ ] Manual: open project detail, switch tabs, confirm overview / vision / runs all render
- [ ] Manual: try Delete (cancel the confirm) — confirm no destructive side effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)