### PR TITLE
feat(ui): rebuild LiveTicker as dense KPI info-bar

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -46,6 +46,7 @@ from app.schemas import (
     TelemetrySummaryOut,
     TelemetrySystem,
     TelemetryTokens7d,
+    TelemetryVerdicts7d,
 )
 from app.services import service_control
 from app.services.diff_parser import DiffResult, parse_unified_diff
@@ -347,11 +348,40 @@ async def get_telemetry_summary(db: AsyncSession = Depends(get_db)):
         uptime_secs=uptime,
     )
 
+    # --- 5. Verdicts (7d) — same cutoff as tokens above ---
+    # Group APPROVE → ok, PR → pr, anything else non-null (REJECT and any
+    # future terminal verdict tag) → x. NULL verdicts are skipped (run still
+    # in flight, or never reached the manager). Verdicts are stored
+    # case-sensitively as APPROVE/PR/REJECT but we lower-case the SQL output
+    # to be defensive against historical writes that mixed cases.
+    verdict_q = (
+        select(
+            func.lower(Run.verdict).label("verdict"),
+            func.count(Run.id).label("n"),
+        )
+        .where(Run.started_at >= cutoff, Run.verdict.isnot(None))
+        .group_by(func.lower(Run.verdict))
+    )
+    verdict_rows = (await db.execute(verdict_q)).all()
+    v_ok = 0
+    v_pr = 0
+    v_x = 0
+    for v, n in verdict_rows:
+        if v == "approve":
+            v_ok += int(n or 0)
+        elif v == "pr":
+            v_pr += int(n or 0)
+        else:
+            v_x += int(n or 0)
+
+    verdicts_7d = TelemetryVerdicts7d(ok=v_ok, pr=v_pr, x=v_x)
+
     return TelemetrySummaryOut(
         active=active,
         queue=queue,
         tokens_7d=tokens_7d,
         system=system,
+        verdicts_7d=verdicts_7d,
     )
 
 

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -526,11 +526,24 @@ class TelemetrySystem(BaseModel):
     uptime_secs: float | None = None
 
 
+class TelemetryVerdicts7d(BaseModel):
+    """Verdict counts over the same 7-day window as ``tokens_7d``.
+
+    ``ok`` covers APPROVE verdicts, ``pr`` covers PR verdicts, ``x`` covers
+    REJECT plus any other non-null terminal verdict (so the three buckets
+    exhaust the verdict-bearing run set without dropping rows).
+    """
+    ok: int = 0
+    pr: int = 0
+    x: int = 0
+
+
 class TelemetrySummaryOut(BaseModel):
     active: TelemetryActive
     queue: TelemetryQueue
     tokens_7d: TelemetryTokens7d
     system: TelemetrySystem
+    verdicts_7d: TelemetryVerdicts7d = TelemetryVerdicts7d()
 
 
 # --- Analytics ---

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -333,7 +333,7 @@ async def test_telemetry_summary_shape_empty(client):
     assert resp.status_code == 200, resp.text
     data = resp.json()
 
-    assert set(data.keys()) == {"active", "queue", "tokens_7d", "system"}
+    assert set(data.keys()) == {"active", "queue", "tokens_7d", "system", "verdicts_7d"}
 
     assert data["active"]["count"] == 0
     assert data["active"]["teammates"] == 0
@@ -347,6 +347,8 @@ async def test_telemetry_summary_shape_empty(client):
     assert data["tokens_7d"]["total"] == 0
     assert data["tokens_7d"]["runs"] == 0
     assert isinstance(data["tokens_7d"]["spark"], list)
+
+    assert data["verdicts_7d"] == {"ok": 0, "pr": 0, "x": 0}
 
     # System status is NOMINAL when get_system_resources returns nothing
     # actionable (e.g. test environment without /proc/meminfo).
@@ -488,3 +490,35 @@ async def test_telemetry_summary_queue_other_bucket(client):
     assert q["done"] == 1
     assert q["other"] == 2
     assert q["pending"] + q["claimed"] + q["done"] + q["other"] == q["total"]
