### PR TITLE
fix(ui): strip markdown in Run Detail DAG task labels

### DIFF
--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -135,6 +135,14 @@
     return t;
   });
 
+  function stripMd(s: string | null | undefined): string {
+    if (!s) return '';
+    return s
+      .replace(/\*\*([^*]+)\*\*/g, '$1')
+      .replace(/\*([^*]+)\*/g, '$1')
+      .replace(/`([^`]+)`/g, '$1');
+  }
+
   function getInitials(name: string): string {
     return name
       .split(' ')
@@ -677,8 +685,8 @@
                   <span class="ix">{String(i + 1).padStart(2, '0')}</span>
                   <span class="id">{shortTaskId(task.id)}</span>
                   <span class="title">
-                    {task.title ?? task.id}
-                    {#if task.description}<span style="color: var(--graphite)"> · {task.description}</span>{/if}
+                    {stripMd(task.title) || task.id}
+                    {#if task.description}<span style="color: var(--graphite)"> · {stripMd(task.description)}</span>{/if}
                     <span style="color: var(--role-{role}); font-family: var(--pro-mono); font-size: 10px; margin-left: 6px">[{role}]</span>
                   </span>
                   <span>


### PR DESCRIPTION
One-line follow-up to #322/#323. Adds the same local `stripMd()` helper to RunDetail.svelte and applies it to task title/description in the DAG tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)