### PR TITLE
fix(ui): Pro design refinement — flap spaces, mode badge, markdown, layout

### DIFF
--- a/dashboard/frontend/src/lib/design/flap.ts
+++ b/dashboard/frontend/src/lib/design/flap.ts
@@ -50,7 +50,9 @@ function buildChars(
   const skipAnim = !animate || reducedMotion();
   for (let i = 0; i < text.length; i++) {
     const s = document.createElement('span');
-    s.textContent = text[i] === ' ' ? ' ' : text[i];
+    // Non-breaking space — regular spaces collapse to 0 width inside the
+    // inline-flex .flap container.
+    s.textContent = text[i] === ' ' ? ' ' : text[i];
     if (skipAnim) {
       // Disable the CSS @keyframes flap so polling-driven updates don't
       // re-trigger the intro animation across a 50-row board.

--- a/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
+++ b/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
@@ -170,6 +170,14 @@
   }
 
   // Pull a short string out of a coordinator message's `content` blob.
+  function stripMd(s: string | null | undefined): string {
+    if (!s) return '';
+    return s
+      .replace(/\*\*([^*]+)\*\*/g, '$1')   // **bold** → bold
+      .replace(/\*([^*]+)\*/g, '$1')        // *em* → em
+      .replace(/`([^`]+)`/g, '$1');         // `code` → code
+  }
+
   function messagePreview(raw: string | null): { verb: string; body: string } {
     if (!raw) return { verb: '', body: '—' };
     if (typeof raw !== 'string') {
@@ -184,10 +192,10 @@
     try {
       const parsed = JSON.parse(raw) as Record<string, unknown>;
       if (parsed.tool) return { verb: 'Use', body: `${parsed.tool}` };
-      if (typeof parsed.text === 'string') return { verb: '', body: parsed.text.slice(0, 80) };
-      return { verb: '', body: raw.slice(0, 80) };
+      if (typeof parsed.text === 'string') return { verb: '', body: stripMd(parsed.text).slice(0, 80) };
+      return { verb: '', body: stripMd(raw).slice(0, 80) };
     } catch {
-      return { verb: '', body: raw.slice(0, 80) };
+      return { verb: '', body: stripMd(raw).slice(0, 80) };
     }
   }
 
@@ -228,7 +236,7 @@
       if (out[role] && out[role]!.statusKind === 'run') continue;
       const e = empFor(t);
       const name = t.claimed_by ?? t.teammate_agent_id ?? `${role}-?`;
-      const taskTitle = t.title?.trim();
+      const taskTitle = stripMd(t.title)?.trim();
       const taskIsNul = !taskTitle;
       const taskMessages = messages.filter((m) => m.task_id === t.id).slice(-1);
       const latest = taskMessages.length

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -146,7 +146,7 @@
     if (m === 'plan') return { label: 'PLAN', cls: 'plan' };
     if (m === 'analyze') return { label: 'ANLZ', cls: 'plan' };
     if (m === 'vision-bootstrap') return { label: 'VIS', cls: 'vision' };
-    if (m === 'agent_teams') return { label: 'TEAMS', cls: 'full' };
+    if (m === 'agent-teams' || m === 'agent_teams') return { label: 'TEAMS', cls: 'full' };
     if (m === 'employee') return { label: 'EMP', cls: 'full' };
     if (m === 'manager') return { label: 'MGR', cls: 'full' };
     if (m === 'full') return { label: 'FULL', cls: 'full' };

--- a/dashboard/frontend/src/pages/ProjectsPage.svelte
+++ b/dashboard/frontend/src/pages/ProjectsPage.svelte
@@ -430,7 +430,7 @@
   .projects-pro {
     display: flex;
     flex-direction: column;
-    min-height: calc(100vh - 40px);
+    min-height: 0;
     background: var(--paper);
     color: var(--ink);
     font-family: var(--pro-sans);


### PR DESCRIPTION
## Summary
Four cross-page UI defects discovered during a Pro design browser audit.

- **Flap spaces collapsing** — `flap.ts` `buildChars()` now uses a non-breaking space (U+00A0) for whitespace chars; regular spaces collapsed to 0 width inside the inline-flex `.flap` host, so `"plan-only run"` rendered as `"plan-onlyrun"`. Affects Dispatch board headlines, Project Detail run rows, and Fleet team header.
- **Markdown asterisks** — `AgentTeamsCanvas.svelte` adds a local 5-line `stripMd()` helper applied to task titles and message previews so orchestrator-stored prompts no longer render `**Backend Specialist**` with literal asterisks. No new dependencies.
- **Mode badge "AGEN"** — DB stores Agent Teams mode as `agent-teams` (hyphen). `modeFor()` in `CommandCenter.svelte` only matched the underscore form, so the actual value fell through to 4-char truncation. Branch now matches both `agent-teams` and `agent_teams` and emits `TEAMS`.
- **Excessive vertical whitespace** — `ProjectsPage.svelte` root used `min-height: calc(100vh - 40px)`, pushing the global footer below sparse content. Replaced with `min-height: 0`; the Shell's flex column already grows `<main>` to fill the viewport. `MissionControl` and `ProjectDetail` already had `min-height: 0` on their roots — no change needed there. Dispatch (`CommandCenter.svelte`) is intentionally tall and was left alone.

## Test plan
- [ ] `npm run build` clean (verified locally — 966ms, only pre-existing a11y warnings)
- [ ] Visual check: Dispatch headlines show proper inter-word spaces
- [ ] Visual check: Fleet teammate rows render plain text, no `**…**`
- [ ] Visual check: Agent Teams runs show `TEAMS` badge instead of `AGEN`
- [ ] Visual check: Projects page footer flush with content on a sparse list

🤖 Generated with [Claude Code](https://claude.com/claude-code)