### PR TITLE
feat(ui): migrate Dispatch + header to Pro design (data-wired)

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -41,6 +41,11 @@ from app.schemas import (
     RunOut,
     TeamSummary,
     TeammateStatus,
+    TelemetryActive,
+    TelemetryQueue,
+    TelemetrySummaryOut,
+    TelemetrySystem,
+    TelemetryTokens7d,
 )
 from app.services import service_control
 from app.services.diff_parser import DiffResult, parse_unified_diff
@@ -167,6 +172,149 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
 async def get_active_teammates(db: AsyncSession = Depends(get_db)):
     """Alias for active-employees using Agent Teams terminology."""
     return await get_active_employees(db)
+
+
+@router.get("/telemetry-summary", response_model=TelemetrySummaryOut)
+async def get_telemetry_summary(db: AsyncSession = Depends(get_db)):
+    """Aggregate the four telemetry cells on the Dispatch board:
+    Active runs, Queue stats, Tokens (7d) summary + sparkline,
+    and a coarse System health label derived from disk/memory.
+    """
+    from datetime import timedelta
+
+    from app.services.systemd import get_system_resources
+
+    # --- 1. Active runs / teammates / roles ---
+    active_runs_res = await db.execute(
+        select(Run).where(Run.status.in_(["running", "plan_reviewing", "reviewing"]))
+    )
+    active_runs = active_runs_res.scalars().all()
+
+    roles: list[str] = []
+    teammates_count = 0
+    if active_runs:
+        for r in active_runs:
+            members_raw = r.team_members
+            if not members_raw:
+                continue
+            try:
+                members = json.loads(members_raw) if isinstance(members_raw, str) else members_raw
+                if isinstance(members, list):
+                    teammates_count += len(members)
+                    for m in members:
+                        name = (m.get("name") if isinstance(m, dict) else str(m)) or ""
+                        for tag in ("backend", "frontend", "qa", "lead"):
+                            if tag in name.lower() and tag not in roles:
+                                roles.append(tag)
+            except Exception:  # noqa: BLE001 — best-effort introspection
+                continue
+
+        # Fallback: derive from running coordinator tasks if team_members was empty.
+        if teammates_count == 0:
+            ct_res = await db.execute(
+                select(CoordinatorTask).where(
+                    CoordinatorTask.status == "running",
+                    CoordinatorTask.run_id.in_([r.run_id for r in active_runs]),
+                )
+            )
+            tasks = ct_res.scalars().all()
+            teammates_count = len(tasks)
+            for t in tasks:
+                name = (t.claimed_by or t.teammate_agent_id or "") or ""
+                for tag in ("backend", "frontend", "qa", "lead"):
+                    if tag in name.lower() and tag not in roles:
+                        roles.append(tag)
+
+    active = TelemetryActive(
+        count=len(active_runs),
+        teammates=teammates_count,
+        roles=roles,
+    )
+
+    # --- 2. Queue stats ---
+    qstate_res = await db.execute(
+        select(QueueItem.state, func.count(QueueItem.id)).group_by(QueueItem.state)
+    )
+    by_state = {row[0]: row[1] for row in qstate_res.all()}
+    claimed = (
+        by_state.get("claimed", 0)
+        + by_state.get("assigned", 0)
+        + by_state.get("planning", 0)
+        + by_state.get("in_progress", 0)
+    )
+    done = by_state.get("completed", 0) + by_state.get("approved", 0)
+    pending = by_state.get("pending", 0)
+    queue_total = sum(by_state.values())
+
+    queue = TelemetryQueue(total=queue_total, claimed=claimed, done=done, pending=pending)
+
+    # --- 3. Tokens (7d) — sum, run count, in/out, sparkline ---
+    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+    daily_q = (
+        select(
+            func.date(Run.started_at).label("date"),
+            func.coalesce(func.sum(Run.tokens_total), 0).label("tot"),
+        )
+        .where(Run.started_at >= cutoff)
+        .group_by(func.date(Run.started_at))
+        .order_by(func.date(Run.started_at))
+    )
+    daily_rows = (await db.execute(daily_q)).all()
+    spark = [int(row.tot or 0) for row in daily_rows]
+
+    sum_q = (
+        select(
+            func.coalesce(func.sum(Run.tokens_total), 0),
+            func.coalesce(func.sum(Run.tokens_input), 0),
+            func.coalesce(func.sum(Run.tokens_output), 0),
+            func.count(Run.id),
+        ).where(Run.started_at >= cutoff)
+    )
+    sum_row = (await db.execute(sum_q)).first()
+    tot7, in7, out7, runs7 = (sum_row[0] or 0, sum_row[1] or 0, sum_row[2] or 0, sum_row[3] or 0)
+
+    tokens_7d = TelemetryTokens7d(
+        total=int(tot7),
+        runs=int(runs7),
+        input=int(in7),
+        output=int(out7),
+        spark=spark,
+    )
+
+    # --- 4. System status ---
+    try:
+        resources = await get_system_resources()
+    except Exception:  # noqa: BLE001
+        resources = {}
+
+    disk_free = resources.get("disk_free_gb")
+    mem_used = resources.get("memory_used_mb")
+    mem_total = resources.get("memory_total_mb")
+    uptime = resources.get("uptime_seconds")
+    mem_pct: int | None = None
+    if mem_used is not None and mem_total:
+        mem_pct = int(round(100 * mem_used / mem_total))
+
+    status_label = "NOMINAL"
+    # CRIT thresholds
+    if (disk_free is not None and disk_free < 1) or (mem_pct is not None and mem_pct > 90):
+        status_label = "CRIT"
+    elif (disk_free is not None and disk_free < 5) or (mem_pct is not None and mem_pct > 70):
+        status_label = "DEGR"
+
+    system = TelemetrySystem(
+        status=status_label,
+        disk_free_gb=disk_free,
+        memory_used_pct=mem_pct,
+        uptime_secs=uptime,
+    )
+
+    return TelemetrySummaryOut(
+        active=active,
+        queue=queue,
+        tokens_7d=tokens_7d,
+        system=system,
+    )
 
 
 @router.get("/latest", response_model=Optional[RunOut])

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -491,6 +491,43 @@ class QueueStats(BaseModel):
     avg_time_to_complete_ms: float | None = None
 
 
+# --- Dispatch telemetry ---
+
+class TelemetryActive(BaseModel):
+    count: int
+    teammates: int
+    roles: list[str] = []
+
+
+class TelemetryQueue(BaseModel):
+    total: int
+    claimed: int
+    done: int
+    pending: int
+
+
+class TelemetryTokens7d(BaseModel):
+    total: int
+    runs: int
+    input: int
+    output: int
+    spark: list[int] = []
+
+
+class TelemetrySystem(BaseModel):
+    status: str  # NOMINAL | DEGR | CRIT
+    disk_free_gb: float | None = None
+    memory_used_pct: int | None = None
+    uptime_secs: float | None = None
+
+
+class TelemetrySummaryOut(BaseModel):
+    active: TelemetryActive
+    queue: TelemetryQueue
+    tokens_7d: TelemetryTokens7d
+    system: TelemetrySystem
+
+
 # --- Analytics ---
 
 class DailyTokenUsage(BaseModel):

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -323,3 +323,79 @@ async def test_get_run_full_context_multiple_queue_items(client):
     # Backwards-compat: ``queue_item`` is the first item (by id), not None
     assert data["queue_item"] is not None
     assert data["queue_item"]["issue_number"] == 42
+
+
+@pytest.mark.asyncio
+async def test_telemetry_summary_shape_empty(client):
+    """GET /api/runs/telemetry-summary returns the four-cell shape even on
+    a brand-new station with no runs and no queue rows."""
+    resp = await client.get("/api/runs/telemetry-summary")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert set(data.keys()) == {"active", "queue", "tokens_7d", "system"}
+
+    assert data["active"]["count"] == 0
+    assert data["active"]["teammates"] == 0
+    assert data["active"]["roles"] == []
+
+    assert data["queue"]["total"] == 0
+    assert data["queue"]["claimed"] == 0
+    assert data["queue"]["done"] == 0
+    assert data["queue"]["pending"] == 0
+
+    assert data["tokens_7d"]["total"] == 0
+    assert data["tokens_7d"]["runs"] == 0
+    assert isinstance(data["tokens_7d"]["spark"], list)
+
+    # System status is NOMINAL when get_system_resources returns nothing
+    # actionable (e.g. test environment without /proc/meminfo).
+    assert data["system"]["status"] in {"NOMINAL", "DEGR", "CRIT"}
+
+
+@pytest.mark.asyncio
+async def test_telemetry_summary_aggregates_runs_and_queue(client):
+    """Endpoint reflects active runs, queue states, and 7d token totals."""
+    from app.database import async_session
+    from app.models import QueueItem, Run
+
+    async with async_session() as s:
+        s.add(Run(
+            run_id="run-tel-active",
+            status="running",
+            started_at=datetime.now(timezone.utc),
+            tokens_total=500,
+            tokens_input=100,
+            tokens_output=400,
+            team_members='[{"name": "backend-spright"}, {"name": "frontend-spright"}]',
+        ))
+        s.add(Run(
+            run_id="run-tel-old",
+            status="completed",
+            started_at=datetime.now(timezone.utc) - timedelta(days=2),
+            tokens_total=300, tokens_input=50, tokens_output=250,
+        ))
+        s.add_all([
+            QueueItem(project_repo="x/y", issue_number=1, mode="full", state="pending"),
+            QueueItem(project_repo="x/y", issue_number=2, mode="full", state="claimed"),
+            QueueItem(project_repo="x/y", issue_number=3, mode="full", state="completed"),
+        ])
+        await s.commit()
+
+    resp = await client.get("/api/runs/telemetry-summary")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+
+    assert data["active"]["count"] == 1
+    assert data["active"]["teammates"] == 2
+    assert sorted(data["active"]["roles"]) == ["backend", "frontend"]
+
+    assert data["queue"]["pending"] == 1
+    assert data["queue"]["claimed"] == 1
+    assert data["queue"]["done"] == 1
+    assert data["queue"]["total"] == 3
+
+    assert data["tokens_7d"]["total"] == 800
+    assert data["tokens_7d"]["runs"] == 2
+    assert data["tokens_7d"]["input"] == 150
+    assert data["tokens_7d"]["output"] == 650

--- a/dashboard/frontend/src/components/layout/Shell.svelte
+++ b/dashboard/frontend/src/components/layout/Shell.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import VaporBackground from '../background/VaporBackground.svelte';
   import TopNav from './TopNav.svelte';
+  import { route } from '../../lib/router.svelte';
   import type { Snippet } from 'svelte';
 
   let {
@@ -16,6 +17,14 @@
     sseConnected?: boolean;
     activeCount?: number;
   } = $props();
+
+  // The Pro Dispatch board owns its own dense, edge-to-edge layout
+  // (strip + ticker + filters + telemetry + board + footer). Drop the
+  // shell's max-width / padding container for it so the bleed isn't
+  // boxed in. Other pages keep the centered, padded canvas.
+  let isDispatch = $derived(
+    route.page === 'command-center' || route.page === 'runs'
+  );
 </script>
 
 <VaporBackground />
@@ -30,7 +39,11 @@
 <main
   id="main-content"
   class="relative overflow-x-hidden"
-  style="z-index: 1; padding: 28px 32px 48px; min-height: calc(100vh - 54px); max-width: 1600px; margin: 0 auto;"
+  style:z-index="1"
+  style:min-height="calc(100vh - 40px)"
+  style:padding={isDispatch ? '0' : '28px 32px 48px'}
+  style:max-width={isDispatch ? 'none' : '1600px'}
+  style:margin={isDispatch ? '0' : '0 auto'}
 >
   {@render children()}
 </main>

--- a/dashboard/frontend/src/components/layout/TopNav.svelte
+++ b/dashboard/frontend/src/components/layout/TopNav.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { route, navigate } from '../../lib/router.svelte';
   import { agentPresence } from '../../lib/agent-presence.svelte';
-  import { formatTokens } from '../../lib/format';
+  import { appearance, setTheme } from '../../lib/appearance.svelte';
+  import { pauseAll } from '../../lib/api';
+  import { addToast } from '../../lib/toast.svelte';
 
   let {
     onTrigger,
@@ -22,6 +24,12 @@
     agentPresence.activeRuns[0]?.tokens_total ?? agentPresence.tokensBurned ?? 0
   );
 
+  function fmtTok(n: number): string {
+    if (!n) return '0';
+    if (n < 1000) return String(n);
+    return (n / 1000).toFixed(n < 10000 ? 1 : 0) + 'K';
+  }
+
   const navItems = [
     { label: 'Dispatch', page: 'command-center', path: '/' },
     { label: 'Mission', page: 'mission-control', path: '/mission-control' },
@@ -32,86 +40,113 @@
   ] as const;
 
   function isActive(page: string): boolean {
-    // Dispatch absorbs the old Runs surface — runs and run-detail
-    // both highlight the Dispatch tab.
     if (page === 'command-center') {
-      return route.page === 'command-center' || route.page === 'runs' || route.page === 'run-detail';
+      return route.page === 'command-center'
+        || route.page === 'runs'
+        || route.page === 'run-detail';
     }
     if (page === 'queue') return route.page === 'queue' || route.page === 'queue-detail';
     if (page === 'projects') return route.page === 'projects' || route.page === 'project-detail';
     return route.page === page;
   }
+
+  function toggleTheme() {
+    setTheme(appearance.theme === 'dark' ? 'light' : 'dark');
+  }
+
+  let stopping = $state(false);
+  async function handleStop() {
+    if (stopping) return;
+    if (activeCount === 0) {
+      // Idle — the Stop button doubles as the legacy trigger so the slot
+      // isn't dead between runs.
+      onTrigger?.();
+      return;
+    }
+    stopping = true;
+    try {
+      await pauseAll();
+      addToast('success', 'Global pause engaged — all agents will defer to the permission tray.');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Pause failed';
+      addToast('error', msg);
+    } finally {
+      stopping = false;
+    }
+  }
 </script>
 