+
+
+@pytest.mark.asyncio
+async def test_telemetry_summary_verdicts_7d(client):
+    """Verdicts are bucketed APPROVE→ok, PR→pr, anything else non-null→x,
+    over the same 7-day cutoff used by ``tokens_7d``. Runs older than 7d or
+    with a NULL verdict are excluded."""
+    from app.database import async_session
+    from app.models import Run
+
+    now = datetime.now(timezone.utc)
+    async with async_session() as s:
+        # Within 7d window
+        s.add(Run(run_id="v1", status="completed", started_at=now, verdict="APPROVE"))
+        s.add(Run(run_id="v2", status="completed", started_at=now, verdict="APPROVE"))
+        s.add(Run(run_id="v3", status="completed", started_at=now, verdict="PR"))
+        s.add(Run(run_id="v4", status="completed", started_at=now, verdict="REJECT"))
+        # Lower-case write (defensive normalization)
+        s.add(Run(run_id="v5", status="completed", started_at=now, verdict="approve"))
+        # Excluded: NULL verdict
+        s.add(Run(run_id="v6", status="running", started_at=now, verdict=None))
+        # Excluded: older than 7 days
+        s.add(Run(
+            run_id="v7", status="completed",
+            started_at=now - timedelta(days=10), verdict="APPROVE",
+        ))
+        await s.commit()
+
+    resp = await client.get("/api/runs/telemetry-summary")
+    assert resp.status_code == 200, resp.text
+    v = resp.json()["verdicts_7d"]
+    assert v == {"ok": 3, "pr": 1, "x": 1}

--- a/dashboard/frontend/src/components/layout/LiveTicker.svelte
+++ b/dashboard/frontend/src/components/layout/LiveTicker.svelte
@@ -1,39 +1,202 @@
 <script lang="ts">
-  import { getAgentEvents } from '../../lib/api';
-  import type { AgentEvent } from '../../lib/types';
+  /**
+   * Global LiveTicker — dense KPI info-bar.
+   *
+   * Renders eleven scrolling cells (ACTIVE, QUEUE, TOK·7D, BACKPRESSURE,
+   * DISK·FREE, MEM, LOAD, UPTIME, NEXT TRIGGER, VERDICTS·7D, MODELS) that
+   * mirror `dashboard/frontend/design-drafts/dispatch-board.html` and the
+   * `STATION_TICKER` array in `pro.js`. Each cell renders as
+   * `<span>LABEL <b class="<color>">VALUE</b></span>` where ``color`` is one
+   * of ``''`` (default ink), ``go`` (green), ``am`` (amber), ``rd`` (red).
+   *
+   * Polls four endpoints on a 10s cadence (paused while the tab is hidden):
+   *   - GET /api/runs/telemetry-summary  → active, queue, tokens_7d, verdicts_7d
+   *   - GET /api/queue/pressure          → backpressure level
+   *   - GET /api/system/status           → disk, mem, load, uptime, next_trigger
+   *   - GET /api/config                  → models map
+   *
+   * The ticker track HTML is duplicated (matching `pro.js`'s `html + html`
+   * trick) so the CSS keyframe scroll loops seamlessly. The CSS rules for
+   * `.ticker`, `.ticker-tag`, `.ticker-track` and the `b.go/.am/.rd` color
+   * tokens already live in `lib/design/pro.css` and are not changed here.
+   */
+  import {
+    getTelemetrySummary,
+    getBackpressure,
+    getSystemStatus,
+    getConfig,
+  } from '../../lib/api';
+  import type {
+    TelemetrySummary,
+    BackpressureStatus,
+    SystemStatus,
+    StationConfig,
+  } from '../../lib/types';
 
-  let events = $state<AgentEvent[]>([]);
+  type Color = '' | 'go' | 'am' | 'rd';
+  type Cell = readonly [string, string, Color];
 
