### PR TITLE
feat(ui): migrate Run Detail to Pro dense console layout

### DIFF
--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -1,11 +1,32 @@
 <script lang="ts">
-  import { getRunFullContext, getRunDiff, getCoordinatorMessages } from '../lib/api';
-  import { formatTokens, formatDuration, timeAgo, formatRunMode, formatSkipReason } from '../lib/format';
-  import { getAgentName, getAgentColor } from '../lib/agent-presence.svelte';
-  import type { RunFullContext, DiffResult, CoordinatorMessage } from '../lib/types';
+  import {
+    getRunFullContext,
+    getRunDiff,
+    getCoordinatorMessages,
+    pauseRun,
+    resumeRun,
+    stopRun,
+    messageRun,
+    operatorApproveRunPlan,
+    operatorRejectRunPlan,
+  } from '../lib/api';
+  import {
+    formatTokens,
+    formatDuration,
+    timeAgo,
+    formatRunMode,
+    formatSkipReason,
+  } from '../lib/format';
+  import { getAgentName, getAgentColor, agentPresence } from '../lib/agent-presence.svelte';
+  import { addToast, toastSuccess, toastError } from '../lib/toast.svelte';
+  import type {
+    RunFullContext,
+    DiffResult,
+    CoordinatorMessage,
+    CoordinatorTask,
+  } from '../lib/types';
   import { navigate } from '../lib/router.svelte';
   import LogViewer from '../components/data-display/LogViewer.svelte';
-  import AutonomyBadge from '../components/badges/AutonomyBadge.svelte';
 
   let { runId }: { runId: string } = $props();
 
@@ -13,8 +34,18 @@
   let diff = $state<DiffResult | null>(null);
   let allMessages = $state<CoordinatorMessage[]>([]);
   let loading = $state(true);
-  let activeTab = $state<'overview' | 'dag' | 'team' | 'conversation' | 'diff' | 'logs' | 'intelligence'>('overview');
+  let activeTab = $state<
+    'overview' | 'dag' | 'team' | 'conversation' | 'diff' | 'logs' | 'intelligence'
+  >('overview');
   let error = $state<string | null>(null);
+
+  // Control state
+  let pausing = $state(false);
+  let stopping = $state(false);
+  let approving = $state(false);
+  let rejecting = $state(false);
+  let messageText = $state('');
+  let sendingMessage = $state(false);
 
   async function loadRun() {
     loading = true;
@@ -22,10 +53,12 @@
     try {
       ctx = await getRunFullContext(runId);
       // Load diff and messages in background
-      getRunDiff(runId).then(d => diff = d).catch(() => {});
-      getCoordinatorMessages(runId).then(m => allMessages = m).catch(() => {});
-    } catch (e: any) {
-      error = e.message ?? 'Failed to load run';
+      getRunDiff(runId).then((d) => (diff = d)).catch(() => {});
+      getCoordinatorMessages(runId)
+        .then((m) => (allMessages = m))
+        .catch(() => {});
+    } catch (e: unknown) {
+      error = e instanceof Error ? e.message : 'Failed to load run';
     } finally {
       loading = false;
     }
@@ -37,644 +70,1069 @@
   });
 
   let run = $derived(ctx?.run);
+  let isLive = $derived(run?.status === 'started' || run?.status === 'running');
+  let runPaused = $derived(!!agentPresence.pausedRuns[runId]);
   let hasDag = $derived((ctx?.coordinator_tasks?.length ?? 0) > 0);
-  let hasTeam = $derived(ctx?.team_summary !== null);
+  let hasTeam = $derived(ctx?.team_summary != null);
   let hasIntelligence = $derived((ctx?.intelligence_decisions?.length ?? 0) > 0);
-  let hasConversation = $derived(allMessages.length > 0 || (ctx?.coordinator_messages?.length ?? 0) > 0);
-  let conversationMessages = $derived(allMessages.length > 0 ? allMessages : (ctx?.coordinator_messages ?? []));
+  let hasConversation = $derived(
+    allMessages.length > 0 || (ctx?.coordinator_messages?.length ?? 0) > 0,
+  );
+  let conversationMessages = $derived(
+    allMessages.length > 0 ? allMessages : (ctx?.coordinator_messages ?? []),
+  );
 
   let hasDiff = $derived((diff?.files?.length ?? 0) > 0 || !!run?.branch);
   let hasLogs = $derived(!!run?.log_file);
+  let planAwaitingApproval = $derived(
+    run?.status === 'awaiting_plan_review' || run?.status === 'plan_reviewing',
+  );
 
