### PR TITLE
chore(ui): Dispatch board polish (closes #310, #311)

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -51,7 +51,7 @@ from app.services import service_control
 from app.services.diff_parser import DiffResult, parse_unified_diff
 from app.services.event_bus import publish
 from app.services.log_importer import import_historical_runs
-from app.services.systemd import systemctl
+from app.services.systemd import get_system_resources, systemctl
 
 logger = logging.getLogger(__name__)
 
@@ -180,10 +180,6 @@ async def get_telemetry_summary(db: AsyncSession = Depends(get_db)):
     Active runs, Queue stats, Tokens (7d) summary + sparkline,
     and a coarse System health label derived from disk/memory.
     """
-    from datetime import timedelta
-
-    from app.services.systemd import get_system_resources
-
     # --- 1. Active runs / teammates / roles ---
     active_runs_res = await db.execute(
         select(Run).where(Run.status.in_(["running", "plan_reviewing", "reviewing"]))
@@ -192,6 +188,17 @@ async def get_telemetry_summary(db: AsyncSession = Depends(get_db)):
 
     roles: list[str] = []
     teammates_count = 0
+    # NOTE: ``CoordinatorTask`` does not currently carry an explicit ``role``
+    # column — see ``dashboard/backend/app/models.py`` (the only ``role`` is
+    # on ``CoordinatorMessage`` for chat direction). Until a schema migration
+    # adds one (and the orchestrator populates it), we fall back to substring
+    # matching teammate names against the canonical role tags. This is
+    # brittle: a teammate named ``frontend-spright`` matches but a renamed
+    # variant like ``ui-spright`` would silently drop out.
+    # TODO(#311): once teammate roles are first-class (either as a column on
+    # CoordinatorTask or as an explicit ``role`` field in the JSON written
+    # to ``Run.team_members``), prefer that over name-substring matching.
+    _ROLE_TAGS = ("backend", "frontend", "qa", "lead")
     if active_runs:
         for r in active_runs:
             members_raw = r.team_members
@@ -202,8 +209,15 @@ async def get_telemetry_summary(db: AsyncSession = Depends(get_db)):
                 if isinstance(members, list):
                     teammates_count += len(members)
                     for m in members:
+                        # Prefer an explicit ``role`` field if the
+                        # orchestrator started writing one; otherwise fall
+                        # back to substring-matching the name.
+                        explicit = (m.get("role") if isinstance(m, dict) else None) or ""
                         name = (m.get("name") if isinstance(m, dict) else str(m)) or ""
-                        for tag in ("backend", "frontend", "qa", "lead"):
+                        if explicit and explicit.lower() in _ROLE_TAGS and explicit.lower() not in roles:
+                            roles.append(explicit.lower())
+                            continue
+                        for tag in _ROLE_TAGS:
                             if tag in name.lower() and tag not in roles:
                                 roles.append(tag)
             except Exception:  # noqa: BLE001 — best-effort introspection
@@ -220,8 +234,10 @@ async def get_telemetry_summary(db: AsyncSession = Depends(get_db)):
             tasks = ct_res.scalars().all()
             teammates_count = len(tasks)
             for t in tasks:
+                # CoordinatorTask has no role column today; match teammate
+                # name as a brittle proxy. See TODO(#311) above.
                 name = (t.claimed_by or t.teammate_agent_id or "") or ""
-                for tag in ("backend", "frontend", "qa", "lead"):
+                for tag in _ROLE_TAGS:
                     if tag in name.lower() and tag not in roles:
                         roles.append(tag)
 
@@ -236,20 +252,31 @@ async def get_telemetry_summary(db: AsyncSession = Depends(get_db)):
         select(QueueItem.state, func.count(QueueItem.id)).group_by(QueueItem.state)
     )
     by_state = {row[0]: row[1] for row in qstate_res.all()}
-    claimed = (
-        by_state.get("claimed", 0)
-        + by_state.get("assigned", 0)
-        + by_state.get("planning", 0)
-        + by_state.get("in_progress", 0)
-    )
-    done = by_state.get("completed", 0) + by_state.get("approved", 0)
-    pending = by_state.get("pending", 0)
+    _CLAIMED_STATES = {"claimed", "assigned", "planning", "in_progress"}
+    _DONE_STATES = {"completed", "approved"}
+    _PENDING_STATES = {"pending"}
+    claimed = sum(v for k, v in by_state.items() if k in _CLAIMED_STATES)
+    done = sum(v for k, v in by_state.items() if k in _DONE_STATES)
+    pending = sum(v for k, v in by_state.items() if k in _PENDING_STATES)
     queue_total = sum(by_state.values())
+    # Anything not bucketed above (e.g. ``failed``, ``paused``, ``cancelled``,
+    # plus any future states) gets routed into ``other`` so the cells add up
+    # to ``total`` and the operator can see queue items aren't simply lost.
+    other = queue_total - (claimed + done + pending)
+    if other < 0:
+        other = 0  # defensive: shouldn't happen, but keep ``other`` non-negative.
 
-    queue = TelemetryQueue(total=queue_total, claimed=claimed, done=done, pending=pending)
+    queue = TelemetryQueue(
+        total=queue_total,
+        claimed=claimed,
+        done=done,
+        pending=pending,
+        other=other,
+    )
 
     # --- 3. Tokens (7d) — sum, run count, in/out, sparkline ---
-    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+    now_utc = datetime.now(timezone.utc)
+    cutoff = now_utc - timedelta(days=7)
     daily_q = (
         select(
             func.date(Run.started_at).label("date"),
@@ -260,18 +287,29 @@ async def get_telemetry_summary(db: AsyncSession = Depends(get_db)):
         .order_by(func.date(Run.started_at))
     )
     daily_rows = (await db.execute(daily_q)).all()
-    spark = [int(row.tot or 0) for row in daily_rows]
+    # Backfill missing days with 0 so the sparkline always has 7 points
+    # ordered oldest → today. ``func.date(...)`` returns a string in SQLite,
+    # so we key by ISO date strings.
+    by_day = {str(row.date): int(row.tot or 0) for row in daily_rows}
+    today = now_utc.date()
+    spark: list[int] = []
+    for offset in range(6, -1, -1):
+        day = today - timedelta(days=offset)
+        spark.append(by_day.get(day.isoformat(), 0))
 
     sum_q = (
         select(
-            func.coalesce(func.sum(Run.tokens_total), 0),
-            func.coalesce(func.sum(Run.tokens_input), 0),
-            func.coalesce(func.sum(Run.tokens_output), 0),
-            func.count(Run.id),
+            func.coalesce(func.sum(Run.tokens_total), 0).label("total"),
+            func.coalesce(func.sum(Run.tokens_input), 0).label("input"),
+            func.coalesce(func.sum(Run.tokens_output), 0).label("output"),
+            func.count(Run.id).label("runs"),
         ).where(Run.started_at >= cutoff)
     )
-    sum_row = (await db.execute(sum_q)).first()
-    tot7, in7, out7, runs7 = (sum_row[0] or 0, sum_row[1] or 0, sum_row[2] or 0, sum_row[3] or 0)
+    sum_row = (await db.execute(sum_q)).mappings().one()
+    tot7 = sum_row["total"] or 0
+    in7 = sum_row["input"] or 0
+    out7 = sum_row["output"] or 0
+    runs7 = sum_row["runs"] or 0
 
     tokens_7d = TelemetryTokens7d(
         total=int(tot7),

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -504,6 +504,11 @@ class TelemetryQueue(BaseModel):
     claimed: int
     done: int
     pending: int
+    # Catch-all for queue items not bucketed into the three above (e.g.
+    # ``failed``, ``paused``, ``cancelled``). Keeps ``claimed + done +
+    # pending + other == total`` so the UI can reconcile the cells with
+    # the headline count without silently dropping rows.
+    other: int = 0
 
 
 class TelemetryTokens7d(BaseModel):

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -399,3 +399,92 @@ async def test_telemetry_summary_aggregates_runs_and_queue(client):
     assert data["tokens_7d"]["runs"] == 2
     assert data["tokens_7d"]["input"] == 150
     assert data["tokens_7d"]["output"] == 650
+    # spark backfilled to a length-7 array even though only 2 days had data
+    assert len(data["tokens_7d"]["spark"]) == 7
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resources, expected_status",
+    [
+        # Plenty of headroom → NOMINAL
+        (
+            {
+                "disk_free_gb": 50.0,
+                "disk_total_gb": 100.0,
+                "memory_used_mb": 4_000,
+                "memory_total_mb": 16_000,
+                "uptime_seconds": 1234.0,
+            },
+            "NOMINAL",
+        ),
+        # Disk under 5G but above 1G, mem 75% → DEGR
+        (
+            {
+                "disk_free_gb": 3.5,
+                "disk_total_gb": 100.0,
+                "memory_used_mb": 12_000,
+                "memory_total_mb": 16_000,
+                "uptime_seconds": 1234.0,
+            },
+            "DEGR",
+        ),
+        # Disk under 1G OR mem above 90% → CRIT
+        (
+            {
+                "disk_free_gb": 0.4,
+                "disk_total_gb": 100.0,
+                "memory_used_mb": 15_000,
+                "memory_total_mb": 16_000,
+                "uptime_seconds": 1234.0,
+            },
+            "CRIT",
+        ),
+    ],
+)
+async def test_telemetry_summary_system_status_thresholds(
+    client, monkeypatch, resources, expected_status
+):
+    """`telemetry_summary.system.status` reflects the disk/memory pressure
+    thresholds in :func:`get_telemetry_summary`. Patches
+    :func:`app.services.systemd.get_system_resources` (the same symbol the
+    router imports module-level) so the test doesn't depend on /proc."""
+    from app.routers import runs as runs_router
+
+    async def fake_resources():
+        return resources
+
+    monkeypatch.setattr(runs_router, "get_system_resources", fake_resources)
+
+    resp = await client.get("/api/runs/telemetry-summary")
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["system"]["status"] == expected_status
+
+
+@pytest.mark.asyncio
+async def test_telemetry_summary_queue_other_bucket(client):
+    """Queue items in ``failed``/``paused``/``cancelled`` end up in the
+    ``other`` bucket so ``claimed + done + pending + other == total``."""
+    from app.database import async_session
+    from app.models import QueueItem
+
+    async with async_session() as s:
+        s.add_all([
+            QueueItem(project_repo="x/y", issue_number=10, mode="full", state="pending"),
+            QueueItem(project_repo="x/y", issue_number=11, mode="full", state="claimed"),
+            QueueItem(project_repo="x/y", issue_number=12, mode="full", state="completed"),
+            QueueItem(project_repo="x/y", issue_number=13, mode="full", state="failed"),
+            QueueItem(project_repo="x/y", issue_number=14, mode="full", state="cancelled"),
+        ])
+        await s.commit()
+
+    resp = await client.get("/api/runs/telemetry-summary")
+    assert resp.status_code == 200, resp.text
+    q = resp.json()["queue"]
+    assert q["total"] == 5
+    assert q["pending"] == 1
+    assert q["claimed"] == 1
+    assert q["done"] == 1
+    assert q["other"] == 2
+    assert q["pending"] + q["claimed"] + q["done"] + q["other"] == q["total"]

--- a/dashboard/frontend/src/components/layout/TopNav.svelte
+++ b/dashboard/frontend/src/components/layout/TopNav.svelte
@@ -141,6 +141,9 @@
       onclick={handleStop}
       disabled={stopping || triggering}
       title={activeCount > 0 ? 'Engage global pause (Cmd+. or Ctrl+.)' : 'Trigger run'}
+      aria-label={activeCount > 0
+        ? 'Engage global pause — all active runs will defer to the permission tray'
+        : 'Trigger a new run'}
     >
       {#if activeCount > 0}
         Stop <kbd>⌘.</kbd>

--- a/dashboard/frontend/src/lib/design/flap.ts
+++ b/dashboard/frontend/src/lib/design/flap.ts
@@ -15,8 +15,15 @@
  * immediately with no transform animation.
  */
 
-const REDUCED_MOTION = typeof window !== 'undefined'
-  && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+/** Read prefers-reduced-motion at call time so the flap respects OS-level
+ * preference changes within a session. Reading on each `buildChars` call is
+ * cheap (single matchMedia lookup) and avoids the complexity of subscribing
+ * to a `change` event and tearing it down. The previous module-level
+ * constant was captured once at import and never updated. */
+function reducedMotion(): boolean {
+  return typeof window !== 'undefined'
+    && !!window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+}
 
 export interface FlapOptions {
   text: string;
@@ -40,7 +47,7 @@ function buildChars(
 ) {
   host.classList.add('flap');
   host.textContent = '';
-  const skipAnim = !animate || REDUCED_MOTION;
+  const skipAnim = !animate || reducedMotion();
   for (let i = 0; i < text.length; i++) {
     const s = document.createElement('span');
     s.textContent = text[i] === ' ' ? ' ' : text[i];

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -305,7 +305,7 @@ export interface AgentEvent {
 // --- Dispatch telemetry ---
 export interface TelemetrySummary {
   active: { count: number; teammates: number; roles: string[] };
-  queue: { total: number; claimed: number; done: number; pending: number };
+  queue: { total: number; claimed: number; done: number; pending: number; other: number };
   tokens_7d: { total: number; runs: number; input: number; output: number; spark: number[] };
   system: {
     status: 'NOMINAL' | 'DEGR' | 'CRIT' | string;

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -43,7 +43,29 @@
   let hovered = $state<Run | null>(null);
   let selectedIdx = $state<number>(-1);
   let clockNow = $state<string>('00:00:00');
-  let acked = $state<Set<string>>(new Set());
+  // Persisted acked alerts: localStorage stores a sorted JSON array of
+  // alert ids (Sets don't serialize directly). Keyed by `dispatch-acked-alerts`
+  // so a page refresh doesn't resurrect alerts the operator already cleared.
+  const ACKED_STORAGE_KEY = 'dispatch-acked-alerts';
+  function loadAckedFromStorage(): Set<string> {
+    if (typeof localStorage === 'undefined') return new Set();
+    try {
+      const raw = localStorage.getItem(ACKED_STORAGE_KEY);
+      if (!raw) return new Set();
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) return new Set(parsed.map(String));
+    } catch { /* corrupt storage — start fresh */ }
+    return new Set();
+  }
+  let acked = $state<Set<string>>(loadAckedFromStorage());
+  $effect(() => {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      // Sort so the persisted JSON is stable across writes — easier to
+      // diff in DevTools and cheaper for the storage engine.
+      localStorage.setItem(ACKED_STORAGE_KEY, JSON.stringify([...acked].sort()));
+    } catch { /* quota exceeded or storage disabled — silent */ }
+  });
 
   // ── Helpers ────────────────────────────────────────────
   function pad2(n: number) { return String(n).padStart(2, '0'); }
@@ -64,6 +86,7 @@
   }
   function fmtAge(startedAt: string | null): string {
     if (!startedAt) return '—';
+    // SQLite timestamps are written by Python with timezone.utc; we append 'Z' if missing so Date() parses as UTC.
     const hasTz = startedAt.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(startedAt);
     const t = new Date(hasTz ? startedAt : startedAt + 'Z').getTime();
     const diff = Date.now() - t;
@@ -103,7 +126,9 @@
     const s = (r.status ?? '').toLowerCase();
     if (s === 'running' || s === 'started') return { label: 'RUN', cls: 'run', tick: true };
     if (s === 'reviewing') return { label: 'REVIEW', cls: 'run', tick: true };
-    if (s === 'plan_reviewing' || s === 'awaiting_plan_review') return { label: 'PLAN ?', cls: 'planok', tick: false };
+    // 'PLAN-RV' (review) chosen over 'PLAN ?' because at the dense board's
+    // 9px uppercase rendering the '?' visually collapsed to a 'T' (PLANT).
+    if (s === 'plan_reviewing' || s === 'awaiting_plan_review') return { label: 'PLAN-RV', cls: 'planok', tick: false };
     if (s === 'plan_approved' || r.verdict === 'APPROVE' || r.verdict === 'PR') return { label: 'PLAN OK', cls: 'planok', tick: false };
     if (s === 'plan_rejected' || r.verdict === 'REJECT') return { label: 'PLAN ✗', cls: 'planx', tick: false };
     if (s === 'interrupted') return { label: 'STOP', cls: 'stop', tick: false };
@@ -115,9 +140,20 @@
 
   function modeFor(r: Run): { label: string; cls: string } {
     const m = (r.mode ?? '').toLowerCase();
+    // Canonical mode values emitted by the orchestrator (run_lifecycle.py +
+    // station_orchestrator.py + run-manager.sh):
+    //   full, plan_only, plan, analyze, vision-bootstrap, employee, manager,
+    //   agent_teams (Agent Teams flow). Local dev DBs typically only have
+    //   `full`; production widens this. Each gets an explicit short badge
+    //   so we don't fall through to the 4-char truncation that produced
+    //   `AGEN` for `agent_teams` (issue #310).
     if (m === 'plan_only') return { label: 'PLAN', cls: 'plan' };
+    if (m === 'plan') return { label: 'PLAN', cls: 'plan' };
+    if (m === 'analyze') return { label: 'ANLZ', cls: 'plan' };
     if (m === 'vision-bootstrap') return { label: 'VIS', cls: 'vision' };
+    if (m === 'agent_teams') return { label: 'TEAMS', cls: 'full' };
     if (m === 'employee') return { label: 'EMP', cls: 'full' };
+    if (m === 'manager') return { label: 'MGR', cls: 'full' };
     if (m === 'full') return { label: 'FULL', cls: 'full' };
     return { label: (m || '—').toUpperCase().slice(0, 4), cls: 'full' };
   }
@@ -306,12 +342,18 @@
     }
     try {
       coordTasks = await getCoordinatorTasks(runId);
-    } catch { coordTasks = []; }
+    } catch (err) {
+      console.warn('[dispatch] getCoordinatorTasks failed', err);
+      coordTasks = [];
+    }
   }
 
   $effect(() => {
     loadAll();
     // Skip polling while the tab is hidden — saves ~0.6 req/s on background tabs.
+    // TODO(#311): drive run-state and agent-event updates from the existing
+    // /api/events/stream SSE so the polls below only refresh telemetry,
+    // system, and projects. Deferred from PR #309 to keep this change small.
     const isHidden = () => typeof document !== 'undefined' && document.visibilityState === 'hidden';
     const fast = setInterval(() => { if (!isHidden()) loadFast(); }, 10_000);
     const slow = setInterval(() => { if (!isHidden()) loadSlow(); }, 30_000);
@@ -506,7 +548,7 @@
       <div class="label">Queue</div>
       <div class="value">{telemetry?.queue.total ?? 0}</div>
       <div class="sub">
-        {telemetry?.queue.claimed ?? 0} claimed · {telemetry?.queue.done ?? 0} done · {telemetry?.queue.pending ?? 0} pending
+        {telemetry?.queue.claimed ?? 0} claimed · {telemetry?.queue.done ?? 0} done · {telemetry?.queue.pending ?? 0} pending{#if (telemetry?.queue.other ?? 0) > 0} · {telemetry?.queue.other} other{/if}
       </div>
     </div>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,15 @@ Exempt from `STATION_API_KEY` auth (verified in `dashboard/backend/app/main.py`)
 
 `GET /api/runs/telemetry-summary` (added by the Pro Dispatch redesign) is the single endpoint backing the four telemetry cells on the home page (Active / Queue / Tokens·7D / System). It aggregates running runs + their teammates, queue counts grouped by lifecycle state, a 7-day token total with daily sparkline points, and a coarse system-health label (`NOMINAL`/`DEGR`/`CRIT`) derived from disk and memory pressure. Lives in `dashboard/backend/app/routers/runs.py`; the response shape is `TelemetrySummaryOut` in `app/schemas.py`.
 
+**Response shape** (see `TelemetrySummaryOut` and the four sub-models in `app/schemas.py` for the authoritative fields and types):
+
+| Sub-object | Fields | What each means |
+|---|---|---|
+| `active` (`TelemetryActive`) | `count`, `teammates`, `roles[]` | Number of runs in `running` / `plan_reviewing` / `reviewing`, total teammate slots across those runs (from `Run.team_members` JSON, falling back to running `CoordinatorTask` rows), and the distinct role tags found (`backend`, `frontend`, `qa`, `lead`). |
+| `queue` (`TelemetryQueue`) | `total`, `claimed`, `done`, `pending`, `other` | Counts of `QueueItem` rows grouped by lifecycle state. `claimed` aggregates `claimed`/`assigned`/`planning`/`in_progress`; `done` aggregates `completed`/`approved`; `pending` is just `pending`; `other` catches anything else (`failed`/`paused`/`cancelled`/...) so the four cells always sum to `total`. |
+| `tokens_7d` (`TelemetryTokens7d`) | `total`, `runs`, `input`, `output`, `spark[]` | Sum of `Run.tokens_total` / `tokens_input` / `tokens_output` and run count for the past 7 days. `spark` is always a length-7 array of per-day token totals (oldest → today, missing days backfilled to 0) feeding the cell sparkline. |
+| `system` (`TelemetrySystem`) | `status`, `disk_free_gb`, `memory_used_pct`, `uptime_secs` | Coarse health label derived from disk and memory pressure: `NOMINAL` is the default; `DEGR` triggers under 5G free or >70% memory used; `CRIT` triggers under 1G free or >90% memory used. Underlying numbers come from `app.services.systemd.get_system_resources`. |
+
 ## Project config
 
 Each managed repository is one row in the `projects` table. The dashboard's Projects page is the easiest way to edit; the underlying schema (used by `POST /api/projects`) is:


### PR DESCRIPTION
Bundles the deferred follow-ups from PR #309 review into a single
small PR. Targets `dev` per CLAUDE.md.

## Summary

- **Backend** (`dashboard/backend/app/routers/runs.py`): harden the
  `telemetry-summary` aggregation — backfill the 7d sparkline, add an
  `other` queue bucket, switch to labelled column access, hoist
  imports, document the brittle role-substring match.
- **Frontend** (`CommandCenter.svelte`, `flap.ts`, `TopNav.svelte`,
  `types.ts`): persist acked alerts, surface `queue.other`, swap
  `PLAN ?` for `PLAN-RV`, add explicit mode-badge branches for every
  canonical orchestrator mode (closes #310), reactive
  `prefers-reduced-motion`, plus minor UX/a11y polish.
- **Docs** (`docs/configuration.md`): enumerate the
  `/api/runs/telemetry-summary` response shape.

## Issue → commit map

### #310 — agent_teams mode badge
- [x] Explicit `modeFor()` branches for every canonical mode incl. `agent_teams` → `TEAMS` — `221e3f3`

### #311 — Backend (`runs.py`)
- [x] Backfill sparkline (always length 7) — `dee2b54`
- [x] Document brittle role substring match + `TODO(#311)` — `dee2b54`
- [x] Queue `other` bucket — `dee2b54`
- [x] Hoist `timedelta` and `get_system_resources` to module scope — `dee2b54`
- [x] Labelled `.mappings().one()` row access for the totals query — `dee2b54`
- [x] Thresholds test (parametrised NOMINAL/DEGR/CRIT) + `other` regression — `dee2b54`

### #311 — Frontend
- [x] Persist `acked` alerts to `localStorage` — `221e3f3`
- [x] Stop ↔ Run dual-purpose button: explicit `aria-label` — `221e3f3`
- [x] UTC date assumption comment in `fmtAge` — `221e3f3`
- [x] `console.warn` on `getCoordinatorTasks` failure — `221e3f3`
- [x] Reactive `REDUCED_MOTION` getter in `flap.ts` — `221e3f3`
- [x] `TODO(#311)` near setInterval for SSE refactor (intentionally deferred) — `221e3f3`
- [x] `PLAN-RV` label — `221e3f3`

### #311 — Docs
- [x] Document `/api/runs/telemetry-summary` response shape — `203d078`

## Intentionally deferred

- **SSE-driven run/event updates** (#311 item 12) — left as
  `TODO(#311)` next to the existing setInterval block. Scope is large
  enough to deserve its own PR.

## Surprises

- `CoordinatorTask` has no `role` column today (only `analyst_role` on
  `Run`). Kept the substring heuristic with an explicit comment + a
  `TODO(#311)` to surface a real role field on `team_members` JSON.
- Local DB only had `mode = "full"`; modeFor was widened to cover the
  full set of canonical orchestrator modes (`analyze`, `plan`,
  `manager`, `agent_teams`) so production never hits the truncation
  fallback.

## Test plan

- [x] `pytest dashboard/backend/tests/test_runs.py -q` → 24 passed
- [x] `npm run build` → succeeds
- [ ] Manual smoke: load `/dispatch`, confirm `PLAN-RV` renders, ack an
  alert + reload to confirm it stays acked, check the queue cell shows
  `other` only when nonzero