-  let segments = $derived.by(() => {
-    const segs = events.slice(0, 20).map((e) => {
-      const actor = (e.agent_id ?? 'station').split(':').pop() ?? 'station';
-      const tool =
-        (e.event_data && (e.event_data as Record<string, unknown>).tool as string)
-        ?? e.event_type
-        ?? 'event';
-      const target =
-        (e.event_data && (e.event_data as Record<string, unknown>).summary as string)
-        ?? (e.event_data && (e.event_data as Record<string, unknown>).file_path as string)
-        ?? '';
-      return { actor, tool, target };
-    });
-    if (segs.length === 0) {
-      return [{ actor: 'station', tool: 'idle', target: 'no recent activity' }];
+  let telemetry = $state<TelemetrySummary | null>(null);
+  let pressure = $state<BackpressureStatus | null>(null);
+  let system = $state<SystemStatus | null>(null);
+  let config = $state<StationConfig | null>(null);
+
+  // ── Formatters ──────────────────────────────────────────
+  function fmtTok(n: number | null | undefined): string {
+    if (n == null) return '—';
+    if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+    if (n >= 1_000) return `${(n / 1_000).toFixed(2)}K`;
+    return String(n);
+  }
+
+  function fmtUptime(seconds: number | null | undefined): string {
+    if (seconds == null || !Number.isFinite(seconds)) return '—';
+    const days = Math.floor(seconds / 86_400);
+    const hours = Math.floor((seconds % 86_400) / 3_600);
+    return `${days}d ${String(hours).padStart(2, '0')}h`;
+  }
+
+  function fmtModel(name: string | undefined): string {
+    if (!name) return '—';
+    // ``claude-opus-4-7`` → ``OPUS-4-7``; strip a leading vendor prefix and
+    // upper-case the rest. Hyphens are preserved by design.
+    return name.replace(/^claude-/i, '').toUpperCase();
+  }
+
+  function pressureColor(level: string | undefined): Color {
+    switch ((level ?? '').toUpperCase()) {
+      case 'GREEN': return 'go';
+      case 'YELLOW': return 'am';
+      case 'RED':
+      case 'BLACK': return 'rd';
+      default: return '';
     }
-    return segs;
+  }
+
+  function diskColor(free: number | null | undefined): Color {
+    if (free == null) return '';
+    if (free < 1) return 'rd';
+    if (free < 5) return 'am';
+    return '';
+  }
+
+  function memColor(pct: number | null | undefined): Color {
+    if (pct == null) return '';
+    if (pct > 90) return 'rd';
+    if (pct > 70) return 'am';
+    return '';
+  }
+
+  // ── Cells ──────────────────────────────────────────────
+  let cells = $derived.by<Cell[]>(() => {
+    // 1. ACTIVE
+    const activeCount = telemetry?.active.count ?? 0;
+    const activeCell: Cell = ['ACTIVE', String(activeCount), activeCount > 0 ? 'go' : ''];
+
+    // 2. QUEUE
+    const queueCell: Cell = ['QUEUE', String(telemetry?.queue.total ?? 0), ''];
+
+    // 3. TOK·7D
+    const tokCell: Cell = ['TOK·7D', fmtTok(telemetry?.tokens_7d.total ?? null), ''];
+
+    // 4. BACKPRESSURE
+    const lvl = pressure?.level ?? '—';
+    const bpCell: Cell = ['BACKPRESSURE', String(lvl).toUpperCase(), pressureColor(lvl)];
+
+    // 5. DISK·FREE
+    const diskFree = system?.resources.disk_free_gb;
+    const diskTotal = system?.resources.disk_total_gb;
+    const diskValue = diskFree != null && diskTotal != null
+      ? `${Math.round(diskFree)}G / ${Math.round(diskTotal)}G`
+      : '—';
+    const diskCell: Cell = ['DISK·FREE', diskValue, diskColor(diskFree)];
+
+    // 6. MEM
+    const memUsedMb = system?.resources.memory_used_mb;
+    const memTotalMb = system?.resources.memory_total_mb;
+    const memPct = telemetry?.system.memory_used_pct
+      ?? (memUsedMb != null && memTotalMb ? Math.round((100 * memUsedMb) / memTotalMb) : null);
+    const memValue = memUsedMb != null && memTotalMb != null && memPct != null
+      ? `${(memUsedMb / 1024).toFixed(1)}G / ${(memTotalMb / 1024).toFixed(1)}G · ${memPct}%`
+      : '—';
+    const memCell: Cell = ['MEM', memValue, memColor(memPct)];
+
+    // 7. LOAD — system.resources.load_avg is a [1m, 5m, 15m] tuple from
+    //   /proc/loadavg (see services/systemd.py). If the field is absent
+    //   (e.g. non-Linux dev box without /proc), fall back to ``—``.
+    //   TODO: cross-platform fallback via ``os.getloadavg()`` if we ever
+    //   ship to a non-Linux runtime.
+    const load = system?.resources.load_avg;
+    const loadValue = Array.isArray(load) && load.length >= 3
+      ? `${load[0].toFixed(2)} · ${load[1].toFixed(2)} · ${load[2].toFixed(2)}`
+      : '—';
+    const loadCell: Cell = ['LOAD', loadValue, ''];
+
+    // 8. UPTIME
+    const uptimeCell: Cell = [
+      'UPTIME',
+      fmtUptime(system?.resources.uptime_seconds ?? telemetry?.system.uptime_secs ?? null),
+      '',
+    ];
+
+    // 9. NEXT TRIGGER
+    //   ``/api/system/status`` exposes ``timer.next_trigger`` as a free-form
+    //   string from systemd (e.g. ``Sat 2026-05-10 18:45:00 UTC``). When the
+    //   timer is inactive or the deploy mode doesn't expose it, render ``—``.
+    //   TODO: parse cron from /api/config when running under compose mode so
+    //   this cell stays useful outside systemd. Skipped for now to keep the
+    //   ticker dependency-free.
+    const nextTrigger = system?.timer?.next_trigger?.trim();
+    const nextCell: Cell = [
+      'NEXT TRIGGER',
+      nextTrigger && nextTrigger !== '' ? nextTrigger : '—',
+      '',
+    ];
+
+    // 10. VERDICTS·7D
+    const v = telemetry?.verdicts_7d;
+    const verdictsValue = v
+      ? `${v.ok} OK / ${v.pr} PR / ${v.x} ✗`
+      : '0 OK / 0 PR / 0 ✗';
+    const verdictsCell: Cell = ['VERDICTS·7D', verdictsValue, ''];
+
+    // 11. MODELS
+    const modelsValue = config?.models
+      ? `${fmtModel(config.models.employee)} · ${fmtModel(config.models.manager)}`
+      : '—';
+    const modelsCell: Cell = ['MODELS', modelsValue, ''];
+
+    return [
+      activeCell, queueCell, tokCell, bpCell, diskCell, memCell, loadCell,
+      uptimeCell, nextCell, verdictsCell, modelsCell,
+    ];
   });
 
+  // The ticker animation depends on the track being twice as long as one
+  // copy (the `@keyframes tick-scroll` translates by -50%). Duplicating the
+  // cells matches `renderTicker()`'s ``html + html`` trick.
+  let loopedCells = $derived([...cells, ...cells]);
+
+  // ── Polling ────────────────────────────────────────────
   async function load() {
-    try {
-      events = await getAgentEvents({ limit: 20 });
-    } catch {
-      // Keep last-good events; ticker just stops advancing.
-    }
+    // Run all four fetches in parallel; tolerate individual failures so the
+    // ticker keeps showing last-good values for the cells that still respond.
+    const [tel, prs, sys, cfg] = await Promise.allSettled([
+      getTelemetrySummary(),
+      getBackpressure(),
+      getSystemStatus(),
+      getConfig(),
+    ]);
+    if (tel.status === 'fulfilled') telemetry = tel.value;
+    if (prs.status === 'fulfilled') pressure = prs.value;
+    if (sys.status === 'fulfilled') system = sys.value;
+    if (cfg.status === 'fulfilled') config = cfg.value;
   }
 
   $effect(() => {
     load();
-    const isHidden = () => typeof document !== 'undefined' && document.visibilityState === 'hidden';
+    const isHidden = () =>
+      typeof document !== 'undefined' && document.visibilityState === 'hidden';
     const t = setInterval(() => { if (!isHidden()) load(); }, 10_000);
     const onVis = () => { if (!isHidden()) load(); };
     document.addEventListener('visibilitychange', onVis);
@@ -44,11 +207,11 @@
   });
 </script>
 
-<div class="ticker" aria-label="Station activity">
+<div class="ticker" aria-label="Station KPIs">
   <span class="ticker-tag">// Live</span>
   <div class="ticker-track">
-    {#each [...segments, ...segments] as seg}
-      <span><b>{seg.actor}</b> · <em>{seg.tool}</em> {seg.target}</span>
+    {#each loopedCells as [label, value, color]}
+      <span>{label} <b class={color}>{value}</b></span>
     {/each}
   </div>
 </div>

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -313,6 +313,7 @@ export interface TelemetrySummary {
     memory_used_pct: number | null;
     uptime_secs: number | null;
   };
+  verdicts_7d: { ok: number; pr: number; x: number };
 }
 
 // --- Notifications ---

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ Exempt from `STATION_API_KEY` auth (verified in `dashboard/backend/app/main.py`)
 
 ### Dispatch telemetry
 
-`GET /api/runs/telemetry-summary` (added by the Pro Dispatch redesign) is the single endpoint backing the four telemetry cells on the home page (Active / Queue / Tokens·7D / System). It aggregates running runs + their teammates, queue counts grouped by lifecycle state, a 7-day token total with daily sparkline points, and a coarse system-health label (`NOMINAL`/`DEGR`/`CRIT`) derived from disk and memory pressure. Lives in `dashboard/backend/app/routers/runs.py`; the response shape is `TelemetrySummaryOut` in `app/schemas.py`.
+`GET /api/runs/telemetry-summary` (added by the Pro Dispatch redesign) is the single endpoint backing the four telemetry cells on the home page (Active / Queue / Tokens·7D / System) and the global LiveTicker KPI bar. It aggregates running runs + their teammates, queue counts grouped by lifecycle state, a 7-day token total with daily sparkline points, a 7-day verdict count (APPROVE/PR/REJECT bucketed as `ok`/`pr`/`x`) for the LiveTicker, and a coarse system-health label (`NOMINAL`/`DEGR`/`CRIT`) derived from disk and memory pressure. Lives in `dashboard/backend/app/routers/runs.py`; the response shape is `TelemetrySummaryOut` in `app/schemas.py`.
 
 **Response shape** (see `TelemetrySummaryOut` and the four sub-models in `app/schemas.py` for the authoritative fields and types):
 
@@ -114,6 +114,7 @@ Exempt from `STATION_API_KEY` auth (verified in `dashboard/backend/app/main.py`)
 | `queue` (`TelemetryQueue`) | `total`, `claimed`, `done`, `pending`, `other` | Counts of `QueueItem` rows grouped by lifecycle state. `claimed` aggregates `claimed`/`assigned`/`planning`/`in_progress`; `done` aggregates `completed`/`approved`; `pending` is just `pending`; `other` catches anything else (`failed`/`paused`/`cancelled`/...) so the four cells always sum to `total`. |
 | `tokens_7d` (`TelemetryTokens7d`) | `total`, `runs`, `input`, `output`, `spark[]` | Sum of `Run.tokens_total` / `tokens_input` / `tokens_output` and run count for the past 7 days. `spark` is always a length-7 array of per-day token totals (oldest → today, missing days backfilled to 0) feeding the cell sparkline. |
 | `system` (`TelemetrySystem`) | `status`, `disk_free_gb`, `memory_used_pct`, `uptime_secs` | Coarse health label derived from disk and memory pressure: `NOMINAL` is the default; `DEGR` triggers under 5G free or >70% memory used; `CRIT` triggers under 1G free or >90% memory used. Underlying numbers come from `app.services.systemd.get_system_resources`. |
+| `verdicts_7d` (`TelemetryVerdicts7d`) | `ok`, `pr`, `x` | 7-day verdict counts grouped by `Run.verdict` (case-insensitive): `APPROVE` → `ok`, `PR` → `pr`, anything else non-null (`REJECT` and any future terminal verdict) → `x`. Runs with NULL verdicts (still in flight or never reviewed) are excluded. Feeds the `VERDICTS·7D` cell in the LiveTicker. |
 
 ## Project config
 


### PR DESCRIPTION
## Summary
- Replaces the agent-event LiveTicker with the 11-cell KPI strip from the Pro Dispatch design draft. Polls `telemetry-summary`, `queue/pressure`, `system/status`, and `config` in parallel on a 10s cadence (paused on hidden tab) and renders ACTIVE / QUEUE / TOK·7D / BACKPRESSURE / DISK·FREE / MEM / LOAD / UPTIME / NEXT TRIGGER / VERDICTS·7D / MODELS with `go`/`am`/`rd` color tokens already defined in `lib/design/pro.css`.
- Adds `verdicts_7d: { ok, pr, x }` to `TelemetrySummaryOut` (single SQL round-trip on the existing endpoint, same 7-day cutoff as `tokens_7d`).
- LOAD, MEM totals, DISK total, UPTIME, and NEXT TRIGGER are pulled from the existing `/api/system/status` `resources` and `timer` blocks — no new endpoints. NEXT TRIGGER falls back to `—` when the timer doesn't expose a value (compose mode, inactive timer).

## Test plan
- [x] `cd dashboard/backend && pytest tests/test_runs.py -q` — 25 passed (existing 24 + new `test_telemetry_summary_verdicts_7d` covering case-normalization and 7-day cutoff).
- [x] `cd dashboard/frontend && npm run build` — succeeds (271 kB JS, 127 kB CSS).
- [ ] Visual check: render Dispatch page, confirm 11 cells scroll seamlessly and MEM/DISK/BACKPRESSURE light amber/red on a stressed station.

🤖 Generated with [Claude Code](https://claude.com/claude-code)