-  let tabs = $derived.by(() => {
-    const t: { id: string; label: string }[] = [{ id: 'overview', label: 'Overview' }];
-    if (hasDag) t.push({ id: 'dag', label: 'DAG' });
-    if (hasTeam) t.push({ id: 'team', label: 'Team' });
-    if (hasConversation) t.push({ id: 'conversation', label: 'Conversation' });
-    if (hasDiff) t.push({ id: 'diff', label: 'Diff' });
-    if (hasLogs) t.push({ id: 'logs', label: 'Logs' });
-    if (hasIntelligence) t.push({ id: 'intelligence', label: 'Intelligence' });
+  type TabId =
+    | 'overview'
+    | 'dag'
+    | 'team'
+    | 'conversation'
+    | 'diff'
+    | 'logs'
+    | 'intelligence';
+
+  let tabs = $derived.by<{ id: TabId; label: string; count?: number; disabled?: boolean }[]>(() => {
+    const t: { id: TabId; label: string; count?: number; disabled?: boolean }[] = [
+      { id: 'overview', label: 'Overview' },
+    ];
+    t.push({
+      id: 'dag',
+      label: 'DAG',
+      count: ctx?.coordinator_tasks?.length ?? 0,
+      disabled: !hasDag,
+    });
+    t.push({
+      id: 'team',
+      label: 'Team',
+      count: ctx?.team_summary?.teammates?.length,
+      disabled: !hasTeam,
+    });
+    t.push({
+      id: 'conversation',
+      label: 'Conversation',
+      count: conversationMessages.length || undefined,
+      disabled: !hasConversation,
+    });
+    t.push({
+      id: 'diff',
+      label: 'Diff',
+      count: diff?.files?.length,
+      disabled: !hasDiff,
+    });
+    t.push({ id: 'logs', label: 'Logs', disabled: !hasLogs });
+    t.push({
+      id: 'intelligence',
+      label: 'Intelligence',
+      count: ctx?.intelligence_decisions?.length ?? 0,
+      disabled: !hasIntelligence,
+    });
     return t;
   });
 
   function getInitials(name: string): string {
-    return name.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase();
-  }
-
-  function getMsgBorderColor(type: string): string {
-    const map: Record<string, string> = { guidance: 'var(--color-cyan)', conflict: 'var(--color-amber)', progress: 'var(--color-emerald)', error: 'var(--color-rose)' };
-    return map[type] ?? 'var(--color-tertiary)';
+    return name
+      .split(' ')
+      .map((w) => w[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
   }
 
   function parseReport(report: string | null): Record<string, unknown> | null {
     if (!report) return null;
-    try { return JSON.parse(report); } catch { return null; }
+    try {
+      return JSON.parse(report) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  function shortRunId(id: string): string {
+    if (id.length <= 12) return id;
+    return id.slice(-12);
+  }
+
+  function shortTaskId(id: string): string {
+    if (!id) return '—';
+    return id.length <= 12 ? id : '…' + id.slice(-9);
+  }
+
+  function taskRoleFromTitle(t: CoordinatorTask): string {
+    const s = (t.title ?? '').toLowerCase();
+    if (s.includes('backend')) return 'backend';
+    if (s.includes('frontend')) return 'frontend';
+    if (s.includes('qa') || s.includes('test')) return 'qa';
+    return 'lead';
+  }
+
+  function taskDuration(t: CoordinatorTask): string {
+    if (!t.started_at) return '—';
+    const start = new Date(
+      t.started_at.endsWith('Z') ? t.started_at : t.started_at + 'Z',
+    ).getTime();
+    const end = t.finished_at
+      ? new Date(
+          t.finished_at.endsWith('Z') ? t.finished_at : t.finished_at + 'Z',
+        ).getTime()
+      : Date.now();
+    return formatDuration(end - start);
+  }
+
+  function taskStatusClass(s: string): string {
+    if (s === 'completed') return 'done';
+    if (s === 'running') return 'run';
+    if (s === 'failed') return 'planx';
+    return 'idle';
+  }
+
+  function friendly(e: unknown, fallback: string): string {
+    const raw = e instanceof Error ? e.message : fallback;
+    return raw.startsWith('409:') ? raw.slice(4).trim() || fallback : raw;
+  }
+
+  async function onPauseRun() {
+    if (!runId || pausing) return;
+    pausing = true;
+    try {
+      if (runPaused) {
+        await resumeRun(runId);
+        addToast('success', `Resume requested for ${runId}`);
+      } else {
+        await pauseRun(runId);
+        addToast('success', `Pause requested for ${runId}`);
+      }
+    } catch (e) {
+      addToast('error', friendly(e, 'Pause/resume failed'));
+    } finally {
+      pausing = false;
+    }
+  }
+
+  async function onStopRun() {
+    if (!runId || stopping) return;
+    const ok = confirm(
+      `Stop run ${runId}? The agent will halt after its next tool call and finish with status=interrupted.`,
+    );
+    if (!ok) return;
+    stopping = true;
+    try {
+      await stopRun(runId);
+      addToast('success', `Stop requested for ${runId}`);
+    } catch (e) {
+      addToast('error', friendly(e, 'Stop failed'));
+    } finally {
+      stopping = false;
+    }
+  }
+
+  async function onSendMessage() {
+    const text = messageText.trim();
+    if (!text || sendingMessage) return;
+    sendingMessage = true;
+    try {
+      await messageRun(runId, text);
+      messageText = '';
+      toastSuccess('Message delivered');
+    } catch (e) {
+      toastError(friendly(e, 'Message failed'));
+    } finally {
+      sendingMessage = false;
+    }
+  }
+
+  async function onApprovePlan() {
+    if (approving) return;
+    approving = true;
+    try {
+      await operatorApproveRunPlan(runId);
+      await loadRun();
+    } catch (e) {
+      toastError(friendly(e, 'Approve failed'));
+    } finally {
+      approving = false;
+    }
+  }
+
+  async function onRejectPlan() {
+    if (rejecting) return;
+    if (!confirm('Reject this plan? The run will end with verdict=REJECT.')) return;
+    rejecting = true;
+    try {
+      await operatorRejectRunPlan(runId);
+      await loadRun();
+    } catch (e) {
+      toastError(friendly(e, 'Reject failed'));
+    } finally {
+      rejecting = false;
+    }
+  }
+
+  // Hotkeys 1..7 for tabs
+  function onKey(e: KeyboardEvent) {
+    const target = e.target as HTMLElement | null;
+    const tag = target?.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+    const n = parseInt(e.key, 10);
+    if (!Number.isNaN(n) && n >= 1 && n <= tabs.length) {
+      const t = tabs[n - 1];
+      if (!t.disabled) activeTab = t.id;
+    }
   }
 </script>
 
+<svelte:window on:keydown={onKey} />
+
 {#if loading}
-  <div class="space-y-4 animate-fade-in">
+  <div class="rd-loading animate-fade-in">
     <div class="skeleton h-8 w-64"></div>
     <div class="skeleton h-48 w-full"></div>
   </div>
 {:else if error}
-  <div class="card p-12 text-center">
-    <p class="text-rose text-sm mb-4">{error}</p>
-    <button onclick={() => navigate('/runs')} class="btn btn-secondary">Back to Runs</button>
+  <div class="rd-empty">
+    <p class="rd-empty-msg">{error}</p>
+    <button onclick={() => navigate('/runs')} class="rd-action">Back to Dispatch</button>
   </div>
 {:else if run}
-  <div class="space-y-6 animate-fade-in run-detail-pro">
-    <!-- ===== HEADER (Pro) ===== -->
-    <div class="rd-head">
-      <div class="rd-head-left">
-        <div class="rd-title-row">
-          <span class="rd-status-dot {run.status === 'started' || run.status === 'running' ? 'go' : run.verdict === 'REJECT' ? 'abort' : run.verdict ? 'go' : ''} {run.status === 'started' || run.status === 'running' ? 'live' : ''}"></span>
-          <h1 class="rd-runid">{run.run_id}</h1>
-          {#if run.verdict}
-            <span class="rd-pill verdict-{run.verdict.toLowerCase()}">{run.verdict}</span>
-          {:else if run.status === 'started' || run.status === 'running'}
-            <span class="rd-pill run">RUN</span>
-          {/if}
-          <AutonomyBadge level={run.autonomy_level} />
-          {#if run.max_budget_usd != null}
-            <span class="rd-meta-chip" title="Per-run budget cap">≤ ${run.max_budget_usd.toFixed(2)}</span>
-          {/if}
-        </div>
-        <div class="rd-meta-row">
+  <div class="rd animate-fade-in">
+    <!-- ── Crumb ─────────────────────────────────────────── -->
+    <div class="crumb">
+      <a href="/runs" onclick={(e) => { e.preventDefault(); navigate('/runs'); }}>← Dispatch</a>
+      <span class="sep">/</span>
+      {#if ctx?.project_repo}
+        <span>{ctx.project_repo}</span>
+        <span class="sep">/</span>
+      {/if}
+      <b>{run.run_id}</b>
+    </div>
+
+    <!-- ── Page header ───────────────────────────────────── -->
+    <div class="page-head">
+      <div class="page-head-left">
+        <h1>
+          <span>{run.run_id}</span>
+          <span class="badges">
+            {#if isLive}
+              <span class="status run"><span class="run-tick"></span><span class="lab">Run</span></span>
+            {:else if run.verdict === 'APPROVE'}
+              <span class="status planok">Approved</span>
+            {:else if run.verdict === 'REJECT'}
+              <span class="status planx">Rejected</span>
+            {:else if run.verdict === 'PR'}
+              <span class="status stop">PR</span>
+            {:else if run.verdict === 'SKIP'}
+              <span class="status idle">Skip</span>
+            {:else if run.status === 'reviewing'}
+              <span class="status stop">Reviewing</span>
+            {:else}
+              <span class="status done">{run.status}</span>
+            {/if}
+            {#if run.mode}
+              {@const m = formatRunMode(run.mode)}
+              <span class="mode {run.mode === 'full' ? 'full' : run.mode === 'plan_only' || run.mode === 'plan' ? 'plan' : (run.mode as string) === 'vision-bootstrap' ? 'vision' : ''}">
+                {m.label}
+              </span>
+            {/if}
+            {#if run.autonomy_level}
+              <span class="aut {run.autonomy_level === 'auto' ? 'auto' : run.autonomy_level === 'manual' ? 'manual' : 'assist'}">
+                {run.autonomy_level}
+              </span>
+            {/if}
+            {#if runPaused}
+              <span class="status stop">Paused</span>
+            {/if}
+          </span>
+        </h1>
+        <div class="meta">
           {#if ctx?.project_repo}
-            <span><b>{ctx.project_repo}</b></span>
+            <span>Project <b>{ctx.project_repo}</b></span>
           {/if}
-          {#if run.issue_number}
+          <span class="sep">·</span>
+          <span>
+            Issue
+            {#if run.issue_number}<b>#{run.issue_number}</b>{:else}<b class="nu">— none —</b>{/if}
+          </span>
+          <span class="sep">·</span>
+          <span>
+            Branch
+            {#if run.branch}<b>{run.branch}</b>{:else}<b class="nu">— none —</b>{/if}
+          </span>
+          {#if run.started_at}
             <span class="sep">·</span>
-            <span>#{run.issue_number}</span>
-          {/if}
-          {#if run.mode}
-            {@const m = formatRunMode(run.mode)}
-            <span class="sep">·</span>
-            <span class="rd-pill mode mode-{run.mode}">{m.icon} {m.label}</span>
+            <span>Started <b>{timeAgo(run.started_at)}</b></span>
           {/if}
           {#if run.skip_reason}
             <span class="sep">·</span>
-            <span class="rd-skip">{formatSkipReason(run.skip_reason)}</span>
-          {/if}
-          {#if run.model}
-            <span class="sep">·</span>
-            <span>{run.model}</span>
+            <span class="skip">{formatSkipReason(run.skip_reason)}</span>
           {/if}
         </div>
       </div>
 
-      <!-- Stat chips (Pro) -->
-      <div class="rd-stats">
-        {#if run.tokens_total}
-          <div class="rd-stat">
-            <span class="k">Tokens</span>
-            <span class="v">{formatTokens(run.tokens_total)}</span>
-          </div>
+      <!-- Run controls -->
+      <div class="rd-controls">
+        {#if isLive}
+          <button class="rd-action" onclick={onPauseRun} disabled={pausing}
+            title={runPaused ? 'Resume this run' : 'Route this run\'s next tool call to the tray'}>
+            {#if pausing}…{:else if runPaused}▶ Resume{:else}⏸ Pause{/if}
+          </button>
+          <button class="rd-action danger" onclick={onStopRun} disabled={stopping}
+            title="Interrupt this run cooperatively">
+            {stopping ? '…' : '⏹ Stop'}
+          </button>
         {/if}
-        {#if run.duration_ms}
-          <div class="rd-stat">
-            <span class="k">Duration</span>
-            <span class="v">{formatDuration(run.duration_ms)}</span>
-          </div>
-        {/if}
-        {#if run.turns}
-          <div class="rd-stat">
-            <span class="k">Turns</span>
-            <span class="v">{run.turns}</span>
-          </div>
+        {#if planAwaitingApproval}
+          <button class="rd-action go" onclick={onApprovePlan} disabled={approving}>
+            {approving ? '…' : '✓ Approve plan'}
+          </button>
+          <button class="rd-action danger" onclick={onRejectPlan} disabled={rejecting}>
+            {rejecting ? '…' : '✗ Reject plan'}
+          </button>
         {/if}
       </div>
     </div>
 
-    <!-- ===== TABS (Pro) ===== -->
-    <div class="rd-tabs">
+    <!-- ── Quick stats ───────────────────────────────────── -->
+    <div class="qstats">
+      <div class="qstat">
+        <span class="k">Tokens</span>
+        {#if run.tokens_total}
+          <span class="v go">{formatTokens(run.tokens_total)}</span>
+          <span class="sub">{formatTokens(run.tokens_input)} in / {formatTokens(run.tokens_output)} out</span>
+        {:else}
+          <span class="v nu">—</span><span class="sub">no usage yet</span>
+        {/if}
+      </div>
+      <div class="qstat">
+        <span class="k">Turns</span>
+        <span class="v">{run.turns ?? 0}</span>
+        <span class="sub">{(run.turns ?? 0) === 0 ? 'no tool calls' : 'tool calls'}</span>
+      </div>
+      <div class="qstat">
+        <span class="k">Cost</span>
+        {#if run.cost_usd}
+          <span class="v">${run.cost_usd.toFixed(2)}</span><span class="sub">USD</span>
+        {:else}
+          <span class="v nu">—</span><span class="sub">awaiting usage</span>
+        {/if}
+      </div>
+      <div class="qstat">
+        <span class="k">Tasks</span>
+        {#if ctx?.team_summary}
+          <span class="v">{ctx.team_summary.tasks_completed}<span class="vsub">/{ctx.team_summary.tasks_total}</span></span>
+          <span class="sub">{ctx.team_summary.tasks_in_progress} active</span>
+        {:else if hasDag}
+          <span class="v">{ctx?.coordinator_tasks?.length ?? 0}</span><span class="sub">total</span>
+        {:else}
+          <span class="v nu">—</span><span class="sub">no DAG</span>
+        {/if}
+      </div>
+      <div class="qstat">
+        <span class="k">Files</span>
+        {#if diff?.files?.length}
+          <span class="v">{diff.files.length}</span>
+          <span class="sub" style="color:var(--go)">+{diff.total_additions}</span>
+        {:else}
+          <span class="v nu">0</span><span class="sub">none touched</span>
+        {/if}
+      </div>
+      <div class="qstat">
+        <span class="k">Duration</span>
+        {#if run.duration_ms}
+          <span class="v">{formatDuration(run.duration_ms)}</span><span class="sub">total</span>
+        {:else if run.started_at && isLive}
+          <span class="v">{timeAgo(run.started_at).replace(' ago', '')}</span>
+          <span class="sub">in flight</span>
+        {:else}
+          <span class="v nu">—</span><span class="sub">not started</span>
+        {/if}
+      </div>
+      <div class="qstat">
+        <span class="k">Verdict</span>
+        {#if run.verdict}
+          <span class="v {run.verdict === 'APPROVE' ? 'go' : run.verdict === 'REJECT' ? 'abort' : 'caution'}" style="font-size:14px">{run.verdict}</span>
+          <span class="sub">final</span>
+        {:else}
+          <span class="v nu">—</span><span class="sub">in progress</span>
+        {/if}
+      </div>
+      <div class="qstat">
+        <span class="k">Budget</span>
+        {#if run.max_budget_usd != null}
+          <span class="v">≤ ${run.max_budget_usd.toFixed(2)}</span>
+          <span class="sub">cap</span>
+        {:else}
+          <span class="v nu">—</span><span class="sub">no cap</span>
+        {/if}
+      </div>
+    </div>
+
+    <!-- ── Tabs ───────────────────────────────────────────── -->
+    <div class="tabs">
       {#each tabs as tab}
         <button
-          onclick={() => activeTab = tab.id as typeof activeTab}
-          class="rd-tab"
+          onclick={() => { if (!tab.disabled) activeTab = tab.id; }}
+          class="tab"
           class:active={activeTab === tab.id}
+          class:disabled={tab.disabled}
+          disabled={tab.disabled}
+          title={tab.disabled ? `No ${tab.label.toLowerCase()} data yet` : ''}
         >
-          {tab.label}
+          {tab.label}{#if tab.count != null}<span class="count">{tab.count}</span>{/if}
         </button>
       {/each}
     </div>
 
-    <!-- ===== TAB CONTENT ===== -->
-    {#if activeTab === 'overview'}
-      {#if run.mode === 'vision-bootstrap'}
-        <!-- Vision-bootstrap runs don't produce employee_report / verdict;
-             they propose new issues directly on GitHub. Render a dedicated
-             summary card so operators see what the run actually did
-             instead of "Employee did not produce a report". -->
-        <div class="card p-5 space-y-3 mb-6" data-testid="vision-bootstrap-summary">
-          <div class="flex items-center justify-between">
-            <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">Vision bootstrap</h3>
-            <span class="text-[10px] font-mono text-tertiary">
-              {#if run.status === 'completed'}
-                {run.vision_bootstrap_count ?? 0} issue{(run.vision_bootstrap_count ?? 0) === 1 ? '' : 's'} proposed
-              {:else if run.status === 'failed' || run.status === 'error'}
-                Failed
-              {:else}
-                {run.status}
-              {/if}
-            </span>
-          </div>
+    <!-- ── Tab body ───────────────────────────────────────── -->
+    <div class="tab-body">
 
-          {#if run.status === 'failed' || run.status === 'error'}
-            <p class="text-sm text-secondary">
-              The vision analyst could not complete this run. Check the logs tab for the underlying error.
-            </p>
-          {:else if (run.vision_bootstrap_count ?? 0) === 0 && run.status === 'completed'}
-            <p class="text-sm text-secondary">
-              The analyst found no gaps to propose. The current repo state already covers the vision's near-term horizons.
-            </p>
-          {:else if run.vision_bootstrap_proposals && run.vision_bootstrap_proposals.length > 0}
-            <p class="text-sm text-secondary leading-snug">
-              These issues carry the <code class="font-mono text-xs">vision-suggested</code> label and are skipped by the orchestrator until you accept one — remove the label to allow autonomous implementation, or close to reject.
-            </p>
-            <ul class="space-y-2">
-              {#each run.vision_bootstrap_proposals as p}
-                <li class="flex items-start gap-2 text-sm">
-                  <span class="font-mono text-tertiary text-xs pt-0.5">#{p.number}</span>
-                  <a
-                    href={p.url}
-                    target="_blank"
-                    rel="noopener"
-                    class="text-primary hover:underline flex-1"
-                  >
-                    {p.title}
-                  </a>
-                  <a
-                    href={p.url}
-                    target="_blank"
-                    rel="noopener"
-                    class="text-tertiary hover:text-primary text-xs pt-0.5"
-                    aria-label="Open on GitHub"
-                  >
-                    ↗
-                  </a>
-                </li>
-              {/each}
-            </ul>
-          {:else if run.status === 'started' || run.status === 'running'}
-            <p class="text-sm text-tertiary">
-              Analyst is running — proposed issues will appear here once the run finishes.
-            </p>
-          {/if}
-        </div>
-      {/if}
-
-      {#if run.mode !== 'vision-bootstrap'}
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <!-- Employee Report -->
-        <div class="card p-5 space-y-3">
-          <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">Employee Report</h3>
-          {#if parseReport(run.employee_report)}
-            {@const report = parseReport(run.employee_report)!}
-            <div class="space-y-3 text-sm">
-              {#each Object.entries(report) as [key, val]}
-                <div>
-                  <span class="text-[10px] font-mono uppercase text-tertiary">{key.replace(/_/g, ' ')}</span>
-                  <div class="text-secondary mt-0.5">
-                    {#if typeof val === 'string'}
-                      <p class="whitespace-pre-wrap">{val}</p>
-                    {:else if Array.isArray(val)}
-                      <ul class="list-disc list-inside space-y-0.5">
-                        {#each val as item}<li>{typeof item === 'string' ? item : JSON.stringify(item)}</li>{/each}
-                      </ul>
-                    {:else}
-                      <pre class="text-xs font-mono bg-surface-1 rounded p-2 overflow-x-auto">{JSON.stringify(val, null, 2)}</pre>
-                    {/if}
-                  </div>
-                </div>
-              {/each}
-            </div>
-          {:else if run.employee_report}
-            <p class="text-sm text-secondary whitespace-pre-wrap">{run.employee_report}</p>
-          {:else}
-            <p class="text-sm text-tertiary">
-              {#if run.status === 'started' || run.status === 'running'}
-                Report will be available after the employee finishes
-              {:else if run.status === 'reviewing'}
-                Employee finished — report pending review
-              {:else}
-                Employee did not produce a report
-              {/if}
-            </p>
-          {/if}
-        </div>
-
-        <!-- Verdict & Context -->
-        <div class="space-y-4">
-          {#if run.verdict_detail}
-            <div class="card p-5 space-y-2">
-              <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">Verdict Detail</h3>
-              <p class="text-sm text-secondary whitespace-pre-wrap">{run.verdict_detail}</p>
-            </div>
-          {/if}
-
-          {#if ctx?.queue_items && ctx.queue_items.length > 0}
-            <div class="card p-5 space-y-2">
-              <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">
-                Queue Items ({ctx.queue_items.length})
-              </h3>
-              <div class="space-y-2">
-                {#each ctx.queue_items as qi}
-                  <div class="text-xs space-y-1 text-secondary font-mono border-t border-border first:border-t-0 pt-2 first:pt-0">
-                    <div class="flex items-center gap-2">
-                      <span>#{qi.issue_number ?? '–'}</span>
-                      <span class="badge badge-{qi.state}">{qi.state}</span>
-                      <span class="text-tertiary">{qi.mode ?? '–'}</span>
-                    </div>
-                    {#if qi.issue_title}
-                      <div class="text-secondary">{qi.issue_title}</div>
-                    {/if}
+      <!-- OVERVIEW -->
+      {#if activeTab === 'overview'}
+        <section class="tab-pane">
+          {#if (run.mode as string) === 'vision-bootstrap'}
+            <div class="card-block" style="margin-bottom: 16px" data-testid="vision-bootstrap-summary">
+              <h3>Vision bootstrap</h3>
+              <p>
+                {#if run.status === 'completed'}
+                  {run.vision_bootstrap_count ?? 0} issue{(run.vision_bootstrap_count ?? 0) === 1 ? '' : 's'} proposed.
+                {:else if run.status === 'failed' || run.status === 'error'}
+                  The vision analyst could not complete this run. Check the logs tab for the underlying error.
+                {:else if (run.vision_bootstrap_count ?? 0) === 0 && run.status === 'completed'}
+                  The analyst found no gaps to propose. The current repo state already covers the vision's near-term horizons.
+                {:else if run.status === 'started' || run.status === 'running'}
+                  Analyst is running — proposed issues will appear here once the run finishes.
+                {/if}
+              </p>
+              {#if run.vision_bootstrap_proposals && run.vision_bootstrap_proposals.length > 0}
+                <p style="margin-top: 6px">
+                  These issues carry the <code>vision-suggested</code> label and are skipped by the orchestrator until you accept one — remove the label to allow autonomous implementation, or close to reject.
+                </p>
+                {#each run.vision_bootstrap_proposals as p}
+                  <div class="mono-line">
+                    <span class="nu">#{p.number}</span> &nbsp;
+                    <a href={p.url} target="_blank" rel="noopener" style="color: var(--data)">{p.title}</a>
                   </div>
                 {/each}
-              </div>
-            </div>
-          {:else if ctx?.queue_item}
-            <div class="card p-5 space-y-2">
-              <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">Queue Item</h3>
-              <div class="text-xs space-y-1 text-secondary font-mono">
-                <div>State: <span class="badge badge-{ctx.queue_item.state}">{ctx.queue_item.state}</span></div>
-                <div>Priority: {ctx.queue_item.priority}</div>
-                {#if ctx.queue_item.issue_title}
-                  <div>Issue: {ctx.queue_item.issue_title}</div>
-                {/if}
-              </div>
+              {/if}
             </div>
           {/if}
 
-          {#if ctx?.plan}
-            <div class="card p-5 space-y-2">
-              <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">Plan</h3>
-              <div class="text-sm text-primary font-medium">{ctx.plan.title}</div>
-              <div class="text-xs text-tertiary font-mono">Status: {ctx.plan.status}</div>
-            </div>
-          {/if}
-
-          <!-- Token Breakdown -->
-          {#if run.tokens_input || run.tokens_output}
-            <div class="card p-5 space-y-2">
-              <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">Token Breakdown</h3>
-              <div class="flex items-center gap-2 h-4 rounded-full overflow-hidden bg-surface-2">
-                {#if run.tokens_input && run.tokens_total}
-                  <div class="h-full rounded-l-full" style="width: {(run.tokens_input / run.tokens_total) * 100}%; background: rgba(99,102,180,0.4)"></div>
+          <div class="cards">
+            <!-- Left: progress + recent activity -->
+            <div class="card-block">
+              <h3>
+                {#if isLive}
+                  In Progress · {ctx?.team_summary ? `Team ${ctx.team_summary.team_name}` : 'Single Run'}
+                {:else if run.verdict}
+                  Finished · Verdict {run.verdict}
+                {:else}
+                  Status · {run.status}
                 {/if}
-                {#if run.tokens_output && run.tokens_total}
-                  <div class="h-full rounded-r-full" style="width: {(run.tokens_output / run.tokens_total) * 100}%; background: rgba(176,96,48,0.4)"></div>
-                {/if}
-              </div>
-              <div class="flex justify-between text-[10px] font-mono text-tertiary">
-                <span>Input: {formatTokens(run.tokens_input ?? 0)}</span>
-                <span>Output: {formatTokens(run.tokens_output ?? 0)}</span>
-              </div>
-            </div>
-          {/if}
-        </div>
-      </div>
-      {/if}
+              </h3>
 
-    {:else if activeTab === 'dag' && ctx?.coordinator_tasks}
-      <div class="card p-5">
-        <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary mb-4">Task DAG</h3>
-        <div class="space-y-2">
-          {#each ctx.coordinator_tasks as task}
-            <div class="flex items-center gap-3 px-3 py-2 rounded-lg bg-surface-1 border border-border">
-              <span class="status-dot {task.status === 'completed' ? 'online' : task.status === 'running' ? 'running' : task.status === 'failed' ? 'error' : 'offline'}"></span>
-              <div class="flex-1 min-w-0">
-                <div class="text-sm text-primary truncate">{task.title ?? task.id}</div>
-                {#if task.description}
-                  <div class="text-xs text-tertiary truncate">{task.description}</div>
-                {/if}
-              </div>
-              <span class="badge badge-{task.status === 'completed' ? 'completed' : task.status === 'running' ? 'running' : task.status === 'failed' ? 'failed' : 'pending'}">
-                {task.status}
-              </span>
-            </div>
-          {/each}
-        </div>
-      </div>
+              {#if parseReport(run.employee_report)}
+                {@const report = parseReport(run.employee_report)!}
+                {#each Object.entries(report) as [key, val]}
+                  <p>
+                    <b style="font-family: var(--pro-sans); font-size: 9px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ash)">{key.replace(/_/g, ' ')}</b><br />
+                    {#if typeof val === 'string'}
+                      {val}
+                    {:else if Array.isArray(val)}
+                      {val.map((v) => (typeof v === 'string' ? v : JSON.stringify(v))).join(' · ')}
+                    {:else}
+                      {JSON.stringify(val)}
+                    {/if}
+                  </p>
+                {/each}
+              {:else if run.employee_report}
+                <p>{run.employee_report}</p>
+              {:else if isLive}
+                <p>
+                  Lead is coordinating
+                  {#if ctx?.team_summary}<b>{ctx.team_summary.teammates.length} specialists</b> on team <b>{ctx.team_summary.team_name}</b>.{:else}the run.{/if}
+                </p>
+              {:else if run.status === 'reviewing'}
+                <p>Run finished — awaiting manager review.</p>
+              {:else}
+                <p>This run did not produce a report.</p>
+              {/if}
 
-    {:else if activeTab === 'team' && ctx?.team_summary}
-      <div class="space-y-4">
-        <!-- Team Summary Bar -->
-        <div class="card p-4 flex items-center gap-6">
-          <div>
-            <span class="text-xs text-tertiary font-mono">Team</span>
-            <div class="text-sm font-heading font-semibold text-primary">{ctx.team_summary.team_name}</div>
-          </div>
-          <div class="flex-1 h-2 rounded-full bg-surface-2 overflow-hidden">
-            <div class="h-full bg-emerald/60 rounded-full transition-all duration-500" style="width: {ctx.team_summary.tasks_total > 0 ? (ctx.team_summary.tasks_completed / ctx.team_summary.tasks_total) * 100 : 0}%"></div>
-          </div>
-          <div class="flex items-center gap-4 text-xs font-mono">
-            <span class="text-emerald">{ctx.team_summary.tasks_completed} done</span>
-            <span style="color: #B06030;">{ctx.team_summary.tasks_in_progress} active</span>
-            {#if ctx.team_summary.conflicts > 0}
-              <span class="text-amber">{ctx.team_summary.conflicts} conflicts</span>
-            {/if}
-          </div>
-        </div>
-
-        <!-- Team Members Grid -->
-        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          {#each ctx.team_summary.teammates as member}
-            {@const memberColor = getAgentColor(member.name.toLowerCase())}
-            <div class="card p-4 space-y-3">
-              <div class="flex items-center gap-3">
-                <div
-                  class="w-10 h-10 rounded-full flex items-center justify-center text-xs font-bold"
-                  style="background: {memberColor}15; color: {memberColor}; border: 2px solid {memberColor};"
-                >
-                  {getInitials(member.name)}
+              {#if ctx?.team_summary && ctx.team_summary.tasks_total > 0}
+                {@const pct =
+                  (ctx.team_summary.tasks_completed / ctx.team_summary.tasks_total) * 100}
+                <div class="progress"><span style="width: {pct}%"></span></div>
+                <div class="progress-meta">
+                  <span>
+                    {ctx.team_summary.tasks_completed} done · {ctx.team_summary.tasks_in_progress} active
+                    {#if ctx.team_summary.conflicts > 0} · <b style="color:var(--caution)">{ctx.team_summary.conflicts} conflicts</b>{/if}
+                  </span>
+                  <span>~{Math.round(pct)}% complete</span>
                 </div>
-                <div class="flex-1 min-w-0">
-                  <div class="text-sm font-medium text-primary">{member.name}</div>
-                  <div class="flex items-center gap-1.5">
-                    <span class="status-dot {member.status === 'completed' ? 'online' : member.status === 'stuck' ? 'error' : 'running'}"></span>
-                    <span class="text-xs text-tertiary capitalize">{member.status}</span>
+              {/if}
+
+              {#if run.verdict_detail}
+                <h3 style="margin-top: 18px">Verdict Detail</h3>
+                <p style="white-space: pre-wrap">{run.verdict_detail}</p>
+              {/if}
+
+              {#if conversationMessages.length > 0}
+                <h3 style="margin-top: 18px">Recent Activity</h3>
+                {#each conversationMessages.slice(-5).reverse() as msg}
+                  {@const agentName = getAgentName(
+                    msg.employee_index,
+                    msg.direction === 'system' ? 'coordinator' : null,
+                  )}
+                  {@const color = getAgentColor(agentName.toLowerCase())}
+                  <div class="mono-line">
+                    <span class="nu">{timeAgo(msg.created_at)}</span> &nbsp;
+                    <span style="color: {color}">{agentName}</span> &nbsp;
+                    <span>{msg.message_type === 'guidance' ? '@' : msg.message_type === 'error' ? '!' : '→'}</span>
+                    <span>{msg.content?.slice(0, 80) ?? ''}</span>
                   </div>
-                </div>
-              </div>
-              <div class="flex items-center gap-3 text-[10px] font-mono text-tertiary">
-                {#if member.turns_used}<span>{member.turns_used} turns</span>{/if}
-                {#if member.tokens_used}<span>{formatTokens(member.tokens_used)} tokens</span>{/if}
-              </div>
-              {#if member.files_touched && member.files_touched.length > 0}
-                <div class="space-y-1">
-                  <span class="text-[10px] font-mono text-tertiary">Files touched:</span>
-                  {#each member.files_touched.slice(0, 3) as file}
-                    <div class="text-[10px] font-mono text-secondary truncate">{file}</div>
-                  {/each}
-                  {#if member.files_touched.length > 3}
-                    <div class="text-[10px] font-mono text-ghost">+{member.files_touched.length - 3} more</div>
-                  {/if}
+                {/each}
+              {/if}
+
+              <!-- Operator message input -->
+              {#if isLive}
+                <div class="rd-message-row">
+                  <input
+                    type="text"
+                    class="rd-message-input"
+                    placeholder="Send a message to the agent…"
+                    bind:value={messageText}
+                    onkeydown={(e) => { if (e.key === 'Enter') onSendMessage(); }}
+                    disabled={sendingMessage}
+                  />
+                  <button class="rd-action" onclick={onSendMessage} disabled={sendingMessage || !messageText.trim()}>
+                    {sendingMessage ? '…' : 'Send'}
+                  </button>
                 </div>
               {/if}
             </div>
-          {/each}
-        </div>
-      </div>
 
-    {:else if activeTab === 'conversation'}
-      <div class="card p-5 space-y-4">
-        <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary">Agent Conversation</h3>
-        {#if conversationMessages.length === 0}
-          <p class="text-sm text-tertiary text-center py-8">No conversation data for this run</p>
-        {:else}
-          <div class="space-y-3 max-h-[600px] overflow-y-auto">
-            {#each conversationMessages as msg}
-              {@const agentName = getAgentName(msg.employee_index, msg.direction === 'system' ? 'coordinator' : null)}
-              {@const color = getAgentColor(agentName.toLowerCase())}
-              <div class="flex items-start gap-3 py-2 pl-3 border-l-2 rounded-r-lg hover:bg-surface-1/30 transition-colors"
-                style="border-color: {getMsgBorderColor(msg.message_type)};">
-                <!-- Avatar -->
-                <div
-                  class="w-8 h-8 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0"
-                  style="background: {color}20; color: {color};"
-                >
-                  {getInitials(agentName)}
-                </div>
-                <!-- Content -->
-                <div class="flex-1 min-w-0">
-                  <div class="flex items-center gap-2 mb-0.5">
-                    <span class="text-xs font-semibold" style="color: {color};">{agentName}</span>
-                    <span class="px-1.5 py-0.5 rounded text-[9px] font-mono bg-surface-2 text-tertiary">{msg.message_type}</span>
-                    <span class="px-1.5 py-0.5 rounded text-[9px] font-mono bg-surface-2 text-ghost">{msg.direction.replace('_', ' ')}</span>
-                    <span class="text-[10px] text-ghost font-mono ml-auto shrink-0">{timeAgo(msg.created_at)}</span>
-                  </div>
-                  <p class="text-sm text-secondary whitespace-pre-wrap break-words">{msg.content ?? ''}</p>
-                </div>
+            <!-- Right: metadata -->
+            <div class="card-block">
+              <h3>Run Metadata</h3>
+              <div class="key-row"><label>Run ID</label><val>{run.run_id}</val></div>
+              {#if run.trace_id}
+                <div class="key-row"><label>Trace</label><val class="dim">{run.trace_id}</val></div>
+              {/if}
+              {#if run.concurrent_group_id}
+                <div class="key-row"><label>Group</label><val class="dim">{run.concurrent_group_id}</val></div>
+              {/if}
+              {#if run.team_name}
+                <div class="key-row"><label>Team</label><val>{run.team_name}</val></div>
+              {/if}
+              <div class="key-row"><label>Mode</label><val>{run.mode ?? '—'}</val></div>
+              <div class="key-row"><label>Autonomy</label><val>{run.autonomy_level ?? 'assisted'}</val></div>
+              <div class="key-row">
+                <label>Status</label>
+                <val style="color: {isLive ? 'var(--go)' : run.status === 'failed' ? 'var(--abort)' : 'var(--ink)'}">{run.status}</val>
               </div>
-            {/each}
-          </div>
-        {/if}
-      </div>
+              <div class="key-row">
+                <label>Verdict</label>
+                <val class={run.verdict ? '' : 'dim'}>{run.verdict ?? '—'}</val>
+              </div>
+              <div class="key-row"><label>Model</label><val class={run.model ? '' : 'dim'}>{run.model ?? '— (defaults)'}</val></div>
+              <div class="key-row"><label>Branch</label><val class={run.branch ? '' : 'dim'}>{run.branch ?? '—'}</val></div>
+              <div class="key-row"><label>Issue</label><val class={run.issue_number ? '' : 'dim'}>{run.issue_number ? '#' + run.issue_number : '—'}</val></div>
+              <div class="key-row"><label>Started</label><val>{run.started_at ? new Date(run.started_at + (run.started_at.endsWith('Z') ? '' : 'Z')).toLocaleString() : '—'}</val></div>
+              <div class="key-row"><label>Finished</label>
+                <val class={run.finished_at ? '' : 'dim'}>
+                  {#if run.finished_at}{new Date(run.finished_at + (run.finished_at.endsWith('Z') ? '' : 'Z')).toLocaleString()}{:else}in flight{/if}
+                </val>
+              </div>
+              {#if run.log_file}
+                <div class="key-row"><label>Log</label><val style="color: var(--data); font-size: 10px; word-break: break-all">{run.log_file}</val></div>
+              {/if}
 
-    {:else if activeTab === 'diff'}
-      <div class="card p-5">
-        <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary mb-4">Code Changes</h3>
-        {#if diff?.files && diff.files.length > 0}
-          <div class="space-y-4">
-            <div class="text-xs font-mono text-secondary">
-              {diff.files.length} file{diff.files.length > 1 ? 's' : ''} changed,
-              <span class="text-emerald">+{diff.total_additions}</span>
-              <span class="text-rose">-{diff.total_deletions}</span>
+              {#if ctx?.queue_items && ctx.queue_items.length > 0}
+                <h3 style="margin-top: 14px">Queue Items ({ctx.queue_items.length})</h3>
+                {#each ctx.queue_items as qi}
+                  <div class="mono-line">
+                    {#if qi.issue_number}<b>#{qi.issue_number}</b> {/if}
+                    <span class="dim">[{qi.state}]</span>
+                    {#if qi.issue_title} {qi.issue_title}{/if}
+                  </div>
+                {/each}
+              {:else if ctx?.queue_item}
+                <h3 style="margin-top: 14px">Queue Item</h3>
+                <div class="mono-line">
+                  <span class="dim">[{ctx.queue_item.state}]</span>
+                  {#if ctx.queue_item.issue_title} {ctx.queue_item.issue_title}{/if}
+                </div>
+              {/if}
+            </div>
+          </div>
+        </section>
+
+      <!-- DAG -->
+      {:else if activeTab === 'dag'}
+        <section class="tab-pane">
+          {#if hasDag}
+            <div class="dag">
+              {#each ctx?.coordinator_tasks ?? [] as task, i}
+                {@const role = taskRoleFromTitle(task)}
+                <div class="dag-row {task.status === 'running' ? 'run' : ''}">
+                  <span class="ix">{String(i + 1).padStart(2, '0')}</span>
+                  <span class="id">{shortTaskId(task.id)}</span>
+                  <span class="title">
+                    {task.title ?? task.id}
+                    {#if task.description}<span style="color: var(--graphite)"> · {task.description}</span>{/if}
+                    <span style="color: var(--role-{role}); font-family: var(--pro-mono); font-size: 10px; margin-left: 6px">[{role}]</span>
+                  </span>
+                  <span>
+                    <span class="status {taskStatusClass(task.status)}">
+                      {#if task.status === 'running'}<span class="run-tick"></span>{/if}
+                      <span class="lab">{task.status}</span>
+                    </span>
+                  </span>
+                  <span class="num {task.touched_files ? '' : 'nu'}">
+                    {#if task.touched_files}
+                      {(() => { try { return (JSON.parse(task.touched_files) as unknown[]).length + ' files'; } catch { return '— files'; } })()}
+                    {:else}
+                      — files
+                    {/if}
+                  </span>
+                  <span class="num">{taskDuration(task)}</span>
+                </div>
+              {/each}
+            </div>
+          {:else}
+            <div class="empty">No DAG tasks recorded for this run.</div>
+          {/if}
+        </section>
+
+      <!-- TEAM -->
+      {:else if activeTab === 'team'}
+        <section class="tab-pane">
+          {#if ctx?.team_summary}
+            <div class="card-block">
+              <h3>Team {ctx.team_summary.team_name}</h3>
+              <p>
+                <b>{ctx.team_summary.teammates.length}</b> agents linked. Lead coordinates
+                {ctx.team_summary.teammates.length - 1} role-specialists.
+                {ctx.team_summary.tasks_completed} of {ctx.team_summary.tasks_total} tasks complete;
+                {ctx.team_summary.tasks_in_progress} in flight.
+                {#if ctx.team_summary.conflicts > 0}<b style="color:var(--caution)">{ctx.team_summary.conflicts} conflicts.</b>{/if}
+              </p>
+              {#if ctx.team_summary.tasks_total > 0}
+                {@const pct = (ctx.team_summary.tasks_completed / ctx.team_summary.tasks_total) * 100}
+                <div class="progress"><span style="width: {pct}%"></span></div>
+                <div class="progress-meta">
+                  <span>{ctx.team_summary.tasks_completed} done · {ctx.team_summary.tasks_in_progress} active</span>
+                  <span>~{Math.round(pct)}% complete</span>
+                </div>
+              {/if}
+            </div>
+
+            <div class="team-grid">
+              {#each ctx.team_summary.teammates as member}
+                {@const memberColor = getAgentColor(member.name.toLowerCase())}
+                <div class="card-block">
+                  <div class="team-head">
+                    <div class="team-avatar" style="background: {memberColor}15; color: {memberColor}; border-color: {memberColor}">
+                      {getInitials(member.name)}
+                    </div>
+                    <div>
+                      <div class="team-name">{member.name}</div>
+                      <div class="team-status">
+                        <span class="run-tick" style="background: {member.status === 'completed' ? 'var(--graphite)' : member.status === 'stuck' ? 'var(--abort)' : 'var(--go)'}; animation: {member.status === 'completed' || member.status === 'stuck' ? 'none' : ''}"></span>
+                        {member.status}
+                      </div>
+                    </div>
+                  </div>
+                  <div class="mono-line">
+                    {#if member.turns_used}{member.turns_used} turns · {/if}
+                    {#if member.tokens_used}{formatTokens(member.tokens_used)} tokens{/if}
+                  </div>
+                  {#if member.files_touched && member.files_touched.length > 0}
+                    <div class="mono-line nu">Files touched:</div>
+                    {#each member.files_touched.slice(0, 3) as file}
+                      <div class="mono-line" style="color: var(--graphite)">{file}</div>
+                    {/each}
+                    {#if member.files_touched.length > 3}
+                      <div class="mono-line nu">+{member.files_touched.length - 3} more</div>
+                    {/if}
+                  {/if}
+                </div>
+              {/each}
+            </div>
+          {:else}
+            <div class="empty">No team data for this run.</div>
+          {/if}
+        </section>
+
+      <!-- CONVERSATION -->
+      {:else if activeTab === 'conversation'}
+        <section class="tab-pane">
+          {#if conversationMessages.length === 0}
+            <div class="empty">No conversation data for this run</div>
+          {:else}
+            <div class="conv">
+              {#each conversationMessages as msg}
+                {@const agentName = getAgentName(
+                  msg.employee_index,
+                  msg.direction === 'system' ? 'coordinator' : null,
+                )}
+                {@const role = agentName.toLowerCase().includes('lead')
+                  ? 'lead'
+                  : agentName.toLowerCase().includes('back')
+                    ? 'backend'
+                    : agentName.toLowerCase().includes('front')
+                      ? 'frontend'
+                      : agentName.toLowerCase().includes('qa')
+                        ? 'qa'
+                        : 'operator'}
+                {@const glyph =
+                  msg.message_type === 'guidance'
+                    ? '@'
+                    : msg.message_type === 'error'
+                      ? '!'
+                      : msg.message_type === 'progress'
+                        ? '→'
+                        : msg.message_type === 'conflict'
+                          ? '!'
+                          : '>'}
+                <div class="conv-row">
+                  <span class="t">{timeAgo(msg.created_at)}</span>
+                  <span class="agent" data-role={role}>{agentName}</span>
+                  <span class="glyph">{glyph}</span>
+                  <span class="body"><em>{msg.message_type}</em>{msg.content ?? ''}</span>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </section>
+
+      <!-- DIFF -->
+      {:else if activeTab === 'diff'}
+        <section class="tab-pane">
+          {#if diff?.files && diff.files.length > 0}
+            <div class="diff-stat">
+              <span><b>{diff.files.length} files</b> changed</span>
+              <span class="add">+{diff.total_additions}</span>
+              <span class="del">−{diff.total_deletions}</span>
+              {#if run.branch}<span class="dim">vs <code>{run.branch}</code></span>{/if}
             </div>
             {#each diff.files as file}
-              <div class="border border-border rounded-lg overflow-hidden">
-                <div class="px-3 py-2 bg-surface-1 border-b border-border flex items-center justify-between">
-                  <span class="text-xs font-mono text-primary">{file.path}</span>
-                  <span class="text-[10px] font-mono text-tertiary">
-                    <span class="text-emerald">+{file.additions}</span>
-                    <span class="text-rose ml-1">-{file.deletions}</span>
+              <div class="diff-file">
+                <div class="file-head">
+                  <span class="path">{file.path}</span>
+                  <span class="meta">
+                    <span class="add">+{file.additions}</span>
+                    &nbsp;
+                    <span class="del">−{file.deletions}</span>
                   </span>
                 </div>
-                <div class="overflow-x-auto">
+                <div class="hunk">
                   {#each file.hunks as hunk}
+                    <div class="hunk-line hd">
+                      @@ -{hunk.old_start},{hunk.old_count} +{hunk.new_start},{hunk.new_count} @@
+                    </div>
                     {#each hunk.lines as line}
-                      <div class="px-3 py-0 text-xs font-mono whitespace-pre leading-5
-                                  {line.type === 'add' ? 'bg-emerald/5 text-emerald' :
-                                   line.type === 'delete' ? 'bg-rose/5 text-rose' :
-                                   'text-secondary'}">
-                        <span class="inline-block w-4 text-ghost mr-2 select-none">
-                          {line.type === 'add' ? '+' : line.type === 'delete' ? '-' : ' '}
-                        </span>{line.content}
+                      <div class="hunk-line {line.type === 'add' ? 'add' : line.type === 'delete' ? 'del' : ''}">
+                        <span class="ln">{line.old_line ?? ''}</span>
+                        <span class="ln">{line.new_line ?? ''}</span>
+                        <span class="sg">{line.type === 'add' ? '+' : line.type === 'delete' ? '−' : ''}</span>
+                        <span class="src">{line.content}</span>
                       </div>
                     {/each}
                   {/each}
                 </div>
               </div>
             {/each}
-          </div>
-        {:else}
-          <p class="text-sm text-tertiary text-center py-8">
-            {#if run.status === 'started' || run.status === 'running'}
-              Diff will be available after the run completes
-            {:else if !run.branch}
-              No branch recorded for this run
-            {:else}
-              No code changes detected
-            {/if}
-          </p>
-        {/if}
-      </div>
+          {:else}
+            <div class="empty">
+              {#if isLive}
+                Diff will be available after the run completes.
+              {:else if !run.branch}
+                No branch recorded for this run.
+              {:else}
+                No code changes detected.
+              {/if}
+            </div>
+          {/if}
+        </section>
 
-    {:else if activeTab === 'logs'}
-      <div class="card p-5">
-        <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary mb-4">Logs</h3>
-        <LogViewer runId={run.run_id} logFile={run.log_file ?? null} />
-      </div>
-
-    {:else if activeTab === 'intelligence' && ctx?.intelligence_decisions}
-      <div class="card p-5">
-        <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary mb-4">Intelligence Decisions</h3>
-        <div class="space-y-2">
-          {#each ctx.intelligence_decisions as event}
-            {#if event.event_type === 'vision_misalignment'}
-              <div class="card p-3" style="border-left: 3px solid #B06030;">
-                <div class="flex items-center gap-2 text-xs text-[#B06030] font-semibold mb-1">
-                  ⚠ Vision misalignment — issue #{event.event_data?.issue_number}
-                </div>
-                <div class="text-xs text-secondary mb-1">
-                  Violated: <code class="text-accent-orange">{event.event_data?.violated_section}</code>
-                </div>
-                <blockquote class="text-xs text-tertiary italic border-l-2 border-tertiary/40 pl-2 my-1">
-                  "{event.event_data?.quote}"
-                </blockquote>
-                <div class="text-xs text-tertiary">Plan excerpt: {event.event_data?.plan_excerpt}</div>
-                <div class="text-[10px] font-mono text-ghost mt-1">{timeAgo(event.created_at)}</div>
-              </div>
-            {:else}
-              <div class="px-3 py-2 rounded-lg bg-surface-1 border border-border">
-                <div class="flex items-center justify-between mb-1">
-                  <span class="text-xs font-mono text-cyan">{event.event_type}</span>
-                  <span class="text-[10px] font-mono text-ghost">{timeAgo(event.created_at)}</span>
-                </div>
-                <pre class="text-[11px] font-mono text-tertiary overflow-x-auto">{JSON.stringify(event.event_data, null, 2)}</pre>
-              </div>
-            {/if}
-          {/each}
-        </div>
-      </div>
-    {/if}
-
-    <!-- Messages (always visible below tabs if present) -->
-    {#if ctx?.coordinator_messages && ctx.coordinator_messages.length > 0}
-      <div class="card p-5">
-        <h3 class="text-xs font-mono uppercase tracking-widest text-tertiary mb-4">Messages</h3>
-        <div class="space-y-2">
-          {#each ctx.coordinator_messages as msg}
-            <div class="flex items-start gap-3 px-3 py-2 rounded-lg bg-surface-1">
-              <span class="badge badge-{msg.message_type === 'guidance' ? 'pr' : msg.message_type === 'conflict' ? 'reject' : msg.message_type === 'error' ? 'reject' : 'pending'}">
-                {msg.message_type}
-              </span>
-              <div class="flex-1">
-                <span class="text-xs text-secondary">{msg.content}</span>
-                <span class="text-[10px] text-ghost ml-2">{timeAgo(msg.created_at)}</span>
+      <!-- LOGS -->
+      {:else if activeTab === 'logs'}
+        <section class="tab-pane">
+          {#if run.log_file}
+            <div class="card-block" style="margin-bottom: 12px">
+              <div style="display: flex; justify-content: space-between; align-items: center; gap: 14px">
+                <span class="mono-line" style="margin: 0">{run.log_file}</span>
+                <span style="font-family: var(--pro-mono); font-size: 11px; color: var(--graphite)">tail -F</span>
               </div>
             </div>
-          {/each}
-        </div>
-      </div>
-    {/if}
+            <LogViewer runId={run.run_id} logFile={run.log_file ?? null} />
+          {:else}
+            <div class="empty">No log file recorded for this run.</div>
+          {/if}
+        </section>
+
+      <!-- INTELLIGENCE -->
+      {:else if activeTab === 'intelligence'}
+        <section class="tab-pane">
+          {#if hasIntelligence}
+            <div class="conv">
+              {#each ctx?.intelligence_decisions ?? [] as event}
+                {#if event.event_type === 'vision_misalignment'}
+                  <div class="card-block" style="border-left: 3px solid var(--caution); margin-bottom: 8px">
+                    <h3 style="color: var(--caution)">⚠ Vision misalignment — issue #{event.event_data?.issue_number}</h3>
+                    <p>Violated: <code>{event.event_data?.violated_section}</code></p>
+                    <p style="font-style: italic; color: var(--graphite); border-left: 2px solid var(--rule); padding-left: 8px">"{event.event_data?.quote}"</p>
+                    <p class="mono-line nu">{timeAgo(event.created_at)}</p>
+                  </div>
+                {:else}
+                  <div class="card-block" style="margin-bottom: 6px">
+                    <div class="mono-line" style="display: flex; justify-content: space-between">
+                      <span style="color: var(--data)">{event.event_type}</span>
+                      <span class="nu">{timeAgo(event.created_at)}</span>
+                    </div>
+                    <pre style="font-family: var(--pro-mono); font-size: 11px; color: var(--graphite); margin: 4px 0; overflow-x: auto">{JSON.stringify(event.event_data, null, 2)}</pre>
+                  </div>
+                {/if}
+              {/each}
+            </div>
+          {:else}
+            <div class="empty">No autonomy decisions recorded for this run.</div>
+          {/if}
+        </section>
+      {/if}
+    </div>
   </div>
 {/if}
 
 <style>
-  /* Pro restyle for the page header + tabs only.
-     Tab content keeps existing app.css tokens — its `card`, `badge`,
-     `text-primary`, etc. classes still resolve correctly. */
-  .run-detail-pro :global(.rd-head) {
-    display: flex; flex-direction: column;
-    gap: 16px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--rule);
-  }
-  @media (min-width: 640px) {
-    .run-detail-pro :global(.rd-head) {
-      flex-direction: row;
-      align-items: flex-end;
-      justify-content: space-between;
-    }
+  /* Edge-to-edge layout — bypass Shell padding (which Shell doesn't apply
+     anyway, so we just use full width). */
+
+  .rd {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
   }
 
-  .run-detail-pro :global(.rd-title-row) {
-    display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
-    margin-bottom: 6px;
+  .rd-loading,
+  .rd-empty {
+    padding: 32px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    align-items: center;
   }
-  .run-detail-pro :global(.rd-runid) {
+
+  .rd-empty-msg {
+    font-family: var(--pro-mono);
+    font-size: 13px;
+    color: var(--abort);
+  }
+
+  /* Crumb */
+  .rd :global(.crumb) {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 6px 16px;
+    border-bottom: 1px solid var(--rule);
+    background: var(--paper);
+    flex-shrink: 0;
+    font-family: var(--pro-mono);
+    font-size: 11px;
+    color: var(--graphite);
+  }
+  .rd :global(.crumb a) {
+    color: var(--graphite);
+    text-decoration: none;
+  }
+  .rd :global(.crumb a:hover) {
+    color: var(--ink);
+  }
+  .rd :global(.crumb b) {
+    color: var(--ink);
+    font-weight: 500;
+  }
+  .rd :global(.crumb .sep) {
+    color: var(--ash);
+  }
+
+  /* Page header */
+  .rd :global(.page-head) {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 18px;
+    align-items: end;
+    padding: 16px 16px 12px;
+    border-bottom: 1px solid var(--rule);
+    flex-shrink: 0;
+  }
+  .rd :global(.page-head h1) {
     margin: 0;
     font-family: var(--pro-mono);
     font-size: 22px;
     font-weight: 600;
     letter-spacing: -0.01em;
     color: var(--ink);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
     word-break: break-all;
   }
-  .run-detail-pro :global(.rd-status-dot) {
-    display: inline-block; width: 8px; height: 8px;
-    background: var(--ash);
-    flex-shrink: 0;
+  .rd :global(.page-head h1 .badges) {
+    display: inline-flex;
+    gap: 6px;
+    flex-wrap: wrap;
   }
-  .run-detail-pro :global(.rd-status-dot.go)    { background: var(--go); }
-  .run-detail-pro :global(.rd-status-dot.abort) { background: var(--abort); }
-  .run-detail-pro :global(.rd-status-dot.live)  { animation: rdlive 1.6s steps(2) infinite; }
-  @keyframes rdlive { 50% { opacity: .35; } }
+  .rd :global(.page-head .meta) {
+    font-family: var(--pro-mono);
+    font-size: 11px;
+    color: var(--graphite);
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 6px;
+  }
+  .rd :global(.page-head .meta b) {
+    color: var(--ink);
+    font-weight: 500;
+  }
+  .rd :global(.page-head .meta b.nu) {
+    color: var(--ash);
+    font-weight: 400;
+  }
+  .rd :global(.page-head .meta .sep) {
+    color: var(--ash);
+  }
+  .rd :global(.page-head .meta .skip) {
+    color: var(--caution);
+    font-style: italic;
+  }
 
-  .run-detail-pro :global(.rd-pill) {
+  /* Controls */
+  .rd :global(.rd-controls) {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-self: end;
+  }
+  .rd :global(.rd-action) {
     font-family: var(--pro-sans);
-    font-weight: 700; font-size: 9px;
-    letter-spacing: 0.14em; text-transform: uppercase;
-    padding: 3px 6px;
-    border: 1px solid currentColor;
-    color: var(--graphite);
+    font-weight: 700;
+    font-size: 10px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    background: transparent;
+    color: var(--ink);
+    border: 1px solid var(--rule-2);
+    padding: 5px 10px;
+    cursor: pointer;
+    height: 26px;
     line-height: 1;
-    display: inline-block;
-    white-space: nowrap;
   }
-  .run-detail-pro :global(.rd-pill.run)              { color: var(--go); }
-  .run-detail-pro :global(.rd-pill.verdict-approve)  { color: var(--go); }
-  .run-detail-pro :global(.rd-pill.verdict-pr)       { color: var(--caution); }
-  .run-detail-pro :global(.rd-pill.verdict-reject)   { color: var(--abort); }
-  .run-detail-pro :global(.rd-pill.verdict-skip)     { color: var(--graphite); }
-  .run-detail-pro :global(.rd-pill.mode)             { color: var(--ink); border-color: var(--rule-2); }
-  .run-detail-pro :global(.rd-pill.mode-vision-bootstrap) { color: var(--graphite); }
-
-  .run-detail-pro :global(.rd-meta-chip) {
-    font-family: var(--pro-mono);
-    font-size: 11px;
-    color: var(--graphite);
-    border: 1px solid var(--rule);
-    padding: 1px 6px;
-  }
-
-  .run-detail-pro :global(.rd-meta-row) {
-    display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
-    font-family: var(--pro-mono);
-    font-size: 11px;
-    color: var(--graphite);
-  }
-  .run-detail-pro :global(.rd-meta-row b)   { color: var(--ink); font-weight: 500; }
-  .run-detail-pro :global(.rd-meta-row .sep){ color: var(--ash); }
-  .run-detail-pro :global(.rd-skip) { font-style: italic; color: var(--caution); }
-
-  .run-detail-pro :global(.rd-stats) {
-    display: flex; align-items: center; gap: 0;
-    border: 1px solid var(--rule);
+  .rd :global(.rd-action:hover:not(:disabled)) {
     background: var(--paper-2);
   }
-  .run-detail-pro :global(.rd-stat) {
-    padding: 6px 14px;
-    border-right: 1px solid var(--rule);
-    display: flex; flex-direction: column; gap: 2px;
-    min-width: 80px;
+  .rd :global(.rd-action:disabled) {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
-  .run-detail-pro :global(.rd-stat:last-child) { border-right: none; }
-  .run-detail-pro :global(.rd-stat .k) {
+  .rd :global(.rd-action.danger) {
+    color: var(--abort);
+    border-color: color-mix(in oklab, var(--abort) 50%, transparent);
+  }
+  .rd :global(.rd-action.danger:hover:not(:disabled)) {
+    background: color-mix(in oklab, var(--abort) 10%, var(--paper));
+  }
+  .rd :global(.rd-action.go) {
+    color: var(--go);
+    border-color: color-mix(in oklab, var(--go) 50%, transparent);
+  }
+  .rd :global(.rd-action.go:hover:not(:disabled)) {
+    background: color-mix(in oklab, var(--go) 10%, var(--paper));
+  }
+
+  /* Quick stats */
+  .rd :global(.qstats) {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    border-bottom: 1px solid var(--rule);
+  }
+  .rd :global(.qstat) {
+    padding: 10px 14px;
+    border-right: 1px solid var(--rule);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+  .rd :global(.qstat:last-child) {
+    border-right: none;
+  }
+  .rd :global(.qstat .k) {
     font-family: var(--pro-sans);
-    font-size: 9px; font-weight: 700;
-    letter-spacing: 0.18em; text-transform: uppercase;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
     color: var(--graphite);
   }
-  .run-detail-pro :global(.rd-stat .v) {
+  .rd :global(.qstat .v) {
     font-family: var(--pro-mono);
-    font-size: 14px; font-weight: 600;
-    color: var(--ink); line-height: 1;
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--ink);
+    line-height: 1;
     font-variant-numeric: tabular-nums;
+  }
+  .rd :global(.qstat .v.go) {
+    color: var(--go);
+  }
+  .rd :global(.qstat .v.caution) {
+    color: var(--caution);
+  }
+  .rd :global(.qstat .v.abort) {
+    color: var(--abort);
+  }
+  .rd :global(.qstat .v.nu) {
+    color: var(--ash);
+  }
+  .rd :global(.qstat .vsub) {
+    font-size: 0.55em;
+    color: var(--ash);
+    margin-left: 4px;
+  }
+  .rd :global(.qstat .sub) {
+    font-family: var(--pro-mono);
+    font-size: 9px;
+    color: var(--ash);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   /* Tabs */
-  .run-detail-pro :global(.rd-tabs) {
-    display: flex; gap: 0;
+  .rd :global(.tabs) {
+    display: flex;
+    gap: 0;
+    align-items: center;
     border-bottom: 1px solid var(--rule);
+    background: var(--paper);
+    padding: 0 16px;
+    flex-shrink: 0;
+    overflow-x: auto;
   }
-  .run-detail-pro :global(.rd-tab) {
+  .rd :global(.tab) {
     font-family: var(--pro-sans);
-    font-size: 11px; font-weight: 700;
-    letter-spacing: 0.16em; text-transform: uppercase;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
     color: var(--graphite);
     background: transparent;
     border: none;
@@ -683,9 +1141,412 @@
     cursor: pointer;
     white-space: nowrap;
   }
-  .run-detail-pro :global(.rd-tab:hover) { color: var(--ink); }
-  .run-detail-pro :global(.rd-tab.active) {
+  .rd :global(.tab.active) {
     color: var(--ink);
     border-bottom-color: var(--ink);
+  }
+  .rd :global(.tab:hover:not(.disabled)) {
+    color: var(--ink);
+  }
+  .rd :global(.tab .count) {
+    font-family: var(--pro-mono);
+    font-size: 10px;
+    color: var(--ash);
+    margin-left: 4px;
+    font-weight: 500;
+  }
+  .rd :global(.tab.active .count) {
+    color: var(--graphite);
+  }
+  .rd :global(.tab.disabled) {
+    color: var(--ash);
+    cursor: not-allowed;
+  }
+
+  .rd :global(.tab-body) {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+  }
+  .rd :global(.tab-pane) {
+    padding: 16px;
+  }
+
+  /* Cards */
+  .rd :global(.cards) {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 16px;
+  }
+  .rd :global(.card-block) {
+    background: var(--paper-2);
+    border: 1px solid var(--rule);
+    padding: 14px 16px;
+  }
+  .rd :global(.card-block h3) {
+    margin: 0 0 8px;
+    font-family: var(--pro-sans);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ash);
+    border-bottom: 1px solid var(--rule);
+    padding-bottom: 6px;
+  }
+  .rd :global(.card-block p) {
+    margin: 6px 0;
+    font-family: var(--pro-sans);
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--ink);
+  }
+  .rd :global(.card-block .mono-line) {
+    font-family: var(--pro-mono);
+    font-size: 11px;
+    color: var(--graphite);
+    margin: 4px 0;
+  }
+  .rd :global(.card-block .mono-line.nu) {
+    color: var(--ash);
+  }
+  .rd :global(.card-block .key-row) {
+    display: grid;
+    grid-template-columns: 90px 1fr;
+    gap: 8px;
+    padding: 3px 0;
+    border-bottom: 1px dashed var(--rule);
+    font-family: var(--pro-mono);
+    font-size: 11px;
+  }
+  .rd :global(.card-block .key-row:last-child) {
+    border-bottom: none;
+  }
+  .rd :global(.card-block .key-row label) {
+    color: var(--ash);
+    font-family: var(--pro-sans);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    align-self: center;
+  }
+  .rd :global(.card-block .key-row val) {
+    color: var(--ink);
+    word-break: break-all;
+  }
+  .rd :global(.card-block .key-row val.dim) {
+    color: var(--ash);
+  }
+
+  /* Progress */
+  .rd :global(.progress) {
+    height: 6px;
+    background: var(--paper-3);
+    position: relative;
+    margin: 4px 0;
+  }
+  .rd :global(.progress > span) {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    background: var(--go);
+  }
+  .rd :global(.progress-meta) {
+    font-family: var(--pro-mono);
+    font-size: 10px;
+    color: var(--ash);
+    display: flex;
+    justify-content: space-between;
+    margin-top: 2px;
+  }
+
+  /* Message input */
+  .rd :global(.rd-message-row) {
+    display: flex;
+    gap: 6px;
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px dashed var(--rule);
+  }
+  .rd :global(.rd-message-input) {
+    flex: 1;
+    font-family: var(--pro-mono);
+    font-size: 12px;
+    background: var(--paper);
+    color: var(--ink);
+    border: 1px solid var(--rule-2);
+    padding: 5px 8px;
+    height: 26px;
+  }
+  .rd :global(.rd-message-input:focus) {
+    outline: none;
+    border-color: var(--data);
+  }
+
+  /* DAG */
+  .rd :global(.dag) {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .rd :global(.dag-row) {
+    display: grid;
+    grid-template-columns: 24px 110px 1fr 80px 90px 70px;
+    gap: 14px;
+    align-items: center;
+    padding: 10px 14px;
+    border: 1px solid var(--rule);
+    background: var(--paper-2);
+    font-family: var(--pro-mono);
+    font-size: 12px;
+  }
+  .rd :global(.dag-row .ix) {
+    color: var(--ash);
+    font-size: 11px;
+  }
+  .rd :global(.dag-row .id) {
+    color: var(--graphite);
+  }
+  .rd :global(.dag-row .title) {
+    font-family: var(--pro-sans);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--ink);
+  }
+  .rd :global(.dag-row .num) {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  .rd :global(.dag-row .num.nu) {
+    color: var(--ash);
+  }
+  .rd :global(.dag-row.run) {
+    border-left: 3px solid var(--go);
+  }
+
+  /* Conversation */
+  .rd :global(.conv) {
+    display: flex;
+    flex-direction: column;
+  }
+  .rd :global(.conv-row) {
+    display: grid;
+    grid-template-columns: 78px 110px 16px 1fr;
+    gap: 8px;
+    padding: 4px 14px;
+    align-items: baseline;
+    font-family: var(--pro-mono);
+    font-size: 12px;
+  }
+  .rd :global(.conv-row + .conv-row) {
+    border-top: 1px dashed var(--rule);
+  }
+  .rd :global(.conv-row .t) {
+    color: var(--ash);
+    font-size: 11px;
+  }
+  .rd :global(.conv-row .agent) {
+    color: var(--ink);
+    font-weight: 500;
+  }
+  .rd :global(.conv-row .agent[data-role="lead"]) {
+    color: var(--role-lead);
+  }
+  .rd :global(.conv-row .agent[data-role="backend"]) {
+    color: var(--role-backend);
+  }
+  .rd :global(.conv-row .agent[data-role="frontend"]) {
+    color: var(--role-frontend);
+  }
+  .rd :global(.conv-row .agent[data-role="qa"]) {
+    color: var(--role-qa);
+  }
+  .rd :global(.conv-row .agent[data-role="operator"]) {
+    color: var(--role-operator);
+  }
+  .rd :global(.conv-row .glyph) {
+    color: var(--graphite);
+  }
+  .rd :global(.conv-row .body) {
+    color: var(--ink);
+    word-break: break-word;
+  }
+  .rd :global(.conv-row .body em) {
+    font-style: normal;
+    color: var(--data);
+    margin-right: 5px;
+  }
+
+  /* Team grid */
+  .rd :global(.team-grid) {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 12px;
+    margin-top: 12px;
+  }
+  .rd :global(.team-head) {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 8px;
+  }
+  .rd :global(.team-avatar) {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 2px solid;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--pro-mono);
+    font-size: 10px;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+  .rd :global(.team-name) {
+    font-family: var(--pro-sans);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--ink);
+  }
+  .rd :global(.team-status) {
+    font-family: var(--pro-mono);
+    font-size: 11px;
+    color: var(--graphite);
+    text-transform: capitalize;
+  }
+
+  /* Diff */
+  .rd :global(.diff-stat) {
+    display: flex;
+    gap: 14px;
+    padding: 10px 14px;
+    border: 1px solid var(--rule);
+    background: var(--paper-2);
+    font-family: var(--pro-mono);
+    font-size: 12px;
+    margin-bottom: 12px;
+    color: var(--graphite);
+  }
+  .rd :global(.diff-stat b) {
+    color: var(--ink);
+    font-weight: 500;
+  }
+  .rd :global(.diff-stat .add) {
+    color: var(--go);
+  }
+  .rd :global(.diff-stat .del) {
+    color: var(--abort);
+  }
+  .rd :global(.diff-stat .dim) {
+    color: var(--ash);
+  }
+  .rd :global(.diff-file) {
+    border: 1px solid var(--rule);
+    background: var(--paper-2);
+    margin-bottom: 8px;
+  }
+  .rd :global(.diff-file .file-head) {
+    font-family: var(--pro-mono);
+    font-size: 12px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--rule);
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+    background: var(--paper-3);
+  }
+  .rd :global(.diff-file .file-head .path) {
+    color: var(--ink);
+    word-break: break-all;
+  }
+  .rd :global(.diff-file .file-head .meta) {
+    color: var(--graphite);
+    flex-shrink: 0;
+  }
+  .rd :global(.diff-file .file-head .add) {
+    color: var(--go);
+  }
+  .rd :global(.diff-file .file-head .del) {
+    color: var(--abort);
+  }
+  .rd :global(.diff-file .hunk) {
+    padding: 8px 0;
+    font-family: var(--pro-mono);
+    font-size: 11px;
+    line-height: 1.45;
+    overflow-x: auto;
+  }
+  .rd :global(.diff-file .hunk-line) {
+    display: grid;
+    grid-template-columns: 36px 36px 16px 1fr;
+    gap: 0;
+  }
+  .rd :global(.diff-file .hunk-line .ln) {
+    color: var(--ash);
+    padding: 0 8px;
+    text-align: right;
+    user-select: none;
+  }
+  .rd :global(.diff-file .hunk-line .sg) {
+    padding: 0 4px;
+    text-align: center;
+    user-select: none;
+  }
+  .rd :global(.diff-file .hunk-line .src) {
+    padding: 0 8px;
+    white-space: pre;
+    color: var(--ink);
+  }
+  .rd :global(.diff-file .hunk-line.add) {
+    background: color-mix(in oklab, var(--go) 9%, transparent);
+  }
+  .rd :global(.diff-file .hunk-line.add .sg) {
+    color: var(--go);
+  }
+  .rd :global(.diff-file .hunk-line.del) {
+    background: color-mix(in oklab, var(--abort) 8%, transparent);
+  }
+  .rd :global(.diff-file .hunk-line.del .sg) {
+    color: var(--abort);
+  }
+  .rd :global(.diff-file .hunk-line.hd) {
+    color: var(--graphite);
+    padding: 0 8px;
+    font-style: italic;
+    grid-column: 1 / -1;
+  }
+
+  /* Empty state */
+  .rd :global(.empty) {
+    font-family: var(--pro-mono);
+    font-size: 12px;
+    color: var(--ash);
+    padding: 32px 14px;
+    text-align: center;
+    border: 1px dashed var(--rule);
+  }
+
+  @media (max-width: 1180px) {
+    .rd :global(.qstats) {
+      grid-template-columns: repeat(4, 1fr);
+    }
+    .rd :global(.cards) {
+      grid-template-columns: 1fr;
+    }
+  }
+  @media (max-width: 760px) {
+    .rd :global(.qstats) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    .rd :global(.dag-row) {
+      grid-template-columns: 24px 1fr 80px;
+    }
+    .rd :global(.dag-row .id),
+    .rd :global(.dag-row .num) {
+      display: none;
+    }
   }
 </style>

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -153,10 +153,6 @@
     }
   }
 
-  function shortRunId(id: string): string {
-    if (id.length <= 12) return id;
-    return id.slice(-12);
-  }
 
   function shortTaskId(id: string): string {
     if (!id) return '—';
@@ -286,7 +282,7 @@
   }
 </script>
 
-<svelte:window on:keydown={onKey} />
+<svelte:window onkeydown={onKey} />
 
 {#if loading}
   <div class="rd-loading animate-fade-in">
@@ -617,37 +613,37 @@
             <!-- Right: metadata -->
             <div class="card-block">
               <h3>Run Metadata</h3>
-              <div class="key-row"><label>Run ID</label><val>{run.run_id}</val></div>
+              <div class="key-row"><span class="k">Run ID</span><span class="v">{run.run_id}</span></div>
               {#if run.trace_id}
-                <div class="key-row"><label>Trace</label><val class="dim">{run.trace_id}</val></div>
+                <div class="key-row"><span class="k">Trace</span><span class="v dim">{run.trace_id}</span></div>
               {/if}
               {#if run.concurrent_group_id}
-                <div class="key-row"><label>Group</label><val class="dim">{run.concurrent_group_id}</val></div>
+                <div class="key-row"><span class="k">Group</span><span class="v dim">{run.concurrent_group_id}</span></div>
               {/if}
               {#if run.team_name}
-                <div class="key-row"><label>Team</label><val>{run.team_name}</val></div>
+                <div class="key-row"><span class="k">Team</span><span class="v">{run.team_name}</span></div>
               {/if}
-              <div class="key-row"><label>Mode</label><val>{run.mode ?? '—'}</val></div>
-              <div class="key-row"><label>Autonomy</label><val>{run.autonomy_level ?? 'assisted'}</val></div>
+              <div class="key-row"><span class="k">Mode</span><span class="v">{run.mode ?? '—'}</span></div>
+              <div class="key-row"><span class="k">Autonomy</span><span class="v">{run.autonomy_level ?? 'assisted'}</span></div>
               <div class="key-row">
-                <label>Status</label>
-                <val style="color: {isLive ? 'var(--go)' : run.status === 'failed' ? 'var(--abort)' : 'var(--ink)'}">{run.status}</val>
+                <span class="k">Status</span>
+                <span class="v" style="color: {isLive ? 'var(--go)' : run.status === 'failed' ? 'var(--abort)' : 'var(--ink)'}">{run.status}</span>
               </div>
               <div class="key-row">
-                <label>Verdict</label>
-                <val class={run.verdict ? '' : 'dim'}>{run.verdict ?? '—'}</val>
+                <span class="k">Verdict</span>
+                <span class="v {run.verdict ? '' : 'dim'}">{run.verdict ?? '—'}</span>
               </div>
-              <div class="key-row"><label>Model</label><val class={run.model ? '' : 'dim'}>{run.model ?? '— (defaults)'}</val></div>
-              <div class="key-row"><label>Branch</label><val class={run.branch ? '' : 'dim'}>{run.branch ?? '—'}</val></div>
-              <div class="key-row"><label>Issue</label><val class={run.issue_number ? '' : 'dim'}>{run.issue_number ? '#' + run.issue_number : '—'}</val></div>
-              <div class="key-row"><label>Started</label><val>{run.started_at ? new Date(run.started_at + (run.started_at.endsWith('Z') ? '' : 'Z')).toLocaleString() : '—'}</val></div>
-              <div class="key-row"><label>Finished</label>
-                <val class={run.finished_at ? '' : 'dim'}>
+              <div class="key-row"><span class="k">Model</span><span class="v {run.model ? '' : 'dim'}">{run.model ?? '— (defaults)'}</span></div>
+              <div class="key-row"><span class="k">Branch</span><span class="v {run.branch ? '' : 'dim'}">{run.branch ?? '—'}</span></div>
+              <div class="key-row"><span class="k">Issue</span><span class="v {run.issue_number ? '' : 'dim'}">{run.issue_number ? '#' + run.issue_number : '—'}</span></div>
+              <div class="key-row"><span class="k">Started</span><span class="v">{run.started_at ? new Date(run.started_at + (run.started_at.endsWith('Z') ? '' : 'Z')).toLocaleString() : '—'}</span></div>
+              <div class="key-row"><span class="k">Finished</span>
+                <span class="v {run.finished_at ? '' : 'dim'}">
                   {#if run.finished_at}{new Date(run.finished_at + (run.finished_at.endsWith('Z') ? '' : 'Z')).toLocaleString()}{:else}in flight{/if}
-                </val>
+                </span>
               </div>
               {#if run.log_file}
-                <div class="key-row"><label>Log</label><val style="color: var(--data); font-size: 10px; word-break: break-all">{run.log_file}</val></div>
+                <div class="key-row"><span class="k">Log</span><span class="v" style="color: var(--data); font-size: 10px; word-break: break-all">{run.log_file}</span></div>
               {/if}
 
               {#if ctx?.queue_items && ctx.queue_items.length > 0}
@@ -1222,7 +1218,7 @@
   .rd :global(.card-block .key-row:last-child) {
     border-bottom: none;
   }
-  .rd :global(.card-block .key-row label) {
+  .rd :global(.card-block .key-row .k) {
     color: var(--ash);
     font-family: var(--pro-sans);
     font-size: 9px;
@@ -1231,11 +1227,11 @@
     text-transform: uppercase;
     align-self: center;
   }
-  .rd :global(.card-block .key-row val) {
+  .rd :global(.card-block .key-row .v) {
     color: var(--ink);
     word-break: break-all;
   }
-  .rd :global(.card-block .key-row val.dim) {
+  .rd :global(.card-block .key-row .v.dim) {
     color: var(--ash);
   }
 


### PR DESCRIPTION
## Summary
- Rewrites Run Detail to the dense crumb / page-head / qstats / tabs layout from `design-drafts/run-detail.html`.
- Lifts run controls (pause / resume / stop, plan approve / reject, send-message) into the page header so they live next to the run id.
- 8-slot quick-stats strip (tokens · turns · cost · tasks · files · duration · verdict · budget) + Overview / DAG / Team / Conversation / Diff / Logs / Intelligence tabs with hotkeys 1..7 and disabled states.
- All actions wired against the existing API surface; Shell still owns strip / ticker / footer (edge-to-edge inside the main content slot).
- Cleans two pre-existing TS comparison errors flagged on `mode === 'vision-bootstrap'` while editing the file.

## Test plan
- [ ] `cd dashboard/frontend && npm run build` compiles (verified).
- [ ] Visit a live run: pause / resume / stop / send-message all post to the matching endpoints.
- [ ] Visit a `plan_only` run in `awaiting_plan_review`: Approve / Reject buttons appear and call the operator plan-review endpoints.
- [ ] DAG / Team / Conversation / Diff / Logs / Intelligence tabs render when their data is present and are disabled otherwise.
- [ ] Hotkeys 1..7 switch tabs; inputs do not steal them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)