### PR TITLE
fix(ui): strip markdown in Dispatch coord-rail lane label

### DIFF
--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -612,7 +612,7 @@
           {:else}
             {#each coordTasks.slice(0, 8) as task (task.id)}
               <div class="task">
-                <div class="lane">{task.claimed_by ?? task.teammate_agent_id ?? 'unassigned'}</div>
+                <div class="lane">{stripMd(task.claimed_by ?? task.teammate_agent_id ?? 'unassigned')}</div>
                 <div class="t">{stripMd(task.title)}</div>
                 <div class="meta">
                   <span>{(task.status ?? '—').toUpperCase()}</span>


### PR DESCRIPTION
## Summary
One-line follow-up to PR #322. The orchestrator stores teammate prompts (with `**bold**` markdown) in `CoordinatorTask.claimed_by`/`teammate_agent_id` for some flows, not just in `title`. PR #322 stripped markdown on the title; the uppercase/blue lane label above it still leaked asterisks into the Coordinator·Live rail.

## Change
Apply the existing local `stripMd()` to the lane string too — `CommandCenter.svelte:615`.

## Test plan
- [x] `npm run build` succeeds.
- [ ] Visit `/` and confirm the Coordinator·Live rail's lane labels render without `**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)