-<nav
-  class="sticky top-0 z-50 flex items-center justify-between"
-  style="padding: 12px 28px; background: rgba(255,245,238,0.65); backdrop-filter: blur(24px) saturate(1.3); -webkit-backdrop-filter: blur(24px) saturate(1.3); border-bottom: 1px solid rgba(255,255,255,0.4); box-shadow: 0 4px 16px rgba(0,0,0,0.03);"
-  aria-label="Main navigation"
->
-  <!-- Left: Logo + Title -->
-  <div class="flex items-center gap-2.5">
-    <div
-      class="flex items-center justify-center"
-      style="width: 30px; height: 30px; border-radius: 9px; background: linear-gradient(135deg, #4A3728, #5C4435); font-weight: 800; font-size: 13px; color: #FFF5EE; box-shadow: 0 2px 8px rgba(74,55,40,0.12); animation: logo-glow 4s ease-in-out infinite;"
-    >C</div>
-    <span style="font-size: 15px; font-weight: 700; color: #3D2A1A;">Claude Station</span>
+<header class="strip" aria-label="Main navigation">
+  <div class="wordmark">
+    <span class="name">Station</span>
+    <span class="tag">OPERATOR · v1</span>
   </div>
 
-  <!-- Center: Nav Pills -->
-  <div
-    class="flex gap-0.5"
-    style="background: rgba(255,255,255,0.60); backdrop-filter: blur(12px); border: 1px solid rgba(255,255,255,0.7); border-radius: 14px; padding: 4px;"
-  >
+  <nav class="strip-nav">
     {#each navItems as item}
       <button
+        type="button"
         onclick={() => navigate(item.path)}
-        class="nav-pill"
         class:active={isActive(item.page)}
         aria-current={isActive(item.page) ? 'page' : undefined}
-        style="padding: 8px 20px; border-radius: 10px; font-size: 13px; font-weight: {isActive(item.page) ? '700' : '500'}; color: {isActive(item.page) ? '#4A3728' : '#9E8872'}; background: {isActive(item.page) ? 'white' : 'transparent'}; box-shadow: {isActive(item.page) ? '0 1px 4px rgba(0,0,0,0.06)' : 'none'}; border: none; cursor: pointer; font-family: inherit; transition: all 0.2s ease;"
-      >
-        {item.label}
-      </button>
+      >{item.label}</button>
     {/each}
-  </div>
+  </nav>
 
-  <!-- Right: Status + Trigger -->
-  <div class="flex items-center gap-3.5">
-    <div class="flex items-center gap-2.5" style="font-size: 12px; color: #8C7A66;">
-      <div class="flex items-center gap-1.5">
-        <div
-          style="width: 7px; height: 7px; border-radius: 50%; background: {activeCount > 0 ? '#2E7D32' : '#22C55E'}; position: relative;"
-        >
-          <div style="position: absolute; inset: -3px; border-radius: 50%; background: rgba(34,197,94,0.2); animation: pulse-ring 2.5s ease-out infinite;"></div>
-        </div>
-        <span>{activeCount > 0 ? `Working (${activeCount})` : 'Idle'}</span>
-      </div>
-      {#if liveTokens > 0}
-        <span style="color: #A08E7A;">·</span>
-        <span
-          data-testid="topnav-live-tokens"
-          title="Tokens burned on the live (or last) run"
-          style="font-variant-numeric: tabular-nums; color: #4E3A26; font-weight: 600;"
-        >{formatTokens(liveTokens)} tok</span>
-      {/if}
-      <span style="color: #A08E7A;">·</span>
-      <span style="color: {sseConnected ? '#2E7D32' : '#D06050'}; font-weight: 600;">SSE</span>
-    </div>
+  <div class="strip-status">
+    <span>
+      <span class="dot {activeCount > 0 ? 'go live' : ''}"></span>
+      <span class="pill">{activeCount > 0 ? `WORKING · ${activeCount}` : 'IDLE'}</span>
+    </span>
+
+    <span
+      data-testid="topnav-live-tokens"
+      title="Tokens burned on the live (or last) run"
+      style="font-variant-numeric: tabular-nums;"
+    >{fmtTok(liveTokens)} TOK</span>
+
+    <span>
+      SSE&nbsp;<b style="color: {sseConnected ? 'var(--go)' : 'var(--abort)'};">●</b>
+    </span>
 
     <button
-      onclick={onTrigger}
-      disabled={triggering}
-      class="trigger-btn"
-      style="padding: 10px 22px; border: none; border-radius: 12px; font-size: 14px; font-weight: 700; font-family: inherit; cursor: pointer; background: linear-gradient(135deg, #4A3728 0%, #5C4435 100%); color: #FFF5EE; box-shadow: 0 2px 8px rgba(74,55,40,0.18); transition: transform 0.15s, box-shadow 0.2s; opacity: {triggering ? '0.7' : '1'};"
+      type="button"
+      class="btn-theme"
+      onclick={toggleTheme}
+      aria-label="Toggle theme"
+      title="Toggle theme (t)"
     >
-      {triggering ? '⏳ Triggering...' : '▶ Trigger Run'}
+      {#if appearance.theme === 'dark'}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="4"/>
+          <line x1="12" y1="2" x2="12" y2="5"/>
+          <line x1="12" y1="19" x2="12" y2="22"/>
+          <line x1="4.2" y1="4.2" x2="6.3" y2="6.3"/>
+          <line x1="17.7" y1="17.7" x2="19.8" y2="19.8"/>
+          <line x1="2" y1="12" x2="5" y2="12"/>
+          <line x1="19" y1="12" x2="22" y2="12"/>
+          <line x1="4.2" y1="19.8" x2="6.3" y2="17.7"/>
+          <line x1="17.7" y1="6.3" x2="19.8" y2="4.2"/>
+        </svg>
+      {:else}
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z"/>
+        </svg>
+      {/if}
+    </button>
+
+    <button
+      type="button"
+      class="btn-stop"
+      onclick={handleStop}
+      disabled={stopping || triggering}
+      title={activeCount > 0 ? 'Engage global pause (Cmd+. or Ctrl+.)' : 'Trigger run'}
+    >
+      {#if activeCount > 0}
+        Stop <kbd>⌘.</kbd>
+      {:else}
+        {triggering ? '…' : 'Run'}
+      {/if}
     </button>
   </div>
-</nav>
-
-<style>
-  .trigger-btn:not(:disabled):hover {
-    transform: scale(1.04);
-    box-shadow: 0 4px 20px rgba(74, 55, 40, 0.25);
-  }
-</style>
+</header>

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   AnalyticsResponse, DiffResult, PlanUsage,
   PromptInfo, StationConfig, TokenUsage,
   AgentEvent, Notification,
+  TelemetrySummary,
   VisionRead, VisionDoc, VisionCommitOut, VisionChatSession, VisionProposals,
 } from './types';
 
@@ -184,6 +185,9 @@ export const listRuns = (params?: {
 
 export const getActiveEmployees = () =>
   request<ActiveEmployee[]>('/api/runs/active-employees');
+
+export const getTelemetrySummary = () =>
+  request<TelemetrySummary>('/api/runs/telemetry-summary');
 
 export const getActiveTeammates = () =>
   request<ActiveEmployee[]>('/api/runs/active-teammates');

--- a/dashboard/frontend/src/lib/design/flap.ts
+++ b/dashboard/frontend/src/lib/design/flap.ts
@@ -1,0 +1,65 @@
+/**
+ * Pro flap renderer — the single-character split-flap intro animation
+ * shared across the Pro design drafts. Mounts a `.flap` span with one
+ * child `<span>` per character, each with a staggered animation-delay.
+ *
+ * Use as a Svelte action:
+ *
+ *     <span use:flap={{ text: 'HELLO', baseDelay: 80 }}></span>
+ *
+ * Or as a plain helper that returns a Node, mirroring the drafts API:
+ *
+ *     el.appendChild(flapNode('HELLO', 80));
+ *
+ * Disabled when the user prefers reduced motion: characters render
+ * immediately with no transform animation.
+ */
+
+const REDUCED_MOTION = typeof window !== 'undefined'
+  && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+
+export interface FlapOptions {
+  text: string;
+  baseDelay?: number;
+  charSpacingMs?: number;
+}
+
+/** Build the inner DOM (children of a `.flap` host) for a flap animation. */
+function buildChars(host: HTMLElement, text: string, baseDelay: number, charSpacingMs: number) {
+  host.classList.add('flap');
+  host.textContent = '';
+  for (let i = 0; i < text.length; i++) {
+    const s = document.createElement('span');
+    s.textContent = text[i] === ' ' ? ' ' : text[i];
+    if (!REDUCED_MOTION) {
+      s.style.animationDelay = `${baseDelay + i * charSpacingMs}ms`;
+    }
+    host.appendChild(s);
+  }
+}
+
+/**
+ * Svelte action: re-renders flap chars whenever the parameter changes.
+ *
+ *     <span use:flap={{ text: '03', baseDelay: 60 }}></span>
+ */
+export function flap(node: HTMLElement, params: FlapOptions) {
+  let { text, baseDelay = 0, charSpacingMs = 18 } = params;
+  buildChars(node, text, baseDelay, charSpacingMs);
+  return {
+    update(next: FlapOptions) {
+      if (next.text === text && (next.baseDelay ?? 0) === baseDelay) return;
+      text = next.text;
+      baseDelay = next.baseDelay ?? 0;
+      charSpacingMs = next.charSpacingMs ?? 18;
+      buildChars(node, text, baseDelay, charSpacingMs);
+    },
+  };
+}
+
+/** Imperative helper mirroring the drafts' `flap()` — returns a new element. */
+export function flapNode(text: string, baseDelay = 0, charSpacingMs = 18): HTMLElement {
+  const wrap = document.createElement('span');
+  buildChars(wrap, text, baseDelay, charSpacingMs);
+  return wrap;
+}

--- a/dashboard/frontend/src/lib/design/flap.ts
+++ b/dashboard/frontend/src/lib/design/flap.ts
@@ -24,14 +24,31 @@ export interface FlapOptions {
   charSpacingMs?: number;
 }
 
-/** Build the inner DOM (children of a `.flap` host) for a flap animation. */
-function buildChars(host: HTMLElement, text: string, baseDelay: number, charSpacingMs: number) {
+/** Build the inner DOM (children of a `.flap` host) for a flap animation.
+ *
+ * When `animate` is false, the staggered per-character animation is
+ * suppressed entirely — used on Svelte action `update()` calls so cell
+ * value changes during polling pop in cleanly without re-flapping the
+ * full board on every refresh.
+ */
+function buildChars(
+  host: HTMLElement,
+  text: string,
+  baseDelay: number,
+  charSpacingMs: number,
+  animate: boolean = true,
+) {
   host.classList.add('flap');
   host.textContent = '';
+  const skipAnim = !animate || REDUCED_MOTION;
   for (let i = 0; i < text.length; i++) {
     const s = document.createElement('span');
-    s.textContent = text[i] === ' ' ? ' ' : text[i];
-    if (!REDUCED_MOTION) {
+    s.textContent = text[i] === ' ' ? ' ' : text[i];
+    if (skipAnim) {
+      // Disable the CSS @keyframes flap so polling-driven updates don't
+      // re-trigger the intro animation across a 50-row board.
+      s.style.animation = 'none';
+    } else {
       s.style.animationDelay = `${baseDelay + i * charSpacingMs}ms`;
     }
     host.appendChild(s);
@@ -42,17 +59,21 @@ function buildChars(host: HTMLElement, text: string, baseDelay: number, charSpac
  * Svelte action: re-renders flap chars whenever the parameter changes.
  *
  *     <span use:flap={{ text: '03', baseDelay: 60 }}></span>
+ *
+ * Initial mount runs the staggered flap intro. Subsequent `update()`
+ * calls (driven by reactive param changes during polling) rebuild the
+ * chars without animation, so values change visibly but don't churn.
  */
 export function flap(node: HTMLElement, params: FlapOptions) {
   let { text, baseDelay = 0, charSpacingMs = 18 } = params;
-  buildChars(node, text, baseDelay, charSpacingMs);
+  buildChars(node, text, baseDelay, charSpacingMs, true);
   return {
     update(next: FlapOptions) {
       if (next.text === text && (next.baseDelay ?? 0) === baseDelay) return;
       text = next.text;
       baseDelay = next.baseDelay ?? 0;
       charSpacingMs = next.charSpacingMs ?? 18;
-      buildChars(node, text, baseDelay, charSpacingMs);
+      buildChars(node, text, baseDelay, charSpacingMs, false);
     },
   };
 }
@@ -60,6 +81,6 @@ export function flap(node: HTMLElement, params: FlapOptions) {
 /** Imperative helper mirroring the drafts' `flap()` — returns a new element. */
 export function flapNode(text: string, baseDelay = 0, charSpacingMs = 18): HTMLElement {
   const wrap = document.createElement('span');
-  buildChars(wrap, text, baseDelay, charSpacingMs);
+  buildChars(wrap, text, baseDelay, charSpacingMs, true);
   return wrap;
 }

--- a/dashboard/frontend/src/lib/design/pro.css
+++ b/dashboard/frontend/src/lib/design/pro.css
@@ -325,3 +325,296 @@
   .pro-ticker-tag { padding: 0 6px; font-size: 8px; }
   .pro-legend { display: none; }
 }
+
+/* ──────────────────────────────────────────────────────────
+   STATION · PRO · UNPREFIXED COMPONENTS
+   These mirror `design-drafts/*.html` so the same component
+   classes (`.strip`, `.wordmark`, `.ticker`, `.section-head`,
+   `.status`, `.mode`, `.aut`, `.run-tick`, `.flap`, `.tele`,
+   `.legend`, `.btn-stop`, `.btn-theme`) work without rewrites.
+   We don't load the drafts file at runtime — these rules are
+   copied here so production code gets the same look-and-feel.
+   ────────────────────────────────────────────────────────── */
+
+/* Top strip ------------------------------------------------ */
+.strip {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 18px;
+  padding: 0 16px;
+  height: 40px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  position: sticky; top: 0; z-index: 10;
+  flex-shrink: 0;
+}
+.wordmark { display: flex; align-items: baseline; gap: 8px; }
+.wordmark .name {
+  font-family: var(--pro-display);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+}
+.wordmark .tag {
+  font-family: var(--pro-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--ash);
+}
+
+.strip-nav {
+  display: flex; gap: 2px; justify-self: start;
+  margin-left: 12px;
+}
+.strip-nav a, .strip-nav button {
+  font-family: var(--pro-sans);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--graphite);
+  padding: 5px 10px;
+  border: 1px solid transparent;
+  background: transparent;
+  cursor: pointer;
+}
+.strip-nav a.active, .strip-nav button.active {
+  color: var(--ink);
+  border-color: var(--rule-2);
+  background: var(--paper-2);
+}
+.strip-nav a:hover, .strip-nav button:hover { color: var(--ink); }
+
+.strip-status {
+  display: flex; align-items: center; gap: 14px;
+  font-family: var(--pro-mono);
+  font-size: 10px;
+  color: var(--graphite);
+}
+.dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  background: var(--ash);
+  margin-right: 5px;
+  transform: translateY(-1px);
+}
+.dot.go      { background: var(--go); }
+.dot.caution { background: var(--caution); }
+.dot.abort   { background: var(--abort); }
+.dot.live    { animation: livedot 1.6s steps(2) infinite; }
+@keyframes livedot { 50% { opacity: .35; } }
+.strip-status .pill { color: var(--ink); font-weight: 500; }
+.strip-status kbd {
+  font-family: var(--pro-mono);
+  font-size: 9px;
+  padding: 1px 4px;
+  border: 1px solid var(--rule-2);
+  color: var(--graphite);
+  margin-left: 4px;
+  background: transparent;
+}
+
+.btn-stop, .btn-theme {
+  font-family: var(--pro-sans);
+  font-weight: 700;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: var(--ink);
+  color: var(--paper);
+  border: 1px solid var(--ink);
+  padding: 5px 10px;
+  cursor: pointer;
+  height: 26px;
+}
+.btn-stop:hover { background: var(--abort); border-color: var(--abort); color: #fff; }
+.btn-stop:disabled { opacity: 0.55; cursor: not-allowed; }
+.btn-theme {
+  background: transparent;
+  color: var(--ink);
+  width: 26px; height: 26px;
+  padding: 0;
+  display: inline-grid; place-items: center;
+}
+.btn-theme:hover { background: var(--paper-2); }
+.btn-theme svg { width: 12px; height: 12px; }
+
+/* Ticker --------------------------------------------------- */
+.ticker {
+  position: relative;
+  height: 22px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper-2);
+  font-family: var(--pro-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: var(--graphite);
+  display: flex; align-items: center;
+  flex-shrink: 0;
+}
+.ticker-tag {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  display: inline-flex; align-items: center;
+  padding: 0 10px;
+  background: var(--ink); color: var(--paper);
+  font-family: var(--pro-sans);
+  font-weight: 700;
+  font-size: 9px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  z-index: 2;
+}
+.ticker-track {
+  display: flex; gap: 0;
+  animation: tick-scroll 60s linear infinite;
+  padding-left: 80px;
+  white-space: nowrap;
+}
+.ticker-track > span {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 0 18px;
+  border-right: 1px solid var(--rule);
+}
+.ticker-track > span b { color: var(--ink); font-weight: 500; }
+.ticker-track > span em { font-style: normal; color: var(--data); }
+.ticker-track > span .go { color: var(--go); }
+.ticker-track > span .am { color: var(--caution); }
+.ticker-track > span .rd { color: var(--abort); }
+@keyframes tick-scroll { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+
+/* Section head -------------------------------------------- */
+.section-head {
+  height: 30px;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 0 14px;
+  font-family: var(--pro-sans);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ash);
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--rule);
+  flex-shrink: 0;
+}
+.section-head .right {
+  color: var(--graphite);
+  font-family: var(--pro-mono);
+  font-size: 10px;
+  letter-spacing: 0;
+  text-transform: none;
+  display: flex; gap: 10px; align-items: center;
+}
+
+/* Status / mode / aut badges ------------------------------ */
+.status {
+  font-family: var(--pro-sans);
+  font-weight: 700;
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 3px 6px;
+  border: 1px solid currentColor;
+  white-space: nowrap;
+  display: inline-block;
+  line-height: 1;
+}
+.status.run    { color: var(--go); }
+.status.planok { color: var(--go); }
+.status.planx  { color: var(--abort); }
+.status.stop   { color: var(--caution); }
+.status.done   { color: var(--graphite); }
+.status.idle   { color: var(--graphite); }
+
+.run-tick {
+  display: inline-block;
+  width: 5px; height: 5px;
+  background: var(--go);
+  margin-right: 5px;
+  vertical-align: 1px;
+  animation: runtick 1.2s steps(2) infinite;
+}
+@keyframes runtick { 50% { opacity: 0.25; } }
+
+.mode, .aut {
+  font-family: var(--pro-sans);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  padding: 2px 5px;
+  border: 1px solid var(--rule-2);
+  color: var(--graphite);
+  display: inline-block;
+  line-height: 1.3;
+}
+.mode.plan   { color: var(--data); border-color: color-mix(in oklab, var(--data) 60%, transparent); }
+.mode.full   { color: var(--ink); }
+.mode.vision { color: var(--graphite); }
+.aut.assist  { color: var(--caution); border-color: color-mix(in oklab, var(--caution) 60%, transparent); }
+.aut.auto    { color: var(--go); border-color: color-mix(in oklab, var(--go) 60%, transparent); }
+.aut.manual  { color: var(--graphite); }
+
+/* Flap ----------------------------------------------------- */
+.flap { display: inline-flex; flex-wrap: wrap; }
+.flap > span {
+  display: inline-block;
+  transform-origin: center top;
+  animation: flap 220ms cubic-bezier(.5,0,.05,1) both;
+}
+@keyframes flap {
+  0%   { transform: rotateX(-92deg); opacity: 0; }
+  60%  { transform: rotateX(8deg);   opacity: 1; }
+  100% { transform: rotateX(0);      opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .flap > span { animation: none; }
+  .ticker-track { animation: none; }
+  .run-tick, .dot.live { animation: none; }
+}
+
+/* Teleprinter footer -------------------------------------- */
+.tele {
+  border-top: 1px solid var(--rule);
+  background: var(--paper-2);
+  padding: 6px 16px;
+  font-family: var(--pro-mono);
+  font-size: 10px;
+  color: var(--graphite);
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  height: 28px;
+  flex-shrink: 0;
+}
+.tele .now { color: var(--ink); display: inline-flex; align-items: center; gap: 7px; }
+.tele .ev  { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.tele .ev b  { color: var(--ink); font-weight: 500; }
+.tele .ev em { font-style: normal; color: var(--data); }
+
+/* Hotkey legend ------------------------------------------- */
+.legend {
+  position: fixed; bottom: 38px; right: 14px;
+  font-family: var(--pro-mono); font-size: 9px; color: var(--ash);
+  display: flex; gap: 8px; pointer-events: none; opacity: 0.7;
+  letter-spacing: 0.04em;
+  z-index: 5;
+}
+.legend kbd {
+  font-family: var(--pro-mono); font-size: 9px;
+  padding: 1px 4px; border: 1px solid var(--rule-2);
+  color: var(--graphite); background: var(--paper);
+  margin-right: 3px;
+}
+
+@media (max-width: 760px) {
+  .strip-nav { display: none; }
+  .ticker-tag { padding: 0 6px; font-size: 8px; }
+  .legend { display: none; }
+}

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -302,6 +302,19 @@ export interface AgentEvent {
   created_at: string;
 }
 
+// --- Dispatch telemetry ---
+export interface TelemetrySummary {
+  active: { count: number; teammates: number; roles: string[] };
+  queue: { total: number; claimed: number; done: number; pending: number };
+  tokens_7d: { total: number; runs: number; input: number; output: number; spark: number[] };
+  system: {
+    status: 'NOMINAL' | 'DEGR' | 'CRIT' | string;
+    disk_free_gb: number | null;
+    memory_used_pct: number | null;
+    uptime_secs: number | null;
+  };
+}
+
 // --- Notifications ---
 export interface Notification {
   id: number;

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -1,521 +1,923 @@
 <script lang="ts">
-  import { listRuns, getQueueStats, getTokenUsage, getPlanUsage, getSystemStatus, getAnalytics, getBackpressure, getActiveEmployees, listQueue, listProjects } from '../lib/api';
+  import {
+    listRuns,
+    getActiveEmployees,
+    getTelemetrySummary,
+    getSystemStatus,
+    getAgentEvents,
+    getCoordinatorTasks,
+    listProjects,
+    pauseAll,
+  } from '../lib/api';
   import { navigate } from '../lib/router.svelte';
   import { agentPresence } from '../lib/agent-presence.svelte';
-  import { formatTokens, formatDuration, timeAgo, formatPercent } from '../lib/format';
+  import { appearance, setTheme } from '../lib/appearance.svelte';
+  import { addToast } from '../lib/toast.svelte';
+  import { flap } from '../lib/design/flap';
+  import type {
+    Run,
+    ActiveEmployee,
+    AgentEvent,
+    CoordinatorTask,
+    Project,
+    TelemetrySummary,
+    SystemStatus,
+  } from '../lib/types';
 
-  function formatUptime(seconds: number | null | undefined): string {
-    if (seconds == null) return '—';
-    const d = Math.floor(seconds / 86400);
-    const h = Math.floor((seconds % 86400) / 3600);
-    const m = Math.floor((seconds % 3600) / 60);
-    if (d > 0) return `${d}d ${h}h`;
+  let { triggering = false, onTrigger }: { triggering?: boolean; onTrigger?: () => void } = $props();
+
+  // ── Data state ─────────────────────────────────────────
+  let recentRuns = $state<Run[]>([]);
+  let activeEmployees = $state<ActiveEmployee[]>([]);
+  let telemetry = $state<TelemetrySummary | null>(null);
+  let systemStatus = $state<SystemStatus | null>(null);
+  let agentEvents = $state<AgentEvent[]>([]);
+  let projects = $state<Project[]>([]);
+  let coordTasks = $state<CoordinatorTask[]>([]);
+  let loading = $state(true);
+
+  // ── UI state ───────────────────────────────────────────
+  type FilterId = 'all' | 'active' | '24h' | 'plan-review' | 'interrupted' | 'by-mode';
+  let activeFilter = $state<FilterId>('all');
+  let searchQuery = $state('');
+  let hovered = $state<Run | null>(null);
+  let selectedIdx = $state<number>(-1);
+  let clockNow = $state<string>('00:00:00');
+  let acked = $state<Set<string>>(new Set());
+
+  // ── Helpers ────────────────────────────────────────────
+  function pad2(n: number) { return String(n).padStart(2, '0'); }
+  function fmtTok(n: number | null | undefined): string {
+    if (n == null || n === 0) return '—';
+    if (n < 1000) return String(n);
+    if (n < 10_000) return (n / 1000).toFixed(1) + 'K';
+    if (n < 1_000_000) return Math.round(n / 1000) + 'K';
+    return (n / 1_000_000).toFixed(1) + 'M';
+  }
+  function fmtDur(ms: number | null | undefined, status: string | null | undefined): string {
+    if (ms == null) return status === 'running' || status === 'started' ? 'live' : '—';
+    if (ms < 60_000) return (ms / 1000).toFixed(1) + 's';
+    const m = Math.floor(ms / 60_000);
+    const s = Math.round((ms % 60_000) / 1000);
+    if (m < 60) return `${m}m${s}s`;
+    return `${Math.floor(m / 60)}h${m % 60}m`;
+  }
+  function fmtAge(startedAt: string | null): string {
+    if (!startedAt) return '—';
+    const hasTz = startedAt.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(startedAt);
+    const t = new Date(hasTz ? startedAt : startedAt + 'Z').getTime();
+    const diff = Date.now() - t;
+    if (diff < 0) return '0s';
+    const s = Math.floor(diff / 1000);
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h`;
+    return `${Math.floor(h / 24)}d`;
+  }
+  function shortId(id: string | null | undefined): string {
+    if (!id) return '—';
+    return id.replace(/^run-(vb-)?/, '…');
+  }
+  function fmtUptime(secs: number | null | undefined): string {
+    if (secs == null) return '—';
+    const d = Math.floor(secs / 86400);
+    const h = Math.floor((secs % 86400) / 3600);
+    if (d > 0) return `${d}d ${pad2(h)}h`;
+    const m = Math.floor((secs % 3600) / 60);
     if (h > 0) return `${h}h ${m}m`;
     return `${m}m`;
   }
 
-  function formatMemoryMB(usedMb: number | null | undefined, totalMb: number | null | undefined): string {
-    if (usedMb == null || totalMb == null) return '—';
-    return `${(usedMb / 1024).toFixed(1)} / ${(totalMb / 1024).toFixed(1)} GB`;
-  }
-  import type { Run, QueueStats, TokenUsage, PlanUsage, SystemStatus, AnalyticsResponse, BackpressureStatus, ActiveEmployee, QueueItem, Project } from '../lib/types';
-  import VaporCard from '../components/vapor/VaporCard.svelte';
-  import VaporBadge from '../components/vapor/VaporBadge.svelte';
-  import SkeletonLoader from '../components/data-display/SkeletonLoader.svelte';
-  import AgentActivityFeed from '../components/agents/AgentActivityFeed.svelte';
-  import { stopRun } from '../lib/api';
-  import { addToast } from '../lib/toast.svelte';
-
-  let stopping = $state(false);
-
-  async function handleStopActiveRun() {
-    const active = agentPresence.activeRuns[0];
-    if (!active?.run_id || stopping) return;
-    const ok = confirm(`Stop the agent NOW?\n\nThis will kill the claude-agent service and mark run ${active.run_id} as interrupted. All active work halts immediately.`);
-    if (!ok) return;
-    stopping = true;
-    try {
-      await stopRun(active.run_id);
-      addToast('success', 'Hard stop issued — service stopping, run interrupted');
-    } catch (e) {
-      const raw = e instanceof Error ? e.message : 'Stop failed';
-      addToast('error', raw.startsWith('409:') ? raw.slice(4).trim() : raw);
-    } finally {
-      stopping = false;
-    }
+  function projectRepo(projectId: number | null | undefined): string {
+    if (projectId == null) return '—';
+    const p = projects.find((x) => x.id === projectId);
+    if (!p) return '—';
+    return p.repo.includes('/') ? p.repo.split('/').pop()! : p.repo;
   }
 
-  let {
-    triggering = false,
-    onTrigger,
-  }: {
-    triggering?: boolean;
-    onTrigger?: () => void;
-  } = $props();
+  // Map run → status / mode / aut bucket
+  type StatusBucket = { label: string; cls: string; tick: boolean };
+  function statusFor(r: Run): StatusBucket {
+    const s = (r.status ?? '').toLowerCase();
+    if (s === 'running' || s === 'started') return { label: 'RUN', cls: 'run', tick: true };
+    if (s === 'reviewing') return { label: 'REVIEW', cls: 'run', tick: true };
+    if (s === 'plan_reviewing' || s === 'awaiting_plan_review') return { label: 'PLAN ?', cls: 'planok', tick: false };
+    if (s === 'plan_approved' || r.verdict === 'APPROVE' || r.verdict === 'PR') return { label: 'PLAN OK', cls: 'planok', tick: false };
+    if (s === 'plan_rejected' || r.verdict === 'REJECT') return { label: 'PLAN ✗', cls: 'planx', tick: false };
+    if (s === 'interrupted') return { label: 'STOP', cls: 'stop', tick: false };
+    if (s === 'failed' || s === 'error') return { label: 'FAIL', cls: 'planx', tick: false };
+    if (s === 'completed' || s === 'finished' || s === 'success') return { label: 'DONE', cls: 'done', tick: false };
+    if (!r.status && !r.finished_at) return { label: 'IDLE', cls: 'idle', tick: false };
+    return { label: (r.status ?? 'IDLE').toUpperCase().slice(0, 6), cls: 'idle', tick: false };
+  }
 
-  // Data state
-  let recentRuns = $state<Run[]>([]);
-  let activeEmployees = $state<ActiveEmployee[]>([]);
-  let queueStats = $state<QueueStats | null>(null);
-  let queueItems = $state<QueueItem[]>([]);
-  let projects = $state<Project[]>([]);
-  let tokenUsage = $state<TokenUsage | null>(null);
-  let planUsage = $state<PlanUsage | null>(null);
-  let systemStatus = $state<SystemStatus | null>(null);
-  let analyticsData = $state<AnalyticsResponse | null>(null);
-  let backpressure = $state<BackpressureStatus | null>(null);
-  let loading = $state(true);
+  function modeFor(r: Run): { label: string; cls: string } {
+    const m = (r.mode ?? '').toLowerCase();
+    if (m === 'plan_only') return { label: 'PLAN', cls: 'plan' };
+    if (m === 'vision-bootstrap') return { label: 'VIS', cls: 'vision' };
+    if (m === 'employee') return { label: 'EMP', cls: 'full' };
+    if (m === 'full') return { label: 'FULL', cls: 'full' };
+    return { label: (m || '—').toUpperCase().slice(0, 4), cls: 'full' };
+  }
 
-  // Derived
-  let stationPhase = $derived<'idle' | 'working' | 'attention'>(
-    activeEmployees.length > 0 ? 'working' :
-    (queueStats?.by_state?.review ?? 0) > 0 ? 'attention' : 'idle'
+  function autFor(r: Run): { label: string; cls: string } {
+    const a = (r.autonomy_level ?? '').toLowerCase();
+    if (a === 'assisted') return { label: 'ASSIST', cls: 'assist' };
+    if (a === 'auto') return { label: 'AUTO', cls: 'auto' };
+    if (a === 'manual') return { label: 'MAN', cls: 'manual' };
+    return { label: '—', cls: 'manual' };
+  }
+
+  function headlineFor(r: Run): { repo: string; title: string; nul: boolean } {
+    const repo = projectRepo(r.project_id);
+    let title: string | null = null;
+    if (r.employee_report) {
+      try {
+        const rep = typeof r.employee_report === 'string' ? JSON.parse(r.employee_report) : r.employee_report;
+        title = (rep && (rep as Record<string, unknown>).issue_title as string) ?? null;
+      } catch { /* ignore */ }
+    }
+    if (!title && r.issue_number) title = `issue #${r.issue_number}`;
+    if (!title && (r.mode as string) === 'vision-bootstrap') return { repo, title: 'vision bootstrap', nul: false };
+    if (!title && r.mode === 'plan_only') return { repo, title: 'plan-only run', nul: true };
+    if (!title) return { repo, title: 'untitled · no issue', nul: true };
+    return { repo, title, nul: false };
+  }
+
+  // ── Filtering ─────────────────────────────────────────
+  let runs24h = $derived(
+    recentRuns.filter((r) => {
+      if (!r.started_at) return false;
+      const hasTz = r.started_at.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(r.started_at);
+      const t = new Date(hasTz ? r.started_at : r.started_at + 'Z').getTime();
+      return Date.now() - t < 24 * 3600 * 1000;
+    }),
+  );
+  let runsActive = $derived(
+    recentRuns.filter((r) => {
+      const s = (r.status ?? '').toLowerCase();
+      return s === 'running' || s === 'started' || s === 'reviewing' || s === 'plan_reviewing';
+    }),
+  );
+  let runsPlanReview = $derived(
+    recentRuns.filter((r) => {
+      const s = (r.status ?? '').toLowerCase();
+      return s === 'plan_reviewing' || s === 'awaiting_plan_review' || s === 'plan_approved' || s === 'plan_rejected';
+    }),
+  );
+  let runsInterrupted = $derived(
+    recentRuns.filter((r) => (r.status ?? '').toLowerCase() === 'interrupted'),
   );
 
-  let stationSummary = $derived.by(() => {
-    if (activeEmployees.length > 0) {
-      const projects = new Set(activeEmployees.map(e => e.project_id)).size;
-      return `${activeEmployees.length} agent${activeEmployees.length > 1 ? 's' : ''} working across ${projects} project${projects > 1 ? 's' : ''}`;
+  let filteredRuns = $derived.by(() => {
+    let base: Run[] = recentRuns;
+    if (activeFilter === 'active') base = runsActive;
+    else if (activeFilter === '24h') base = runs24h;
+    else if (activeFilter === 'plan-review') base = runsPlanReview;
+    else if (activeFilter === 'interrupted') base = runsInterrupted;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      base = base.filter((r) =>
+        (r.run_id ?? '').toLowerCase().includes(q)
+        || projectRepo(r.project_id).toLowerCase().includes(q)
+        || (r.branch ?? '').toLowerCase().includes(q)
+        || String(r.issue_number ?? '').includes(q),
+      );
     }
-    if ((queueStats?.by_state?.review ?? 0) > 0) {
-      return `${queueStats!.by_state.review} item${queueStats!.by_state.review > 1 ? 's' : ''} need review`;
-    }
-    if (systemStatus?.timer?.next_trigger) {
-      return `Next run ${timeAgo(systemStatus.timer.next_trigger)}`;
-    }
-    return 'All systems nominal';
+    return base;
   });
 
-  let verdictCounts = $derived.by(() => {
-    if (!analyticsData?.verdict_distribution) return { approve: 0, pr: 0, reject: 0, skip: 0, total: 0 };
-    const dist = analyticsData.verdict_distribution;
-    return {
-      approve: dist.find(v => v.verdict === 'APPROVE')?.count ?? 0,
-      pr: dist.find(v => v.verdict === 'PR')?.count ?? 0,
-      reject: dist.find(v => v.verdict === 'REJECT')?.count ?? 0,
-      skip: dist.find(v => v.verdict === 'SKIP')?.count ?? 0,
-      total: dist.reduce((s, v) => s + v.count, 0) || 1,
-    };
+  let counts = $derived({
+    all: recentRuns.length,
+    active: runsActive.length,
+    '24h': runs24h.length,
+    'plan-review': runsPlanReview.length,
+    interrupted: runsInterrupted.length,
   });
 
-  let successRate = $derived(
-    verdictCounts.total > 0
-      ? Math.round(((verdictCounts.approve + verdictCounts.pr) / verdictCounts.total) * 100)
-      : 0
+  // ── Alerts derived from system status ─────────────────
+  type Alert = { id: string; level: 'caution' | 'abort'; lev: string; body: string; time: string };
+  let alerts = $derived.by<Alert[]>(() => {
+    const out: Alert[] = [];
+    const r = systemStatus?.resources;
+    if (!r) return out;
+    const now = `${pad2(new Date().getHours())}:${pad2(new Date().getMinutes())}`;
+    if (r.disk_free_gb != null) {
+      if (r.disk_free_gb < 1) {
+        out.push({ id: 'disk-abort', level: 'abort', lev: 'Abort · Disk',
+          body: `Only ${r.disk_free_gb.toFixed(1)} G free — purge worktrees now.`, time: now });
+      } else if (r.disk_free_gb < 5) {
+        out.push({ id: 'disk-caution', level: 'caution', lev: 'Caution · Disk',
+          body: `${r.disk_free_gb.toFixed(1)} G free of ${(r.disk_total_gb ?? 0).toFixed(0)} G — keep an eye on it.`, time: now });
+      }
+    }
+    if (r.memory_used_mb != null && r.memory_total_mb) {
+      const pct = r.memory_used_mb / r.memory_total_mb;
+      if (pct > 0.9) {
+        out.push({ id: 'mem-abort', level: 'abort', lev: 'Abort · Memory',
+          body: `${(r.memory_used_mb / 1024).toFixed(1)} / ${(r.memory_total_mb / 1024).toFixed(1)} G used (${Math.round(pct * 100)}%) — back off concurrency.`, time: now });
+      } else if (pct > 0.7) {
+        out.push({ id: 'mem-caution', level: 'caution', lev: 'Caution · Memory',
+          body: `${(r.memory_used_mb / 1024).toFixed(1)} / ${(r.memory_total_mb / 1024).toFixed(1)} G used (${Math.round(pct * 100)}%).`, time: now });
+      }
+    }
+    return out.filter((a) => !acked.has(a.id));
+  });
+
+  // ── Ticker entries ────────────────────────────────────
+  let tickerSegments = $derived.by(() => {
+    const segs = agentEvents.slice(0, 20).map((e) => {
+      const actor = (e.agent_id ?? 'station').split(':').pop() ?? 'station';
+      const tool =
+        (e.event_data && (e.event_data as Record<string, unknown>).tool as string)
+        ?? e.event_type
+        ?? 'event';
+      const target =
+        (e.event_data && (e.event_data as Record<string, unknown>).summary as string)
+        ?? (e.event_data && (e.event_data as Record<string, unknown>).file_path as string)
+        ?? '';
+      return { actor, tool, target };
+    });
+    if (segs.length === 0) {
+      // Idle fallback so the rail isn't blank between bursts
+      return [
+        { actor: 'station', tool: 'idle', target: 'no recent activity' },
+      ];
+    }
+    return segs;
+  });
+
+  // ── Footer event ──────────────────────────────────────
+  let footerEvent = $derived.by(() => {
+    const e = agentEvents[0];
+    if (!e) return { actor: '—', tool: '', target: 'awaiting events' };
+    const actor = (e.agent_id ?? 'station').split(':').pop() ?? 'station';
+    const tool = ((e.event_data && (e.event_data as Record<string, unknown>).tool as string) ?? e.event_type ?? '').toString();
+    const target = ((e.event_data && (e.event_data as Record<string, unknown>).summary as string)
+      ?? (e.event_data && (e.event_data as Record<string, unknown>).file_path as string)
+      ?? '').toString();
+    return { actor, tool, target };
+  });
+
+  let latestActiveRun = $derived(
+    recentRuns.find((r) => {
+      const s = (r.status ?? '').toLowerCase();
+      return s === 'running' || s === 'started' || s === 'reviewing' || s === 'plan_reviewing';
+    }) ?? recentRuns[0] ?? null,
   );
 
-  let queuePending = $derived(
-    (queueStats?.by_state?.pending ?? 0) +
-    (queueStats?.by_state?.assigned ?? 0) +
-    (queueStats?.by_state?.claimed ?? 0) +
-    (queueStats?.by_state?.planning ?? 0)
-  );
-
-  // Fetch data
-  async function loadData() {
-    const [runsRes, empRes, qRes, tRes, pRes, sRes, aRes, bRes, qiRes, projRes] = await Promise.allSettled([
-      listRuns({ limit: 15 }),
+  // ── Loaders ──────────────────────────────────────────
+  async function loadAll() {
+    const [runsR, empR, telR, sysR, evR, projR] = await Promise.allSettled([
+      listRuns({ limit: 50 }),
       getActiveEmployees(),
-      getQueueStats(),
-      getTokenUsage(),
-      getPlanUsage(),
+      getTelemetrySummary(),
       getSystemStatus(),
-      getAnalytics({ days: 7 }),
-      getBackpressure(),
-      listQueue({ limit: 50 }),
+      getAgentEvents({ limit: 20 }),
       listProjects(),
     ]);
-    if (runsRes.status === 'fulfilled') recentRuns = runsRes.value.runs;
-    if (empRes.status === 'fulfilled') activeEmployees = empRes.value;
-    if (qRes.status === 'fulfilled') queueStats = qRes.value;
-    if (tRes.status === 'fulfilled') tokenUsage = tRes.value;
-    if (pRes.status === 'fulfilled') planUsage = pRes.value;
-    if (sRes.status === 'fulfilled') systemStatus = sRes.value;
-    if (aRes.status === 'fulfilled') analyticsData = aRes.value;
-    if (bRes.status === 'fulfilled') backpressure = bRes.value;
-    if (qiRes.status === 'fulfilled') queueItems = qiRes.value.items;
-    if (projRes.status === 'fulfilled') projects = projRes.value;
+    if (runsR.status === 'fulfilled') recentRuns = runsR.value.runs;
+    if (empR.status === 'fulfilled') activeEmployees = empR.value;
+    if (telR.status === 'fulfilled') telemetry = telR.value;
+    if (sysR.status === 'fulfilled') systemStatus = sysR.value;
+    if (evR.status === 'fulfilled') agentEvents = evR.value;
+    if (projR.status === 'fulfilled') projects = projR.value;
     loading = false;
   }
 
-  $effect(() => {
-    loadData();
-    const interval = setInterval(loadData, 30_000);
-    return () => clearInterval(interval);
-  });
-
-  function getProjectRepo(projectId: number | null | undefined): string | null {
-    if (projectId == null) return null;
-    const proj = projects.find((p) => p.id === projectId);
-    if (!proj) return null;
-    const repo = proj.repo ?? '';
-    return repo.includes('/') ? repo.split('/').pop()! : repo;
+  async function loadCoordTasks(runId: string | null | undefined) {
+    if (!runId) {
+      coordTasks = [];
+      return;
+    }
+    try {
+      coordTasks = await getCoordinatorTasks(runId);
+    } catch { coordTasks = []; }
   }
 
-  function getIssueTitle(run: Run): string | null {
-    if (!run.employee_report) return null;
-    try {
-      const report = typeof run.employee_report === 'string'
-        ? JSON.parse(run.employee_report)
-        : run.employee_report;
-      return report?.issue_title ?? null;
-    } catch {
-      return null;
+  $effect(() => {
+    loadAll();
+    const t = setInterval(loadAll, 10_000);
+    const c = setInterval(() => {
+      const d = new Date();
+      clockNow = `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+    }, 1000);
+    return () => { clearInterval(t); clearInterval(c); };
+  });
+
+  // Reload coordinator tasks whenever the latest active run changes
+  $effect(() => {
+    loadCoordTasks(latestActiveRun?.run_id);
+  });
+
+  // ── Keyboard shortcuts ───────────────────────────────
+  function onKeydown(e: KeyboardEvent) {
+    if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+    if (e.key === '/') {
+      e.preventDefault();
+      (document.querySelector('.dispatch-pro .search') as HTMLInputElement | null)?.focus();
+      return;
+    }
+    if (e.key === 'j' || e.key === 'k') {
+      e.preventDefault();
+      const list = filteredRuns;
+      if (list.length === 0) return;
+      let next = selectedIdx;
+      if (e.key === 'j') next = Math.min(list.length - 1, selectedIdx + 1);
+      else next = Math.max(0, selectedIdx - 1);
+      selectedIdx = next;
+      hovered = list[next];
+      const rows = document.querySelectorAll<HTMLElement>('.dispatch-pro .board-row');
+      rows[next]?.scrollIntoView({ block: 'nearest' });
+      return;
+    }
+    if (e.key === 't') {
+      e.preventDefault();
+      setTheme(appearance.theme === 'dark' ? 'light' : 'dark');
+      return;
+    }
+    if (e.key === '.' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleGlobalPause();
+      return;
     }
   }
 
-  function getRunLabel(run: Run): string {
-    const repo = getProjectRepo(run.project_id);
-    const issue = run.issue_number ? `#${run.issue_number}` : null;
-    if (repo && issue) return `${repo} ${issue}`;
-    if (repo) return repo;
-    if (issue) return issue;
-    return run.run_id?.slice(0, 20) ?? `Run #${run.id}`;
+  let pausing = $state(false);
+  async function handleGlobalPause() {
+    if (pausing) return;
+    pausing = true;
+    try {
+      await pauseAll();
+      addToast('success', 'Global pause engaged.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Pause failed';
+      addToast('error', msg);
+    } finally {
+      pausing = false;
+    }
   }
 
-  function getRowTint(run: Run): string {
-    if (run.verdict === 'APPROVE' || run.verdict === 'PR') return 'background: rgba(46,125,50,0.04);';
-    if (run.verdict === 'REJECT') return 'background: rgba(208,96,80,0.04);';
-    if (run.status === 'running' || run.status === 'started' || run.status === 'reviewing' || run.status === 'plan_reviewing') return 'background: rgba(46,125,50,0.03);';
-    if (run.status === 'interrupted') return 'background: rgba(176,96,48,0.04);';
-    if (run.status === 'failed') return 'background: rgba(208,96,80,0.03);';
-    return '';
+  function ackAlert(id: string) {
+    const next = new Set(acked);
+    next.add(id);
+    acked = next;
   }
 
-  function getVerdictBadge(verdict: string | null): string {
-    if (!verdict) return '';
-    const map: Record<string, string> = { 'APPROVE': 'badge-approve', 'PR': 'badge-pr', 'REJECT': 'badge-reject', 'SKIP': 'badge-pending' };
-    return map[verdict] ?? '';
+  // ── Sparkline polyline points ─────────────────────────
+  function sparkPoints(spark: number[]): string {
+    if (!spark || spark.length === 0) return '';
+    const w = 80, h = 32;
+    const max = Math.max(...spark, 1);
+    const min = Math.min(...spark);
+    const range = max - min || 1;
+    const step = spark.length > 1 ? w / (spark.length - 1) : 0;
+    return spark.map((v, i) => {
+      const x = i * step;
+      const y = h - ((v - min) / range) * (h - 4) - 2;
+      return `${x.toFixed(1)},${y.toFixed(1)}`;
+    }).join(' ');
   }
 
-  function getStatusBadge(run: Run): { label: string; cls: string } {
-    // Priority: live > terminal
-    const s = (run.status ?? '').toLowerCase();
-    if (s === 'running' || s === 'started') return { label: 'RUNNING', cls: 'badge-running' };
-    if (s === 'reviewing') return { label: 'REVIEWING', cls: 'badge-running' };
-    if (s === 'plan_reviewing') return { label: 'PLAN REVIEW', cls: 'badge-running' };
-    if (run.verdict) return { label: run.verdict, cls: getVerdictBadge(run.verdict) };
-    if (s === 'completed' || s === 'finished' || s === 'success') return { label: 'DONE', cls: 'badge-completed' };
-    if (s === 'failed' || s === 'error') return { label: 'FAILED', cls: 'badge-reject' };
-    if (s === 'interrupted') return { label: 'STOPPED', cls: 'badge-pending' };
-    if (!run.status && !run.finished_at) return { label: 'QUEUED', cls: 'badge-pending' };
-    return { label: (run.status ?? 'unknown').toUpperCase(), cls: 'badge-pending' };
+  function navigateRow(r: Run) {
+    navigate(`/runs/${r.run_id}`);
   }
 
-  function getStatusDot(run: Run): string {
-    if (run.verdict === 'APPROVE' || run.verdict === 'PR') return 'background: #2E7D32; box-shadow: 0 0 6px rgba(46,125,50,0.35);';
-    if (run.verdict === 'REJECT') return 'background: #D06050;';
-    const s = (run.status ?? '').toLowerCase();
-    if (s === 'running' || s === 'started' || s === 'reviewing' || s === 'plan_reviewing') return 'background: #2E7D32; box-shadow: 0 0 6px rgba(46,125,50,0.35);';
-    if (s === 'failed' || s === 'error') return 'background: #D06050;';
-    if (s === 'interrupted') return 'background: #B06030;';
-    return 'background: #C4AA90;';
-  }
+  let currentRunTokens = $derived(
+    activeEmployees[0]?.tokens_total
+      ?? agentPresence.activeRuns[0]?.tokens_total
+      ?? agentPresence.tokensBurned
+      ?? 0,
+  );
 </script>
+
+<svelte:window onkeydown={onKeydown} />
 
 <div data-testid="command-center" class="dispatch-pro animate-fade-in">
 
-  {#if loading}
-    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 28px;">
-      {#each Array(4) as _}
-        <div class="card" style="padding: 24px;"><SkeletonLoader lines={2} /></div>
+  <!-- Live ticker -->
+  <div class="ticker">
+    <span class="ticker-tag">// Live</span>
+    <div class="ticker-track">
+      {#each [...tickerSegments, ...tickerSegments] as seg}
+        <span><b>{seg.actor}</b> · <em>{seg.tool}</em> {seg.target}</span>
       {/each}
     </div>
-    <div class="card" style="padding: 24px;"><SkeletonLoader lines={8} /></div>
+  </div>
 
-  {:else}
-    <!-- Page header (Pro) -->
-    <div class="dp-page-head">
-      <h1 class="dp-title">Dispatch</h1>
-      <div class="dp-meta">
-        {#if stationPhase === 'working'}
-          <span class="dp-status go">{stationSummary}</span>
-          <span class="sep">·</span>
-          <button onclick={() => navigate('/mission-control')} class="dp-mc-btn">Open Mission Control →</button>
+  <!-- Filters -->
+  <div class="filters">
+    <div class="views" role="tablist">
+      <button class="view" class:active={activeFilter === 'all'} onclick={() => activeFilter = 'all'}>
+        All <span class="count">{counts.all}</span>
+      </button>
+      <button class="view" class:active={activeFilter === 'active'} onclick={() => activeFilter = 'active'}>
+        Active <span class="count">{counts.active}</span>
+      </button>
+      <button class="view" class:active={activeFilter === '24h'} onclick={() => activeFilter = '24h'}>
+        24H <span class="count">{counts['24h']}</span>
+      </button>
+      <button class="view" class:active={activeFilter === 'plan-review'} onclick={() => activeFilter = 'plan-review'}>
+        Plan-Review <span class="count">{counts['plan-review']}</span>
+      </button>
+      <button class="view" class:active={activeFilter === 'interrupted'} onclick={() => activeFilter = 'interrupted'}>
+        Interrupted <span class="count">{counts.interrupted}</span>
+      </button>
+      <button class="view" class:active={activeFilter === 'by-mode'} onclick={() => activeFilter = 'by-mode'} title="Coming soon">
+        By Mode
+      </button>
+    </div>
+    <div class="filter-right">
+      {#if latestActiveRun}
+        <span>{projectRepo(latestActiveRun.project_id)}</span>
+        <span>·</span>
+      {/if}
+      <input
+        class="search"
+        placeholder="filter…  ·  / focuses"
+        bind:value={searchQuery}
+      />
+    </div>
+  </div>
+
+  {#if activeFilter === 'by-mode'}
+    <div class="mode-stub">
+      <span class="mode plan">PLAN</span>
+      <span>Mode-grouped view is coming soon — switch back to <button class="link" onclick={() => activeFilter = 'all'}>All</button>.</span>
+    </div>
+  {/if}
+
+  <!-- Alerts (rendered only if any) -->
+  {#if alerts.length > 0}
+    <div class="alerts">
+      {#each alerts as a (a.id)}
+        <div class="alert {a.level === 'caution' ? 'caution' : ''}">
+          <span class="dot {a.level === 'caution' ? 'caution' : 'abort'}"></span>
+          <span class="lev">{a.lev}</span>
+          <span class="time">{a.time}</span>
+          <span class="body">{a.body}</span>
+          <button class="ack" onclick={() => ackAlert(a.id)}>Ack</button>
+        </div>
+      {/each}
+    </div>
+  {/if}
+
+  <!-- Telemetry strip -->
+  <section class="telemetry">
+    <div class="tcell">
+      <div class="label">Active</div>
+      <div class="value {(telemetry?.active.count ?? 0) > 0 ? 'go' : ''}">{telemetry?.active.count ?? 0}</div>
+      <div class="sub">
+        {#if telemetry && telemetry.active.teammates > 0}
+          {telemetry.active.teammates} teammates
+          {#if telemetry.active.roles.length > 0}· {telemetry.active.roles.join(', ')}{/if}
         {:else}
-          <span>{stationSummary}</span>
+          no live work
         {/if}
       </div>
     </div>
 
-    <!--
-      Live Activity — Phase 1 of "The Bridge".
-      Replaces the silent landing page with a stream of agent narration, tool
-      calls, and phase transitions. Pulled straight from agentPresence so the
-      same data any page could already access now surfaces on home. Renders
-      whenever we have activity — otherwise yields an idle hint instead of
-      dead whitespace.
-    -->
-    {#if agentPresence.activeRuns.length > 0 || agentPresence.conversationLog.length > 0}
-      <div
-        data-testid="bridge-activity"
-        style="background: rgba(255,251,247,0.65); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border: 1px solid rgba(240,220,200,0.6); border-radius: 18px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.04), 0 12px 32px rgba(0,0,0,0.07); margin-bottom: 28px; animation: card-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.10s both;"
-      >
-        <div style="padding: 14px 24px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid rgba(0,0,0,0.04);">
-          <div style="display: flex; align-items: center; gap: 10px;">
-            <div
-              style="width: 8px; height: 8px; border-radius: 50%; {agentPresence.activeRuns.length > 0 ? 'background: #2E7D32; box-shadow: 0 0 8px rgba(46,125,50,0.45);' : 'background: #C4AA90;'}"
-            ></div>
-            <span style="font-size: 15px; font-weight: 700; color: #3D2A1A;">
-              {agentPresence.activeRuns.length > 0 ? 'Live' : 'Last activity'}
-            </span>
-            {#if agentPresence.phase && agentPresence.phase !== 'idle'}
-              <span style="font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: #7A6652; font-weight: 600;">· {agentPresence.phase}</span>
-            {/if}
-            {#if agentPresence.tokensBurned > 0}
-              <span style="font-size: 12px; color: #4E3A26; font-variant-numeric: tabular-nums;">· {formatTokens(agentPresence.tokensBurned)} tokens</span>
-            {/if}
-          </div>
-          <div style="display: flex; align-items: center; gap: 8px;">
-            {#if agentPresence.activeRuns.length > 0}
-              <button
-                onclick={handleStopActiveRun}
-                disabled={stopping}
-                data-testid="bridge-stop-btn"
-                title="Hard stop: kill the agent service and mark active runs interrupted"
-                style="font-size: 12px; font-weight: 700; color: #8B1A1A; background: rgba(208,80,80,0.10); border: 1px solid rgba(208,80,80,0.30); padding: 6px 12px; border-radius: 8px; cursor: pointer; font-family: inherit; transition: background 0.15s ease;"
-              >{stopping ? '…' : '⏹ Stop agent'}</button>
-            {/if}
-            <button
-              onclick={() => navigate('/mission-control')}
-              style="font-size: 13px; color: #B06030; font-weight: 600; cursor: pointer; border: none; background: none; font-family: inherit;"
-            >Open Mission Control →</button>
-          </div>
-        </div>
-        <div style="position: relative; height: 260px; padding: 6px 14px;">
-          <AgentActivityFeed maxEntries={120} />
-        </div>
+    <div class="tcell">
+      <div class="label">Queue</div>
+      <div class="value">{telemetry?.queue.total ?? 0}</div>
+      <div class="sub">
+        {telemetry?.queue.claimed ?? 0} claimed · {telemetry?.queue.done ?? 0} done · {telemetry?.queue.pending ?? 0} pending
       </div>
-    {:else}
-      <div
-        data-testid="bridge-idle"
-        style="background: rgba(255,251,247,0.45); border: 1px dashed rgba(240,220,200,0.8); border-radius: 14px; padding: 16px 20px; margin-bottom: 28px; font-size: 13px; color: #8C7A66; display: flex; align-items: center; justify-content: space-between;"
-      >
-        <span>No live activity. Trigger a run to watch the agent work here, in real time.</span>
-        <button
-          onclick={onTrigger}
-          disabled={triggering}
-          style="font-size: 13px; font-weight: 600; color: #B06030; cursor: pointer; border: none; background: none; font-family: inherit;"
-        >{triggering ? 'Triggering…' : 'Trigger run →'}</button>
-      </div>
-    {/if}
-
-    <!-- 4 Metric Cards -->
-    <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 28px;">
-      <VaporCard stagger={0.05}>
-        <div style="display: flex; justify-content: space-between; align-items: center;">
-          <div style="font-size: 14px; color: #7A6652; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;">Runs (7d)</div>
-          <div style="width: 32px; height: 32px; background: rgba(59,130,246,0.08); border-radius: 9px; display: flex; align-items: center; justify-content: center;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#3B82F6" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
-          </div>
-        </div>
-        <div style="font-size: 48px; font-weight: 800; letter-spacing: -0.05em; margin-top: 10px; line-height: 1; color: #3D2A1A;">{analyticsData?.total_runs ?? 0}</div>
-        <div style="font-size: 13px; color: #2E7D32; font-weight: 600; margin-top: 8px;">{stationSummary}</div>
-      </VaporCard>
-
-      <VaporCard stagger={0.12}>
-        <div style="display: flex; justify-content: space-between; align-items: center;">
-          <div style="font-size: 14px; color: #7A6652; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;">Success</div>
-          <div style="width: 32px; height: 32px; background: rgba(234,88,12,0.08); border-radius: 9px; display: flex; align-items: center; justify-content: center;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#EA580C" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
-          </div>
-        </div>
-        <div style="font-size: 48px; font-weight: 800; letter-spacing: -0.05em; margin-top: 10px; line-height: 1; color: #D84315;">{successRate}%</div>
-        <div style="width: 100%; height: 4px; background: rgba(0,0,0,0.05); border-radius: 999px; margin-top: 12px; overflow: hidden;">
-          <div class="progress-fill" style="width: {successRate}%; height: 100%; background: #D84315; border-radius: 999px;"></div>
-        </div>
-      </VaporCard>
-
-      <VaporCard stagger={0.19}>
-        <div style="display: flex; justify-content: space-between; align-items: center;">
-          <div style="font-size: 14px; color: #7A6652; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;">Tokens</div>
-          <div style="width: 32px; height: 32px; background: rgba(99,102,241,0.08); border-radius: 9px; display: flex; align-items: center; justify-content: center;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6366F1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
-          </div>
-        </div>
-        <div style="font-size: 48px; font-weight: 800; letter-spacing: -0.05em; margin-top: 10px; line-height: 1; color: #3D2A1A;">{formatTokens(tokenUsage?.daily?.tokens_total ?? null)}</div>
-        <div style="font-size: 13px; color: #8C7A66; margin-top: 8px;">
-          {#if planUsage?.weekly_tokens_percent != null}
-            {formatPercent(planUsage.weekly_tokens_percent)} of weekly plan
-          {:else}
-            this week
-          {/if}
-        </div>
-      </VaporCard>
-
-      <VaporCard stagger={0.26}>
-        <div style="display: flex; justify-content: space-between; align-items: center;">
-          <div style="font-size: 14px; color: #7A6652; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;">Queue</div>
-          <div style="width: 32px; height: 32px; background: rgba(176,96,48,0.08); border-radius: 9px; display: flex; align-items: center; justify-content: center;">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#B06030" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
-          </div>
-        </div>
-        <div style="font-size: 48px; font-weight: 800; letter-spacing: -0.05em; margin-top: 10px; line-height: 1; color: #B06030;">{queuePending}</div>
-        <div style="font-size: 13px; color: #8C7A66; margin-top: 8px;">{queueStats?.by_state?.review ?? 0} in review</div>
-      </VaporCard>
     </div>
 
-    <!-- Recent Runs Table -->
-    <div style="background: rgba(255,251,247,0.65); backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px); border: 1px solid rgba(240,220,200,0.6); border-radius: 18px; overflow: hidden; box-shadow: 0 4px 12px rgba(0,0,0,0.04), 0 12px 32px rgba(0,0,0,0.07); animation: card-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.35s both; margin-bottom: 28px;">
-      <div style="padding: 16px 24px; display: flex; justify-content: space-between; align-items: center; border-bottom: 1px solid rgba(0,0,0,0.04);">
-        <span style="font-size: 15px; font-weight: 700; color: #3D2A1A;">Recent Runs</span>
+    <div class="tcell">
+      <div class="label">Tokens · 7D</div>
+      <div class="value">{fmtTok(telemetry?.tokens_7d.total ?? 0)}</div>
+      {#if telemetry && telemetry.tokens_7d.spark.length > 0}
+        <svg class="spark" viewBox="0 0 80 32" preserveAspectRatio="none" aria-hidden="true">
+          <polyline
+            points={sparkPoints(telemetry.tokens_7d.spark)}
+            fill="none" stroke="currentColor" stroke-width="1.4"
+          />
+        </svg>
+      {/if}
+      <div class="sub">
+        {telemetry?.tokens_7d.runs ?? 0} runs · {fmtTok(telemetry?.tokens_7d.output ?? 0)} out / {fmtTok(telemetry?.tokens_7d.input ?? 0)} in
       </div>
-      {#each recentRuns.slice(0, 10) as run (run.id)}
-        {@const status = getStatusBadge(run)}
-        {@const title = getIssueTitle(run)}
-        <button
-          onclick={() => navigate(`/runs/${run.run_id}`)}
-          title="Open {run.run_id}"
-          style="display: flex; align-items: center; gap: 14px; padding: 14px 24px; border-bottom: 1px solid rgba(0,0,0,0.04); transition: background 0.2s ease; cursor: pointer; width: 100%; text-align: left; border: none; font-family: inherit; {getRowTint(run)}"
-        >
-          <div style="width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; {getStatusDot(run)}"></div>
+    </div>
 
-          <!-- Left: project/#issue + title -->
-          <div style="flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px;">
-            <div style="display: flex; align-items: baseline; gap: 8px; min-width: 0;">
-              <span style="font-size: 14px; font-weight: 700; color: #2A1C0E; white-space: nowrap;">{getRunLabel(run)}</span>
-              {#if title}
-                <span style="font-size: 13px; color: #4E3A26; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0;">{title}</span>
-              {/if}
-            </div>
-            <div style="display: flex; align-items: center; gap: 10px; font-size: 12px; color: #6B5743;">
-              {#if run.turns != null}<span>{run.turns} turns</span>{/if}
-              {#if run.duration_ms}<span>·</span><span>{formatDuration(run.duration_ms)}</span>{/if}
-              {#if run.branch}<span>·</span><span style="font-family: var(--font-mono); font-size: 11px;">{run.branch}</span>{/if}
-              {#if run.autonomy_level}<span>·</span><span style="text-transform: uppercase; letter-spacing: 0.05em; font-size: 10px; font-weight: 600;">{run.autonomy_level}</span>{/if}
-            </div>
-          </div>
+    <div class="tcell">
+      <div class="label">System</div>
+      <div class="value {(telemetry?.system.status ?? 'NOMINAL') === 'CRIT' ? 'abort' : (telemetry?.system.status ?? 'NOMINAL') === 'DEGR' ? 'caution' : 'go'}">{telemetry?.system.status ?? 'NOMINAL'}</div>
+      <div class="sub">
+        {#if telemetry?.system.disk_free_gb != null}
+          disk {telemetry.system.disk_free_gb.toFixed(1)} G ·
+        {/if}
+        {#if telemetry?.system.memory_used_pct != null}
+          mem {telemetry.system.memory_used_pct}% ·
+        {/if}
+        uptime {fmtUptime(telemetry?.system.uptime_secs)}
+      </div>
+    </div>
+  </section>
 
-          <!-- Right: status + verdict + tokens + time -->
-          <div style="display: flex; align-items: center; gap: 10px; flex-shrink: 0;">
-            <span class="badge {status.cls}">{status.label}</span>
-            {#if run.verdict && status.label !== run.verdict}
-              <span class="badge {getVerdictBadge(run.verdict)}">{run.verdict}</span>
-            {/if}
-            <span style="font-size: 13px; color: #4E3A26; min-width: 56px; text-align: right; font-variant-numeric: tabular-nums;">{run.tokens_total ? formatTokens(run.tokens_total) : '—'}</span>
-            <span style="font-size: 12px; color: #6B5743; min-width: 60px; text-align: right;">{timeAgo(run.started_at)}</span>
-          </div>
-        </button>
-      {/each}
-      {#if recentRuns.length === 0}
-        <div style="padding: 48px 24px; text-align: center;">
-          <div style="font-size: 32px; opacity: 0.2; margin-bottom: 12px;">▶</div>
-          <p style="font-size: 14px; color: #7A6652; margin-bottom: 4px;">No runs yet</p>
-          <p style="font-size: 13px; color: #8C7A66;">Trigger your first agent run to see results here</p>
-        </div>
+  <!-- Board -->
+  <section class="board">
+    <div class="board-main">
+      <div class="board-head">
+        <span class="col-ix">#</span>
+        <span class="col-id">Run ID</span>
+        <span>Mode</span>
+        <span>Aut</span>
+        <span>Headline</span>
+        <span>Status</span>
+        <span class="num">Turns</span>
+        <span class="num">Tok</span>
+        <span class="num">Dur</span>
+        <span class="num">Age</span>
+      </div>
+
+      {#if loading}
+        <div class="empty">Loading…</div>
+      {:else if filteredRuns.length === 0}
+        <div class="empty">No runs match this filter.</div>
+      {:else}
+        {#each filteredRuns as r, i (r.run_id ?? r.id)}
+          {@const stat = statusFor(r)}
+          {@const m = modeFor(r)}
+          {@const a = autFor(r)}
+          {@const head = headlineFor(r)}
+          {@const baseDelay = i * 60}
+          <button
+            type="button"
+            class="board-row"
+            class:selected={selectedIdx === i || hovered?.run_id === r.run_id}
+            data-run-id={r.run_id}
+            onmouseenter={() => { hovered = r; selectedIdx = i; }}
+            onfocus={() => { hovered = r; selectedIdx = i; }}
+            onclick={() => navigateRow(r)}
+          >
+            <span class="ix"><span use:flap={{ text: String(i + 1).padStart(2, '0'), baseDelay }}></span></span>
+            <span class="id"><span use:flap={{ text: shortId(r.run_id), baseDelay: baseDelay + 24 }}></span></span>
+            <span><span class="mode {m.cls}"><span use:flap={{ text: m.label, baseDelay: baseDelay + 48 }}></span></span></span>
+            <span><span class="aut {a.cls}"><span use:flap={{ text: a.label, baseDelay: baseDelay + 60 }}></span></span></span>
+            <span class="title">
+              <span class="repo"><span use:flap={{ text: head.repo + '  ·  ', baseDelay: baseDelay + 80 }}></span></span>
+              <span class="t" class:nul={head.nul}><span use:flap={{ text: head.title, baseDelay: baseDelay + 110 }}></span></span>
+            </span>
+            <span><span class="status {stat.cls}">
+              {#if stat.tick}<span class="run-tick"></span>{/if}
+              <span use:flap={{ text: stat.label, baseDelay: baseDelay + 160 }}></span>
+            </span></span>
+            <span class="num" class:nu={r.turns == null}>
+              <span use:flap={{ text: r.turns == null ? '—' : String(r.turns), baseDelay: baseDelay + 200 }}></span>
+            </span>
+            <span class="num" class:nu={r.tokens_total == null}>
+              <span use:flap={{ text: fmtTok(r.tokens_total), baseDelay: baseDelay + 230 }}></span>
+            </span>
+            <span class="num" class:nu={r.duration_ms == null && (r.status ?? '') !== 'running'}>
+              <span use:flap={{ text: fmtDur(r.duration_ms, r.status), baseDelay: baseDelay + 260 }}></span>
+            </span>
+            <span class="num">
+              <span use:flap={{ text: fmtAge(r.started_at), baseDelay: baseDelay + 290 }}></span>
+            </span>
+          </button>
+        {/each}
       {/if}
     </div>
 
-    <!-- 3 Secondary Cards -->
-    <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; animation: card-in 0.6s cubic-bezier(0.16, 1, 0.3, 1) 0.85s both;">
-      <VaporCard>
-        <div style="font-size: 14px; color: #7A6652; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 14px;">Active Projects</div>
-        <div style="display: flex; flex-direction: column; gap: 12px;">
-          {#each (queueItems.reduce((acc, item) => { if (!acc.find(a => a.repo === item.project_repo)) acc.push({ repo: item.project_repo, active: ['in_progress', 'assigned', 'claimed', 'planning'].includes(item.state) }); return acc; }, [] as { repo: string; active: boolean }[]).slice(0, 4)) as project}
-            <div style="display: flex; align-items: center; justify-content: space-between;">
-              <span style="font-size: 14px; {project.active ? 'font-weight: 600; color: #3D2A1A;' : 'color: #8C7A66;'}">{project.repo.split('/').pop()}</span>
-              <VaporBadge variant={project.active ? 'active' : 'disabled'}>{project.active ? 'Active' : 'Idle'}</VaporBadge>
+    <!-- Right rail -->
+    <aside class="side">
+      <section>
+        <div class="section-head">
+          <span>Coordinator · Live</span>
+          <span class="right">{latestActiveRun ? shortId(latestActiveRun.run_id) : '—'}</span>
+        </div>
+        <div class="body">
+          {#if !latestActiveRun || coordTasks.length === 0}
+            <div class="task empty">No coordinator tasks.</div>
+          {:else}
+            {#each coordTasks.slice(0, 8) as task (task.id)}
+              <div class="task">
+                <div class="lane">{task.claimed_by ?? task.teammate_agent_id ?? 'unassigned'}</div>
+                <div class="t">{task.title}</div>
+                <div class="meta">
+                  <span>{(task.status ?? '—').toUpperCase()}</span>
+                  {#if task.employee_index != null}<span>EMP {task.employee_index}</span>{/if}
+                </div>
+              </div>
+            {/each}
+          {/if}
+        </div>
+      </section>
+
+      <section>
+        <div class="section-head">
+          <span>Context</span>
+          <span class="right">{hovered ? shortId(hovered.run_id) : 'hover a row'}</span>
+        </div>
+        <div class="body">
+          {#if !hovered}
+            <div class="ctx"><div class="empty">Hover or use j/k to inspect a run.</div></div>
+          {:else}
+            {@const stat = statusFor(hovered)}
+            <div class="ctx">
+              <div class="row"><span class="lbl">Run ID</span><span class="val">{hovered.run_id ?? '—'}</span></div>
+              <div class="row"><span class="lbl">Project</span><span class="val">{projectRepo(hovered.project_id)}</span></div>
+              <div class="row"><span class="lbl">Mode</span><span class="val">{hovered.mode ?? '—'}</span></div>
+              <div class="row"><span class="lbl">Autonomy</span><span class="val">{hovered.autonomy_level ?? '—'}</span></div>
+              <div class="row"><span class="lbl">Status</span><span class="val" style="color: var(--{stat.cls === 'run' || stat.cls === 'planok' ? 'go' : stat.cls === 'planx' ? 'abort' : stat.cls === 'stop' ? 'caution' : 'graphite'});">{hovered.status ?? '—'}</span></div>
+              <div class="row"><span class="lbl">Turns</span><span class="val">{hovered.turns ?? '—'}</span></div>
+              <div class="row"><span class="lbl">Tokens</span><span class="val">{fmtTok(hovered.tokens_total)}</span></div>
+              <div class="row"><span class="lbl">Duration</span><span class="val">{fmtDur(hovered.duration_ms, hovered.status)}</span></div>
+              <div class="row"><span class="lbl">Branch</span><span class="val" style={hovered.branch ? '' : 'color: var(--ash);'}>{hovered.branch ?? '—'}</span></div>
+              <div class="row"><span class="lbl">Issue</span><span class="val" style={hovered.issue_number ? '' : 'color: var(--ash);'}>{hovered.issue_number ? `#${hovered.issue_number}` : '—'}</span></div>
+              <div class="row"><span class="lbl">Verdict</span><span class="val" style={hovered.verdict ? '' : 'color: var(--ash);'}>{hovered.verdict ?? '—'}</span></div>
+              <div class="row"><span class="lbl">Cost</span><span class="val" style={hovered.cost_usd ? '' : 'color: var(--ash);'}>{hovered.cost_usd != null ? `$${hovered.cost_usd.toFixed(3)}` : '—'}</span></div>
             </div>
-          {/each}
-          {#if queueItems.length === 0}
-            <div style="font-size: 13px; color: #8C7A66;">No projects in queue</div>
           {/if}
         </div>
-      </VaporCard>
+      </section>
+    </aside>
+  </section>
 
-      <VaporCard>
-        <div style="font-size: 14px; color: #7A6652; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 14px;">Queue Preview</div>
-        <div style="display: flex; flex-direction: column; gap: 10px;">
-          {#each queueItems.filter(i => i.state === 'pending' || i.state === 'assigned').slice(0, 3) as item}
-            <div style="font-size: 13px; color: #3D2A1A; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">{item.issue_title || `#${item.issue_number}`}</div>
-          {/each}
-          {#if queuePending > 3}
-            <div style="font-size: 12px; color: #8C7A66; margin-top: 2px;">+{queuePending - 3} more in queue</div>
-          {/if}
-          {#if queuePending === 0}
-            <div style="font-size: 13px; color: #8C7A66;">Queue empty</div>
-          {/if}
-        </div>
-      </VaporCard>
+  <!-- Footer -->
+  <footer class="tele">
+    <span class="now">
+      <span class="run-tick"></span>
+      <span>{clockNow}</span>
+    </span>
+    <span><b>{latestActiveRun ? shortId(latestActiveRun.run_id) : '—'}</b></span>
+    <span class="ev">
+      {#if footerEvent.actor !== '—'}
+        {footerEvent.actor} · <em>{footerEvent.tool}</em> {footerEvent.target}
+      {:else}
+        awaiting events
+      {/if}
+    </span>
+    <span data-testid="footer-tokens">{currentRunTokens > 0 ? `+${fmtTok(currentRunTokens)}` : '—'}</span>
+  </footer>
 
-      <VaporCard>
-        <div style="font-size: 14px; color: #7A6652; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; margin-bottom: 14px;">System Health</div>
-        <div style="display: flex; flex-direction: column; gap: 12px;">
-          <div style="display: flex; justify-content: space-between; align-items: center;">
-            <span style="font-size: 14px; color: #3D2A1A;">Service</span>
-            <span style="font-size: 13px; color: {systemStatus?.service?.active ? '#2E7D32' : '#D06050'}; font-weight: 600;">{systemStatus?.service?.active ? 'Online' : 'Offline'}</span>
-          </div>
-          <div style="display: flex; justify-content: space-between; align-items: center;">
-            <span style="font-size: 14px; color: #3D2A1A;">Backpressure</span>
-            <span style="font-size: 13px; color: {
-              backpressure?.level === 'GREEN' ? '#2E7D32' :
-              backpressure?.level === 'YELLOW' ? '#B06030' :
-              backpressure?.level === 'RED' ? '#D06050' :
-              backpressure?.level === 'BLACK' ? '#111111' :
-              '#8C7A66'
-            }; font-weight: 600;">{backpressure?.level ?? '—'}</span>
-          </div>
-          <div style="display: flex; justify-content: space-between; align-items: center;">
-            <span style="font-size: 14px; color: #3D2A1A;">Memory</span>
-            <span style="font-size: 13px; color: #8C7A66;">{formatMemoryMB(systemStatus?.resources?.memory_used_mb, systemStatus?.resources?.memory_total_mb)}</span>
-          </div>
-          <div style="display: flex; justify-content: space-between; align-items: center;">
-            <span style="font-size: 14px; color: #3D2A1A;">Uptime</span>
-            <span style="font-size: 13px; color: #8C7A66;">{formatUptime(systemStatus?.resources?.uptime_seconds)}</span>
-          </div>
-        </div>
-      </VaporCard>
-    </div>
-  {/if}
+  <div class="legend" aria-hidden="true">
+    <span><kbd>/</kbd>filter</span>
+    <span><kbd>j/k</kbd>row</span>
+    <span><kbd>t</kbd>theme</span>
+    <span><kbd>⌘.</kbd>stop</span>
+  </div>
 </div>
 
 <style>
-  .dispatch-pro :global(.dp-page-head) {
-    display: flex; align-items: center; justify-content: space-between;
-    gap: 14px; padding: 6px 0 12px; margin-bottom: 18px;
-    border-bottom: 1px solid var(--rule);
-  }
-  .dispatch-pro :global(.dp-title) {
-    margin: 0;
+  /* Layout — keep flush with the strip; the page owns its own padding. */
+  .dispatch-pro {
+    display: flex;
+    flex-direction: column;
+    min-height: calc(100vh - 40px);
+    background: var(--paper);
+    color: var(--ink);
     font-family: var(--pro-sans);
-    font-size: 14px; font-weight: 700;
-    letter-spacing: 0.18em; text-transform: uppercase;
+    background-image: radial-gradient(circle at 1px 1px, var(--dot) 1px, transparent 0);
+    background-size: 24px 24px;
+  }
+
+  /* Filter strip */
+  .dispatch-pro :global(.filters) {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    height: 34px;
+    padding: 0 16px;
+    border-bottom: 1px solid var(--rule);
+    background: var(--paper);
+  }
+  .dispatch-pro :global(.views) { display: flex; align-items: center; }
+  .dispatch-pro :global(.view) {
+    font-family: var(--pro-sans);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--graphite);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    padding: 8px 12px;
+    cursor: pointer;
+    height: 34px;
+  }
+  .dispatch-pro :global(.view.active) { color: var(--ink); border-bottom-color: var(--ink); }
+  .dispatch-pro :global(.view .count) {
+    font-family: var(--pro-mono); font-size: 9px; color: var(--ash);
+    margin-left: 4px; font-weight: 500;
+  }
+  .dispatch-pro :global(.view.active .count) { color: var(--graphite); }
+  .dispatch-pro :global(.view:hover) { color: var(--ink); }
+  .dispatch-pro :global(.filter-right) {
+    display: flex; align-items: center; gap: 12px;
+    font-family: var(--pro-mono); font-size: 10px; color: var(--ash);
+  }
+  .dispatch-pro :global(.search) {
+    font-family: var(--pro-mono);
+    font-size: 11px;
+    background: var(--paper-2);
+    border: 1px solid var(--rule);
+    padding: 3px 8px;
+    color: var(--ink);
+    width: 180px;
+    border-radius: 0;
+  }
+  .dispatch-pro :global(.search::placeholder) { color: var(--ash); }
+  .dispatch-pro :global(.search:focus) { outline: none; border-color: var(--ink); }
+
+  /* By-Mode stub banner */
+  .dispatch-pro :global(.mode-stub) {
+    display: flex; align-items: center; gap: 10px;
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--rule);
+    background: color-mix(in oklab, var(--data) 6%, var(--paper));
+    font-family: var(--pro-mono); font-size: 11px; color: var(--ink);
+  }
+  .dispatch-pro :global(.mode-stub .link) {
+    background: none; border: none; color: var(--data);
+    text-decoration: underline; cursor: pointer; font: inherit;
+  }
+
+  /* Alerts */
+  .dispatch-pro :global(.alerts) { border-bottom: 1px solid var(--rule); }
+  .dispatch-pro :global(.alert) {
+    display: grid;
+    grid-template-columns: 8px auto auto 1fr auto;
+    gap: 10px;
+    align-items: center;
+    padding: 6px 16px;
+    border-left: 3px solid var(--abort);
+    background: color-mix(in oklab, var(--abort) 6%, var(--paper));
+    font-family: var(--pro-mono);
+    font-size: 11px;
     color: var(--ink);
   }
-  .dispatch-pro :global(.dp-meta) {
-    font-family: var(--pro-mono); font-size: 12px;
-    color: var(--graphite);
-    display: flex; gap: 8px; align-items: center;
+  .dispatch-pro :global(.alert.caution) {
+    border-left-color: var(--caution);
+    background: color-mix(in oklab, var(--caution) 6%, var(--paper));
   }
-  .dispatch-pro :global(.dp-meta .sep) { color: var(--ash); }
-  .dispatch-pro :global(.dp-status.go) { color: var(--go); font-weight: 500; }
-  .dispatch-pro :global(.dp-mc-btn) {
-    background: transparent; border: none; cursor: pointer;
-    color: var(--data); font-family: inherit; font-size: inherit;
-    padding: 0; text-decoration: underline; text-underline-offset: 2px;
+  .dispatch-pro :global(.alert .lev) {
+    font-family: var(--pro-sans); font-weight: 700;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    font-size: 10px; color: var(--abort);
   }
-  .dispatch-pro :global(.dp-mc-btn:hover) { filter: brightness(0.9); }
+  .dispatch-pro :global(.alert.caution .lev) { color: var(--caution); }
+  .dispatch-pro :global(.alert .time) { color: var(--ash); font-size: 10px; }
+  .dispatch-pro :global(.alert .body b) { font-weight: 500; }
+  .dispatch-pro :global(.alert .ack) {
+    font-family: var(--pro-sans); font-size: 9px;
+    letter-spacing: 0.16em; text-transform: uppercase;
+    color: var(--ink); background: transparent;
+    border: 1px solid var(--rule-2); padding: 2px 8px; cursor: pointer;
+  }
+  .dispatch-pro :global(.alert .ack:hover) { background: var(--paper-2); }
 
-  /* Flatten neumorphic surfaces on the page */
-  .dispatch-pro :global(.card) {
-    background: var(--paper-2) !important;
-    border: 1px solid var(--rule) !important;
-    border-radius: 0 !important;
-    backdrop-filter: none !important;
-    -webkit-backdrop-filter: none !important;
-    box-shadow: none !important;
-    transition: border-color 200ms ease !important;
-    animation: none !important;
+  /* Telemetry */
+  .dispatch-pro :global(.telemetry) {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    border-bottom: 1px solid var(--rule);
   }
-  .dispatch-pro :global(.card:hover) {
-    border-color: var(--rule-2) !important;
-    transform: none !important;
-    box-shadow: none !important;
+  .dispatch-pro :global(.tcell) {
+    padding: 14px 18px;
+    border-right: 1px solid var(--rule);
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto auto;
+    column-gap: 14px; row-gap: 4px;
   }
-  /* Kill the breathe animations on KPI cards */
-  .dispatch-pro :global(.card-breathe),
-  .dispatch-pro :global(.card-breathe-amber),
-  .dispatch-pro :global([class*="card-in"]) {
-    animation: none !important;
+  .dispatch-pro :global(.tcell:last-child) { border-right: none; }
+  .dispatch-pro :global(.tcell .label) {
+    font-family: var(--pro-sans); font-size: 9px; font-weight: 700;
+    letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--graphite);
+    grid-column: 1; grid-row: 1;
+  }
+  .dispatch-pro :global(.tcell .value) {
+    font-family: var(--pro-mono); font-weight: 600; font-size: 26px;
+    letter-spacing: -0.02em; color: var(--ink); line-height: 1;
+    grid-column: 1; grid-row: 2;
+  }
+  .dispatch-pro :global(.tcell .value.go)      { color: var(--go); }
+  .dispatch-pro :global(.tcell .value.caution) { color: var(--caution); }
+  .dispatch-pro :global(.tcell .value.abort)   { color: var(--abort); }
+  .dispatch-pro :global(.tcell .sub) {
+    font-family: var(--pro-mono); font-size: 10px; color: var(--ash);
+    grid-column: 1 / -1; grid-row: 3; margin-top: 4px;
+  }
+  .dispatch-pro :global(.tcell .spark) {
+    grid-column: 2; grid-row: 1 / 3; align-self: center;
+    width: 80px; height: 32px; color: var(--graphite);
+  }
+
+  /* Board */
+  .dispatch-pro :global(.board) {
+    display: grid;
+    grid-template-columns: 1fr 300px;
+    min-height: 440px;
+    flex: 1;
+  }
+  .dispatch-pro :global(.board-main) {
+    border-right: 1px solid var(--rule);
+    display: flex; flex-direction: column;
+  }
+  .dispatch-pro :global(.board-head),
+  .dispatch-pro :global(.board-row) {
+    display: grid;
+    grid-template-columns: 28px 110px 56px 60px 1.2fr 78px 50px 62px 62px 52px;
+    align-items: center; gap: 10px; padding: 0 16px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .dispatch-pro :global(.board-head) {
+    height: 28px; background: var(--paper-2);
+    font-family: var(--pro-sans); font-size: 9px; font-weight: 700;
+    letter-spacing: 0.2em; text-transform: uppercase; color: var(--ash);
+    position: sticky; top: 40px;
+  }
+  .dispatch-pro :global(.board-head .num) { text-align: right; }
+  .dispatch-pro :global(.board-row) {
+    height: 38px;
+    font-family: var(--pro-mono); font-size: 11px; color: var(--ink);
+    cursor: pointer; text-decoration: none;
+    background: transparent;
+    border-left: none; border-right: none; border-top: none;
+    text-align: left;
+  }
+  .dispatch-pro :global(.board-row:hover) { background: var(--paper-2); }
+  .dispatch-pro :global(.board-row.selected) {
+    background: color-mix(in oklab, var(--data) 9%, var(--paper));
+  }
+  .dispatch-pro :global(.board-row .ix) { color: var(--ash); font-size: 10px; }
+  .dispatch-pro :global(.board-row .id) { color: var(--graphite); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .dispatch-pro :global(.board-row .title) {
+    font-family: var(--pro-sans); font-size: 12px; font-weight: 500; color: var(--ink);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    min-width: 0;
+  }
+  .dispatch-pro :global(.board-row .title .repo) { color: var(--graphite); margin-right: 8px; }
+  .dispatch-pro :global(.board-row .title .nul) { color: var(--ash); font-style: italic; }
+  .dispatch-pro :global(.board-row .num) { text-align: right; font-variant-numeric: tabular-nums; }
+  .dispatch-pro :global(.board-row .nu) { color: var(--ash); }
+  .dispatch-pro :global(.empty) {
+    padding: 24px 16px; text-align: center;
+    font-family: var(--pro-mono); font-size: 11px; color: var(--ash);
+  }
+
+  /* Right rail (split: tasking + context) */
+  .dispatch-pro :global(.side) {
+    display: grid; grid-template-rows: 1fr 1fr; min-height: 100%;
+  }
+  .dispatch-pro :global(.side > section) {
+    display: flex; flex-direction: column; min-height: 0;
+  }
+  .dispatch-pro :global(.side > section + section) { border-top: 1px solid var(--rule); }
+  .dispatch-pro :global(.side .body) { overflow-y: auto; padding: 0; }
+  .dispatch-pro :global(.task) {
+    padding: 10px 14px; border-bottom: 1px solid var(--rule);
+    display: grid; gap: 3px;
+  }
+  .dispatch-pro :global(.task .lane) {
+    font-family: var(--pro-sans); font-size: 8px; font-weight: 700;
+    letter-spacing: 0.2em; text-transform: uppercase; color: var(--data);
+  }
+  .dispatch-pro :global(.task .t) {
+    font-family: var(--pro-sans); font-size: 12px; color: var(--ink); line-height: 1.3;
+  }
+  .dispatch-pro :global(.task .meta) {
+    font-family: var(--pro-mono); font-size: 9px; color: var(--ash); letter-spacing: 0.04em;
+    display: flex; gap: 8px; flex-wrap: wrap;
+  }
+  .dispatch-pro :global(.task.empty) {
+    color: var(--ash); font-family: var(--pro-mono); font-size: 11px; padding: 12px 14px;
+  }
+
+  .dispatch-pro :global(.ctx) {
+    padding: 12px 14px; font-family: var(--pro-mono); font-size: 11px; color: var(--ink);
+  }
+  .dispatch-pro :global(.ctx .row) {
+    display: grid; grid-template-columns: 70px 1fr; gap: 8px;
+    padding: 3px 0; border-bottom: 1px dashed var(--rule);
+  }
+  .dispatch-pro :global(.ctx .row:last-child) { border-bottom: none; }
+  .dispatch-pro :global(.ctx .row .lbl) {
+    color: var(--ash); font-family: var(--pro-sans); font-size: 9px; font-weight: 700;
+    letter-spacing: 0.16em; text-transform: uppercase;
+  }
+  .dispatch-pro :global(.ctx .row .val) { color: var(--ink); }
+  .dispatch-pro :global(.ctx .empty) {
+    color: var(--ash); font-style: italic; padding: 12px 0;
+  }
+
+  @media (max-width: 1180px) {
+    .dispatch-pro :global(.board) { grid-template-columns: 1fr; }
+    .dispatch-pro :global(.board-main) { border-right: none; }
+    .dispatch-pro :global(.telemetry) { grid-template-columns: repeat(2, 1fr); }
+    .dispatch-pro :global(.tcell:nth-child(2)) { border-right: none; }
+    .dispatch-pro :global(.board-head),
+    .dispatch-pro :global(.board-row) {
+      grid-template-columns: 28px 56px 60px 1fr 78px 50px 62px 52px;
+    }
+    .dispatch-pro :global(.board-row .id),
+    .dispatch-pro :global(.board-head .col-id) { display: none; }
   }
 </style>

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -269,21 +269,33 @@
   );
 
   // ── Loaders ──────────────────────────────────────────
-  async function loadAll() {
-    const [runsR, empR, telR, sysR, evR, projR] = await Promise.allSettled([
-      listRuns({ limit: 50 }),
+  // Fast path: live ticker + working count drivers (cheap, change quickly).
+  async function loadFast() {
+    const [empR, evR] = await Promise.allSettled([
       getActiveEmployees(),
+      getAgentEvents({ limit: 20 }),
+    ]);
+    if (empR.status === 'fulfilled') activeEmployees = empR.value;
+    if (evR.status === 'fulfilled') agentEvents = evR.value;
+  }
+
+  // Slow path: heavier endpoints (telemetry runs ~5 SQL queries; system
+  // status reads /proc and shells out). Refresh less often.
+  async function loadSlow() {
+    const [runsR, telR, sysR, projR] = await Promise.allSettled([
+      listRuns({ limit: 50 }),
       getTelemetrySummary(),
       getSystemStatus(),
-      getAgentEvents({ limit: 20 }),
       listProjects(),
     ]);
     if (runsR.status === 'fulfilled') recentRuns = runsR.value.runs;
-    if (empR.status === 'fulfilled') activeEmployees = empR.value;
     if (telR.status === 'fulfilled') telemetry = telR.value;
     if (sysR.status === 'fulfilled') systemStatus = sysR.value;
-    if (evR.status === 'fulfilled') agentEvents = evR.value;
     if (projR.status === 'fulfilled') projects = projR.value;
+  }
+
+  async function loadAll() {
+    await Promise.all([loadFast(), loadSlow()]);
     loading = false;
   }
 
@@ -299,12 +311,23 @@
 
   $effect(() => {
     loadAll();
-    const t = setInterval(loadAll, 10_000);
+    // Skip polling while the tab is hidden — saves ~0.6 req/s on background tabs.
+    const isHidden = () => typeof document !== 'undefined' && document.visibilityState === 'hidden';
+    const fast = setInterval(() => { if (!isHidden()) loadFast(); }, 10_000);
+    const slow = setInterval(() => { if (!isHidden()) loadSlow(); }, 30_000);
     const c = setInterval(() => {
       const d = new Date();
       clockNow = `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
     }, 1000);
-    return () => { clearInterval(t); clearInterval(c); };
+    // On tab refocus, pull fresh data immediately so users don't see stale-then-update.
+    const onVis = () => { if (!isHidden()) loadAll(); };
+    if (typeof document !== 'undefined') document.addEventListener('visibilitychange', onVis);
+    return () => {
+      clearInterval(fast);
+      clearInterval(slow);
+      clearInterval(c);
+      if (typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVis);
+    };
   });
 
   // Reload coordinator tasks whenever the latest active run changes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,7 +154,7 @@ claude-agent-station/
 │       │   ├── App.svelte          # Root + hash-based routing
 │       │   ├── pages/              # 8 page components
 │       │   │   ├── AgentTeamsCanvas.svelte  # Agent Teams live view
-│       │   │   ├── CommandCenter.svelte     # Dispatch
+│       │   │   ├── CommandCenter.svelte     # Dispatch — Pro dense board (strip + ticker + filters + telemetry + run table + right rail)
 │       │   │   ├── MissionControl.svelte    # Mission control panel
 │       │   │   ├── ProjectDetail.svelte     # Single-project view
 │       │   │   ├── ProjectsPage.svelte      # Projects list

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,10 @@ Authentication settings are listed in the env-vars table above. Additional behav
 
 Exempt from `STATION_API_KEY` auth (verified in `dashboard/backend/app/main.py`): the health router, the internal agent webhook router, the WebSocket log-streaming router (`logs.ws_router` at `/api/logs/ws`, which has its own inline WebSocket auth), the GitHub webhook router, and GitHub App lifecycle endpoints.
 
+### Dispatch telemetry
+
+`GET /api/runs/telemetry-summary` (added by the Pro Dispatch redesign) is the single endpoint backing the four telemetry cells on the home page (Active / Queue / Tokens·7D / System). It aggregates running runs + their teammates, queue counts grouped by lifecycle state, a 7-day token total with daily sparkline points, and a coarse system-health label (`NOMINAL`/`DEGR`/`CRIT`) derived from disk and memory pressure. Lives in `dashboard/backend/app/routers/runs.py`; the response shape is `TelemetrySummaryOut` in `app/schemas.py`.
+
 ## Project config
 
 Each managed repository is one row in the `projects` table. The dashboard's Projects page is the easiest way to edit; the underlying schema (used by `POST /api/projects`) is:


### PR DESCRIPTION
## Summary

- Rewrites the Station header (`TopNav`) and home page (`CommandCenter`) to the Pro dispatch-board layout from `design-drafts/dispatch-board.html`, fully wired to live data — no mock numbers.
- Adds `GET /api/runs/telemetry-summary` so the four telemetry cells (Active / Queue / Tokens·7D / System) come from a single backend round-trip.
- Adds a `flap` Svelte action (with reduced-motion fallback) and copies the unprefixed Pro component CSS (`.strip`, `.ticker`, `.section-head`, `.status`, `.mode`, `.aut`, `.run-tick`, `.flap`, `.tele`, `.legend`, `.btn-stop`, `.btn-theme`) into `lib/design/pro.css` so we don't load the `design-drafts/` file at runtime.

## What's wired

- **Strip header**: SSE indicator + `WORKING · N` pill + token total from `/api/runs/active-employees` + agentPresence; `Stop ⌘.` button hits `POST /api/system/pause`; theme toggle persists via the existing `appearance.svelte` (data-theme on `<html>`).
- **Ticker**: last 20 entries from `/api/agent-events?limit=20`, looped via duplicating the track.
- **Filters**: All / Active / 24H / Plan-Review / Interrupted are real client-side filters over `/api/runs?limit=50`. *By-Mode* renders a stub banner ("Coming soon").
- **Alerts**: derived from `/api/system/status` resources — caution at disk <5G or mem >70%, abort at disk <1G or mem >90%. Hidden entirely when no thresholds trip.
- **Telemetry**: all four cells fetch from the new `/api/runs/telemetry-summary`. Includes a 7-day token sparkline.
- **Board**: 50-row dense table with flap intro animation, click → `/runs/<id>`, hover/`j`/`k` populates the right-rail Context panel.
- **Coordinator Live (right rail)**: `getCoordinatorTasks(runId)` for the most-recent active run; empty state otherwise.
- **Footer**: live clock (1Hz), short run-id, latest agent event, token delta.
- **Keyboard**: `/` focus search, `j`/`k` rows, `t` theme, `Cmd+.` / `Ctrl+.` global pause.

## What's stubbed

- The *By-Mode* filter renders a banner pointing back at *All* — not built out as a separate grouped view.

## Test plan

- [x] `npm run build` succeeds (vite + svelte 5).
- [x] Backend tests: `pytest dashboard/backend/tests/test_runs.py -q` → 20 passed (incl. 2 new telemetry-summary cases covering empty + populated shapes).
- [x] `data-testid="command-center"` and `.animate-fade-in` preserved on the Dispatch root → existing `Dashboard page loads` Playwright test still has its markers.
- [ ] Manually exercise hover, j/k, t, ⌘. on a deployed station.
- [ ] Verify alerts only appear when disk/memory cross thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)