### PR TITLE
feat(ui): mount LiveTicker + StationStatusFooter globally

### DIFF
--- a/dashboard/frontend/src/components/layout/LiveTicker.svelte
+++ b/dashboard/frontend/src/components/layout/LiveTicker.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import { getAgentEvents } from '../../lib/api';
+  import type { AgentEvent } from '../../lib/types';
+
+  let events = $state<AgentEvent[]>([]);
+
+  let segments = $derived.by(() => {
+    const segs = events.slice(0, 20).map((e) => {
+      const actor = (e.agent_id ?? 'station').split(':').pop() ?? 'station';
+      const tool =
+        (e.event_data && (e.event_data as Record<string, unknown>).tool as string)
+        ?? e.event_type
+        ?? 'event';
+      const target =
+        (e.event_data && (e.event_data as Record<string, unknown>).summary as string)
+        ?? (e.event_data && (e.event_data as Record<string, unknown>).file_path as string)
+        ?? '';
+      return { actor, tool, target };
+    });
+    if (segs.length === 0) {
+      return [{ actor: 'station', tool: 'idle', target: 'no recent activity' }];
+    }
+    return segs;
+  });
+
+  async function load() {
+    try {
+      events = await getAgentEvents({ limit: 20 });
+    } catch {
+      // Keep last-good events; ticker just stops advancing.
+    }
+  }
+
+  $effect(() => {
+    load();
+    const isHidden = () => typeof document !== 'undefined' && document.visibilityState === 'hidden';
+    const t = setInterval(() => { if (!isHidden()) load(); }, 10_000);
+    const onVis = () => { if (!isHidden()) load(); };
+    document.addEventListener('visibilitychange', onVis);
+    return () => {
+      clearInterval(t);
+      document.removeEventListener('visibilitychange', onVis);
+    };
+  });
+</script>
+
+<div class="ticker" aria-label="Station activity">
+  <span class="ticker-tag">// Live</span>
+  <div class="ticker-track">
+    {#each [...segments, ...segments] as seg}
+      <span><b>{seg.actor}</b> · <em>{seg.tool}</em> {seg.target}</span>
+    {/each}
+  </div>
+</div>

--- a/dashboard/frontend/src/components/layout/Shell.svelte
+++ b/dashboard/frontend/src/components/layout/Shell.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
   import VaporBackground from '../background/VaporBackground.svelte';
   import TopNav from './TopNav.svelte';
-  import { route } from '../../lib/router.svelte';
+  import LiveTicker from './LiveTicker.svelte';
+  import StationStatusFooter from './StationStatusFooter.svelte';
   import type { Snippet } from 'svelte';
 
   let {
@@ -17,14 +18,6 @@
     sseConnected?: boolean;
     activeCount?: number;
   } = $props();
-
-  // The Pro Dispatch board owns its own dense, edge-to-edge layout
-  // (strip + ticker + filters + telemetry + board + footer). Drop the
-  // shell's max-width / padding container for it so the bleed isn't
-  // boxed in. Other pages keep the centered, padded canvas.
-  let isDispatch = $derived(
-    route.page === 'command-center' || route.page === 'runs'
-  );
 </script>
 
 <VaporBackground />
@@ -36,14 +29,16 @@
   {activeCount}
 />
 
+<LiveTicker />
+
 <main
   id="main-content"
   class="relative overflow-x-hidden"
   style:z-index="1"
-  style:min-height="calc(100vh - 40px)"
-  style:padding={isDispatch ? '0' : '28px 32px 48px'}
-  style:max-width={isDispatch ? 'none' : '1600px'}
-  style:margin={isDispatch ? '0' : '0 auto'}
+  style:flex="1 1 auto"
+  style:min-height="0"
 >
   {@render children()}
 </main>
+
+<StationStatusFooter />

--- a/dashboard/frontend/src/components/layout/StationStatusFooter.svelte
+++ b/dashboard/frontend/src/components/layout/StationStatusFooter.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { getActiveEmployees, getAgentEvents } from '../../lib/api';
+  import type { ActiveEmployee, AgentEvent } from '../../lib/types';
+
+  let active = $state<ActiveEmployee[]>([]);
+  let events = $state<AgentEvent[]>([]);
+  let clockNow = $state('00:00:00');
+
+  function pad2(n: number) { return String(n).padStart(2, '0'); }
+  function fmtTok(n: number | null | undefined): string {
+    if (n == null || n === 0) return '—';
+    if (n < 1000) return String(n);
+    if (n < 10_000) return (n / 1000).toFixed(1) + 'K';
+    if (n < 1_000_000) return Math.round(n / 1000) + 'K';
+    return (n / 1_000_000).toFixed(1) + 'M';
+  }
+  function shortId(id: string | null | undefined): string {
+    if (!id) return '—';
+    return id.replace(/^run-(vb-)?/, '…');
+  }
+
+  let latest = $derived(active[0] ?? null);
+
+  let footerEvent = $derived.by(() => {
+    const e = events[0];
+    if (!e) return { actor: '—', tool: '', target: 'awaiting events' };
+    const actor = (e.agent_id ?? 'station').split(':').pop() ?? 'station';
+    const tool = ((e.event_data && (e.event_data as Record<string, unknown>).tool as string) ?? e.event_type ?? '').toString();
+    const target = ((e.event_data && (e.event_data as Record<string, unknown>).summary as string)
+      ?? (e.event_data && (e.event_data as Record<string, unknown>).file_path as string)
+      ?? '').toString();
+    return { actor, tool, target };
+  });
+
+  let liveTokens = $derived(latest?.tokens_total ?? 0);
+
+  async function load() {
+    try {
+      const [a, e] = await Promise.allSettled([
+        getActiveEmployees(),
+        getAgentEvents({ limit: 5 }),
+      ]);
+      if (a.status === 'fulfilled') active = a.value;
+      if (e.status === 'fulfilled') events = e.value;
+    } catch {
+      // Keep last-good state.
+    }
+  }
+
+  $effect(() => {
+    load();
+    const isHidden = () => typeof document !== 'undefined' && document.visibilityState === 'hidden';
+    const t = setInterval(() => { if (!isHidden()) load(); }, 10_000);
+    const c = setInterval(() => {
+      const d = new Date();
+      clockNow = `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
+    }, 1000);
+    const onVis = () => { if (!isHidden()) load(); };
+    document.addEventListener('visibilitychange', onVis);
+    return () => {
+      clearInterval(t);
+      clearInterval(c);
+      document.removeEventListener('visibilitychange', onVis);
+    };
+  });
+</script>
+
+<footer class="tele" aria-label="Station status">
+  <span class="now">
+    <span class="run-tick"></span>
+    <span>{clockNow}</span>
+  </span>
+  <span><b>{latest ? shortId(latest.run_id) : '—'}</b></span>
+  <span class="ev">
+    {#if footerEvent.actor !== '—'}
+      {footerEvent.actor} · <em>{footerEvent.tool}</em> {footerEvent.target}
+    {:else}
+      awaiting events
+    {/if}
+  </span>
+  <span data-testid="footer-tokens">{liveTokens > 0 ? `+${fmtTok(liveTokens)}` : '—'}</span>
+</footer>

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -4,20 +4,17 @@
     getActiveEmployees,
     getTelemetrySummary,
     getSystemStatus,
-    getAgentEvents,
     getCoordinatorTasks,
     listProjects,
     pauseAll,
   } from '../lib/api';
   import { navigate } from '../lib/router.svelte';
-  import { agentPresence } from '../lib/agent-presence.svelte';
   import { appearance, setTheme } from '../lib/appearance.svelte';
   import { addToast } from '../lib/toast.svelte';
   import { flap } from '../lib/design/flap';
   import type {
     Run,
     ActiveEmployee,
-    AgentEvent,
     CoordinatorTask,
     Project,
     TelemetrySummary,
@@ -31,7 +28,6 @@
   let activeEmployees = $state<ActiveEmployee[]>([]);
   let telemetry = $state<TelemetrySummary | null>(null);
   let systemStatus = $state<SystemStatus | null>(null);
-  let agentEvents = $state<AgentEvent[]>([]);
   let projects = $state<Project[]>([]);
   let coordTasks = $state<CoordinatorTask[]>([]);
   let loading = $state(true);
@@ -42,7 +38,6 @@
   let searchQuery = $state('');
   let hovered = $state<Run | null>(null);
   let selectedIdx = $state<number>(-1);
-  let clockNow = $state<string>('00:00:00');
   // Persisted acked alerts: localStorage stores a sorted JSON array of
   // alert ids (Sets don't serialize directly). Keyed by `dispatch-acked-alerts`
   // so a page refresh doesn't resurrect alerts the operator already cleared.
@@ -262,40 +257,9 @@
     return out.filter((a) => !acked.has(a.id));
   });
 
-  // ── Ticker entries ────────────────────────────────────
-  let tickerSegments = $derived.by(() => {
-    const segs = agentEvents.slice(0, 20).map((e) => {
-      const actor = (e.agent_id ?? 'station').split(':').pop() ?? 'station';
-      const tool =
-        (e.event_data && (e.event_data as Record<string, unknown>).tool as string)
-        ?? e.event_type
-        ?? 'event';
-      const target =
-        (e.event_data && (e.event_data as Record<string, unknown>).summary as string)
-        ?? (e.event_data && (e.event_data as Record<string, unknown>).file_path as string)
-        ?? '';
-      return { actor, tool, target };
-    });
-    if (segs.length === 0) {
-      // Idle fallback so the rail isn't blank between bursts
-      return [
-        { actor: 'station', tool: 'idle', target: 'no recent activity' },
-      ];
-    }
-    return segs;
-  });
-
-  // ── Footer event ──────────────────────────────────────
-  let footerEvent = $derived.by(() => {
-    const e = agentEvents[0];
-    if (!e) return { actor: '—', tool: '', target: 'awaiting events' };
-    const actor = (e.agent_id ?? 'station').split(':').pop() ?? 'station';
-    const tool = ((e.event_data && (e.event_data as Record<string, unknown>).tool as string) ?? e.event_type ?? '').toString();
-    const target = ((e.event_data && (e.event_data as Record<string, unknown>).summary as string)
-      ?? (e.event_data && (e.event_data as Record<string, unknown>).file_path as string)
-      ?? '').toString();
-    return { actor, tool, target };
-  });
+  // The live ticker and station-status footer are now mounted globally in
+  // Shell.svelte (LiveTicker + StationStatusFooter) so they appear on every
+  // page. CommandCenter no longer polls /api/agent-events directly.
 
   let latestActiveRun = $derived(
     recentRuns.find((r) => {
@@ -305,14 +269,15 @@
   );
 
   // ── Loaders ──────────────────────────────────────────
-  // Fast path: live ticker + working count drivers (cheap, change quickly).
+  // Fast path: working-count driver (cheap, changes quickly). The live
+  // ticker and station footer have their own polls in Shell-mounted
+  // components.
   async function loadFast() {
-    const [empR, evR] = await Promise.allSettled([
-      getActiveEmployees(),
-      getAgentEvents({ limit: 20 }),
-    ]);
-    if (empR.status === 'fulfilled') activeEmployees = empR.value;
-    if (evR.status === 'fulfilled') agentEvents = evR.value;
+    try {
+      activeEmployees = await getActiveEmployees();
+    } catch {
+      // Keep last-good list.
+    }
   }
 
   // Slow path: heavier endpoints (telemetry runs ~5 SQL queries; system
@@ -357,17 +322,12 @@
     const isHidden = () => typeof document !== 'undefined' && document.visibilityState === 'hidden';
     const fast = setInterval(() => { if (!isHidden()) loadFast(); }, 10_000);
     const slow = setInterval(() => { if (!isHidden()) loadSlow(); }, 30_000);
-    const c = setInterval(() => {
-      const d = new Date();
-      clockNow = `${pad2(d.getHours())}:${pad2(d.getMinutes())}:${pad2(d.getSeconds())}`;
-    }, 1000);
     // On tab refocus, pull fresh data immediately so users don't see stale-then-update.
     const onVis = () => { if (!isHidden()) loadAll(); };
     if (typeof document !== 'undefined') document.addEventListener('visibilitychange', onVis);
     return () => {
       clearInterval(fast);
       clearInterval(slow);
-      clearInterval(c);
       if (typeof document !== 'undefined') document.removeEventListener('visibilitychange', onVis);
     };
   });
@@ -450,27 +410,11 @@
     navigate(`/runs/${r.run_id}`);
   }
 
-  let currentRunTokens = $derived(
-    activeEmployees[0]?.tokens_total
-      ?? agentPresence.activeRuns[0]?.tokens_total
-      ?? agentPresence.tokensBurned
-      ?? 0,
-  );
 </script>
 
 <svelte:window onkeydown={onKeydown} />
 
 <div data-testid="command-center" class="dispatch-pro animate-fade-in">
-
-  <!-- Live ticker -->
-  <div class="ticker">
-    <span class="ticker-tag">// Live</span>
-    <div class="ticker-track">
-      {#each [...tickerSegments, ...tickerSegments] as seg}
-        <span><b>{seg.actor}</b> · <em>{seg.tool}</em> {seg.target}</span>
-      {/each}
-    </div>
-  </div>
 
   <!-- Filters -->
   <div class="filters">
@@ -702,23 +646,6 @@
       </section>
     </aside>
   </section>
-
-  <!-- Footer -->
-  <footer class="tele">
-    <span class="now">
-      <span class="run-tick"></span>
-      <span>{clockNow}</span>
-    </span>
-    <span><b>{latestActiveRun ? shortId(latestActiveRun.run_id) : '—'}</b></span>
-    <span class="ev">
-      {#if footerEvent.actor !== '—'}
-        {footerEvent.actor} · <em>{footerEvent.tool}</em> {footerEvent.target}
-      {:else}
-        awaiting events
-      {/if}
-    </span>
-    <span data-testid="footer-tokens">{currentRunTokens > 0 ? `+${fmtTok(currentRunTokens)}` : '—'}</span>
-  </footer>
 
   <div class="legend" aria-hidden="true">
     <span><kbd>/</kbd>filter</span>


### PR DESCRIPTION
## Summary
- Extracts the Dispatch ticker into `LiveTicker.svelte` (mounted in `Shell.svelte`) so the station activity strip appears on every page.
- Extracts the Dispatch footer (clock, latest active run, latest agent event, token delta) into `StationStatusFooter.svelte`, also Shell-mounted.
- Drops Shell's per-route `isDispatch` padding flip. All pages now flow flush with the viewport edges between the strip header and the global footer; pages retain their own internal padding.
- CommandCenter loses the duplicated ticker + footer markup, the now-unused `clockNow` / `currentRunTokens` / `footerEvent` derives, and its `getAgentEvents` poll — the global components own that concern now.

## Wiring
- `LiveTicker` polls `/api/agent-events?limit=20` every 10 s; pauses while `document.visibilityState === 'hidden'`; refetches on `visibilitychange`.
- `StationStatusFooter` polls `/api/runs/active-employees` + `/api/agent-events?limit=5` every 10 s with the same visibility gating; clock ticks every 1 s.
- `data-testid="footer-tokens"` preserved on the footer's token cell.

## Follow-up
- This is the first half of "make every page look like Dispatch". Per-page content rewrites against the design drafts in `design-drafts/{mission,fleet,queue,run-detail,projects,project-detail,settings}.html` will land as parallel PRs.

## Test plan
- [x] `npm run build` succeeds (only pre-existing a11y warnings).
- [ ] Visit `/`, `/queue`, `/agent-teams`, `/projects`, `/settings`, `/runs/<id>` — confirm strip + ticker + content + footer appear on each.
- [ ] Confirm `data-testid="command-center"` still present on Dispatch root (e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)