### PR TITLE
fix(ui): final Pro refinement — coord-rail markdown + mission activity fill

### DIFF
--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -98,6 +98,13 @@
     if (!id) return '—';
     return id.replace(/^run-(vb-)?/, '…');
   }
+  function stripMd(s: string | null | undefined): string {
+    if (!s) return '';
+    return s
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/\*([^*]+)\*/g, '$1')
+      .replace(/`([^`]+)`/g, '$1');
+  }
   function fmtUptime(secs: number | null | undefined): string {
     if (secs == null) return '—';
     const d = Math.floor(secs / 86400);
@@ -606,7 +613,7 @@
             {#each coordTasks.slice(0, 8) as task (task.id)}
               <div class="task">
                 <div class="lane">{task.claimed_by ?? task.teammate_agent_id ?? 'unassigned'}</div>
-                <div class="t">{task.title}</div>
+                <div class="t">{stripMd(task.title)}</div>
                 <div class="meta">
                   <span>{(task.status ?? '—').toUpperCase()}</span>
                   {#if task.employee_index != null}<span>EMP {task.employee_index}</span>{/if}

--- a/dashboard/frontend/src/pages/MissionControl.svelte
+++ b/dashboard/frontend/src/pages/MissionControl.svelte
@@ -606,8 +606,12 @@
   .mc-shell {
     display: flex;
     flex-direction: column;
-    height: 100%;
-    min-height: 0;
+    /* Match AgentTeamsCanvas: pin to viewport so .main can flex-grow into the
+       remaining space below the page-head + intervene + (optional) banner.
+       Without this, height:100% never resolves (App's wrapper isn't a flex
+       container) and the .main grid collapses to its content height,
+       leaving a tall blank gap above the global footer. */
+    min-height: calc(100vh - 40px);
     background: var(--paper);
     color: var(--ink);
     font-family: var(--pro-sans);


### PR DESCRIPTION
## Summary
Two cross-page UI refinements after the Pro design migration browser audit.

- **Dispatch coord rail markdown stripping** — `CommandCenter.svelte` right-rail "Coordinator · Live" rendered task titles raw, e.g. `BACKEND: YOU ARE THE **BACKEND SPECIALIST** ...`. Added a local `stripMd()` helper (matching the one in `AgentTeamsCanvas.svelte`) and applied it to `task.title`. No other coordinator/teammate text fields are rendered on this page.
- **Mission Control empty space below content** — `.mc-shell` used `height: 100%` but `App.svelte`'s wrapper isn't a flex container, so the height never resolved and `.main { flex: 1 }` collapsed to content height, leaving a tall blank gap above the global footer. Switched `.mc-shell` to `min-height: calc(100vh - 40px)` (same approach as `AgentTeamsCanvas.svelte`) so the activity feed + TX/Agents rail fill remaining viewport.

## Test plan
- [x] `npm run build` succeeds.
- [ ] Visual check: Dispatch right rail shows clean task titles without literal `**` asterisks.
- [ ] Visual check: Mission Control activity area extends to the footer; "Waiting for first event…" placeholder is vertically centered in the feed instead of leaving ~470px of empty space below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)