### PR TITLE
feat(auth): add OpenAI + Gemini API key auth alongside Claude OAuth

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -59,6 +59,10 @@ services:
       # across rebuilds. Used as override when the App flow isn't viable
       # (e.g. dashboard reachable only on localhost / private VM).
       STATION_GITHUB_PAT_PATH: /var/lib/claude-agent-station/github_pat.json
+      # Third-party provider API keys (OpenAI Codex, Google Gemini). Same
+      # named volume so bring-your-own-key configuration survives container
+      # rebuilds. The file is chmod 0600 by the service module.
+      STATION_PROVIDER_KEYS_PATH: /var/lib/claude-agent-station/provider_keys.json
       # Public-facing dashboard URL — used in the manifest's redirect_url and
       # setup_url so GitHub can find us after creating/installing the App.
       STATION_DASHBOARD_BASE_URL: http://localhost:8420

--- a/dashboard/backend/app/main.py
+++ b/dashboard/backend/app/main.py
@@ -32,6 +32,7 @@ from app.routers import (
     plans,
     projects,
     prompts,
+    provider_keys,
     queue,
     runs,
     system,
@@ -217,6 +218,7 @@ app.include_router(queue.router, dependencies=_auth)
 app.include_router(agent_events.router, dependencies=_auth)
 app.include_router(audit.router, dependencies=_auth)
 app.include_router(permissions.router, dependencies=_auth)
+app.include_router(provider_keys.router, dependencies=_auth)
 app.include_router(vision_router.router, dependencies=_auth)
 
 # GitHub webhook: has own auth via HMAC signature verification

--- a/dashboard/backend/app/routers/provider_keys.py
+++ b/dashboard/backend/app/routers/provider_keys.py
@@ -1,0 +1,78 @@
+"""HTTP surface for third-party provider API keys.
+
+Bring-your-own-key panels for non-Anthropic LLM providers (OpenAI Codex,
+Google Gemini). Deliberately separate from ``oauth.py`` (which is
+Anthropic-specific) and ``github_app.py`` (GitHub).
+
+Endpoints:
+  GET    /api/provider-keys           — status for every supported provider
+  PUT    /api/provider-keys/{name}    — store a raw API key (never echoed back)
+  DELETE /api/provider-keys/{name}    — remove the stored key
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, field_validator
+
+from app.schemas import ProviderKeyStatus, ProviderKeysOut
+from app.services import provider_keys as svc
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/provider-keys", tags=["provider-keys"])
+
+
+def _ensure_supported(provider: str) -> None:
+    if provider not in svc.SUPPORTED_PROVIDERS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown provider '{provider}'. Supported: {', '.join(svc.SUPPORTED_PROVIDERS)}",
+        )
+
+
+class ProviderKeyUpdate(BaseModel):
+    """Body for ``PUT /api/provider-keys/{provider}``.
+
+    The raw key is accepted on the way in but never serialised back —
+    GET responses only carry the masked form.
+    """
+
+    key: str
+
+    @field_validator("key")
+    @classmethod
+    def _strip_and_require(cls, v: str) -> str:
+        v = (v or "").strip()
+        if not v:
+            raise ValueError("key must not be empty")
+        return v
+
+
+@router.get("", response_model=ProviderKeysOut)
+async def get_keys() -> ProviderKeysOut:
+    """Return the configured/masked status for every supported provider."""
+    return ProviderKeysOut(
+        openai=ProviderKeyStatus(**svc.get_status("openai")),
+        gemini=ProviderKeyStatus(**svc.get_status("gemini")),
+    )
+
+
+@router.put("/{provider}", response_model=ProviderKeyStatus)
+async def set_key(provider: str, body: ProviderKeyUpdate) -> ProviderKeyStatus:
+    """Persist ``body.key`` for ``provider``; return the new public status."""
+    _ensure_supported(provider)
+    status = svc.write_key(provider, body.key)
+    logger.info("provider_keys: write provider=%s len=%d", provider, len(body.key))
+    return ProviderKeyStatus(**status)
+
+
+@router.delete("/{provider}", response_model=ProviderKeyStatus)
+async def clear_key(provider: str) -> ProviderKeyStatus:
+    """Remove the stored key for ``provider``. Idempotent."""
+    _ensure_supported(provider)
+    status = svc.delete_key(provider)
+    logger.info("provider_keys: delete provider=%s", provider)
+    return ProviderKeyStatus(**status)

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -254,6 +254,28 @@ class AuthStatus(BaseModel):
     expired: bool = False
 
 
+# --- Provider API keys (OpenAI / Gemini / ...) ---
+
+
+class ProviderKeyStatus(BaseModel):
+    """Public status of one provider's stored API key.
+
+    Note ``masked_key`` carries only the safe-to-display redacted form
+    (e.g. ``sk-pro…aBc1``) — the raw key is never serialised back.
+    """
+
+    configured: bool
+    masked_key: str | None = None
+    last_updated: datetime | None = None
+
+
+class ProviderKeysOut(BaseModel):
+    """Snapshot of every supported provider's status."""
+
+    openai: ProviderKeyStatus
+    gemini: ProviderKeyStatus
+
+
 # --- Webhook ---
 
 class WebhookRunEvent(BaseModel):

--- a/dashboard/backend/app/services/provider_keys.py
+++ b/dashboard/backend/app/services/provider_keys.py
@@ -1,0 +1,117 @@
+"""Storage for third-party provider API keys (OpenAI, Gemini, ...).
+
+Sibling of ``app.services.github_pat`` — simple bring-your-own-key
+persistence for non-Anthropic LLM providers used by specialised
+teammate roles. No OAuth flow, no refresh dance, just a JSON file.
+
+On-disk discipline mirrors the GitHub PAT path:
+  - JSON file, atomic write, mode 0600
+  - Path is env-driven via ``STATION_PROVIDER_KEYS_PATH``
+  - Lives under the station-data volume in compose so keys survive
+    container rebuilds.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Set of providers we recognise. The router validates against this so
+# adding e.g. Mistral later is a one-line change here + a UI panel.
+SUPPORTED_PROVIDERS: tuple[str, ...] = ("openai", "gemini")
+
+
+def _path() -> Path:
+    """Resolve the storage path lazily so tests can monkeypatch the env var."""
+    return Path(
+        os.environ.get(
+            "STATION_PROVIDER_KEYS_PATH",
+            str(Path.home() / ".claude-agent-station" / "provider_keys.json"),
+        )
+    )
+
+
+def _read_all() -> dict[str, dict]:
+    """Load the full {provider: {key, last_updated}} map; {} on missing/corrupt."""
+    p = _path()
+    if not p.exists():
+        return {}
+    try:
+        with p.open() as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Failed to read provider keys file: %s", e)
+        return {}
+
+
+def _write_all(data: dict[str, dict]) -> None:
+    """Atomic write with mode 0600 from creation."""
+    p = _path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(".tmp")
+    fd = os.open(tmp, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as f:
+        json.dump(data, f)
+    tmp.replace(p)
+
+
+def mask_key(provider: str, key: str) -> str:
+    """Return a masked representation safe to send back over HTTP.
+
+    Provider-specific prefixes get more context preserved (so the user
+    can sanity-check which key is wired) while still hiding the body.
+    """
+    if not key:
+        return ""
+    if provider == "openai" and key.startswith("sk-") and len(key) > 12:
+        return f"{key[:6]}…{key[-4:]}"
+    if provider == "gemini" and key.startswith("AIza") and len(key) > 12:
+        return f"{key[:6]}…{key[-4:]}"
+    if len(key) > 12:
+        return f"{key[:4]}…{key[-4:]}"
+    # Too short to safely reveal anything — fully redact.
+    return "*" * len(key)
+
+
+def read_key(provider: str) -> str | None:
+    """Return the raw stored key for ``provider``, or None."""
+    return _read_all().get(provider, {}).get("key") or None
+
+
+def get_status(provider: str) -> dict:
+    """Return ``{configured, masked_key, last_updated}`` for the UI."""
+    entry = _read_all().get(provider) or {}
+    key = entry.get("key")
+    if not key:
+        return {"configured": False, "masked_key": None, "last_updated": None}
+    return {
+        "configured": True,
+        "masked_key": mask_key(provider, key),
+        "last_updated": entry.get("last_updated"),
+    }
+
+
+def write_key(provider: str, key: str) -> dict:
+    """Persist ``key`` for ``provider``; return its new public status."""
+    data = _read_all()
+    data[provider] = {
+        "key": key,
+        "last_updated": datetime.now(UTC).isoformat(),
+    }
+    _write_all(data)
+    return get_status(provider)
+
+
+def delete_key(provider: str) -> dict:
+    """Remove the stored key for ``provider``. Idempotent."""
+    data = _read_all()
+    if provider in data:
+        data.pop(provider, None)
+        _write_all(data)
+    return get_status(provider)

--- a/dashboard/backend/tests/test_provider_keys.py
+++ b/dashboard/backend/tests/test_provider_keys.py
@@ -1,0 +1,108 @@
+"""Endpoint tests for the provider-keys router (OpenAI / Gemini API keys)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import Base, engine
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db, monkeypatch, tmp_path):
+    """A clean ASGI client with the keys file pointed at a tmp path."""
+    monkeypatch.setenv("STATION_PROVIDER_KEYS_PATH", str(tmp_path / "provider_keys.json"))
+
+    from app.main import app
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_get_returns_unconfigured_when_empty(client):
+    resp = await client.get("/api/provider-keys")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["openai"]["configured"] is False
+    assert body["openai"]["masked_key"] is None
+    assert body["openai"]["last_updated"] is None
+    assert body["gemini"]["configured"] is False
+    assert body["gemini"]["masked_key"] is None
+
+
+@pytest.mark.asyncio
+async def test_put_openai_persists_and_redacts_in_response(client, tmp_path):
+    raw = "sk-test123ABCDEFG"
+    resp = await client.put("/api/provider-keys/openai", json={"key": raw})
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["configured"] is True
+    assert body["last_updated"]  # ISO timestamp populated
+    # Masked form: sk- prefix preserved, suffix preserved, middle hidden,
+    # and crucially the raw key must not appear anywhere in the response.
+    masked = body["masked_key"]
+    assert masked is not None
+    assert raw not in masked
+    assert masked.startswith("sk-tes")
+    assert masked.endswith("DEFG")
+    assert "…" in masked
+
+    # And a follow-up GET reflects the same state.
+    snap = (await client.get("/api/provider-keys")).json()
+    assert snap["openai"]["configured"] is True
+    assert snap["openai"]["masked_key"] == masked
+    assert snap["gemini"]["configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_put_gemini_uses_aiza_aware_mask(client):
+    raw = "AIzaSyD-EXAMPLE-KEY-WXYZ"
+    resp = await client.put("/api/provider-keys/gemini", json={"key": raw})
+    assert resp.status_code == 200
+    masked = resp.json()["masked_key"]
+    assert masked.startswith("AIzaSy")
+    assert masked.endswith("WXYZ")
+    assert raw not in masked
+
+
+@pytest.mark.asyncio
+async def test_delete_clears_configured_state(client):
+    await client.put("/api/provider-keys/openai", json={"key": "sk-test123ABCDEFG"})
+    resp = await client.delete("/api/provider-keys/openai")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["configured"] is False
+    assert body["masked_key"] is None
+    assert body["last_updated"] is None
+
+    # GET confirms.
+    snap = (await client.get("/api/provider-keys")).json()
+    assert snap["openai"]["configured"] is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_rejected_with_400(client):
+    put_resp = await client.put("/api/provider-keys/anthropic", json={"key": "sk-x"})
+    assert put_resp.status_code == 400
+
+    del_resp = await client.delete("/api/provider-keys/mistral")
+    assert del_resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_empty_key_rejected(client):
+    resp = await client.put("/api/provider-keys/openai", json={"key": "   "})
+    # Pydantic validator fires before the route body, so we get a 422.
+    assert resp.status_code in (400, 422)

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   AgentEvent, Notification,
   TelemetrySummary,
   VisionRead, VisionDoc, VisionCommitOut, VisionChatSession, VisionProposals,
+  ProviderKeyStatus, ProviderKeysOut, ProviderName,
 } from './types';
 
 import { toastError } from './toast.svelte';
@@ -337,6 +338,19 @@ export const setGitHubPAT = (token: string) =>
 
 export const clearGitHubPAT = () =>
   requestWithToast<{ status: string }>('/api/github/app/pat', { method: 'DELETE' });
+
+// --- Provider API keys (OpenAI / Gemini) ---
+
+export const getProviderKeys = () =>
+  request<ProviderKeysOut>('/api/provider-keys');
+
+export const setProviderKey = (provider: ProviderName, key: string) =>
+  requestWithToast<ProviderKeyStatus>(`/api/provider-keys/${provider}`, {
+    method: 'PUT', body: JSON.stringify({ key }),
+  });
+
+export const clearProviderKey = (provider: ProviderName) =>
+  requestWithToast<ProviderKeyStatus>(`/api/provider-keys/${provider}`, { method: 'DELETE' });
 
 export interface GitHubRepo {
   full_name: string;

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -3,6 +3,20 @@
 // Mirrors backend Pydantic schemas
 // ============================================
 
+// --- Provider API keys (OpenAI / Gemini) ---
+export interface ProviderKeyStatus {
+  configured: boolean;
+  masked_key: string | null;
+  last_updated: string | null;
+}
+
+export interface ProviderKeysOut {
+  openai: ProviderKeyStatus;
+  gemini: ProviderKeyStatus;
+}
+
+export type ProviderName = 'openai' | 'gemini';
+
 // --- Enums ---
 export type AgentMode = 'full' | 'analyze' | 'plan' | 'plan_only' | 'triage' | 'review' | 'fix';
 export type RunStatus = 'started' | 'employee_done' | 'reviewing' | 'finished' | 'verdict' | 'plan_reviewing' | 'plan_review_done' | 'awaiting_plan_review' | 'plan_approved' | 'plan_rejected' | string;

--- a/dashboard/frontend/src/pages/SettingsPage.svelte
+++ b/dashboard/frontend/src/pages/SettingsPage.svelte
@@ -4,10 +4,11 @@
            getGitHubAppStatus, startGitHubAppManifest, disconnectGitHubApp,
            setGitHubPAT, clearGitHubPAT,
            refreshOAuthToken,
+           getProviderKeys, setProviderKey, clearProviderKey,
            getAutonomyAudit, getAutonomySummary,
            type AutonomyAuditRow, type AutonomySummary,
            type GitHubAppStatus } from '../lib/api';
-  import type { PromptInfo, SystemStatus, AuthStatus } from '../lib/types';
+  import type { PromptInfo, SystemStatus, AuthStatus, ProviderKeysOut, ProviderName } from '../lib/types';
   import { toastSuccess, toastError } from '../lib/toast.svelte';
   import { navigate } from '../lib/router.svelte';
   import { appearance, setTheme, setAnimationsEnabled } from '../lib/appearance.svelte';
@@ -148,6 +149,51 @@
     oauthState = '';
     oauthCode = '';
     oauthError = '';
+  }
+
+  // ── Provider API keys (OpenAI / Gemini) ─────────────
+  let providerKeys = $state<ProviderKeysOut | null>(null);
+  let openaiInput = $state('');
+  let geminiInput = $state('');
+  let savingProvider = $state<ProviderName | null>(null);
+
+  async function loadProviderKeys() {
+    try {
+      providerKeys = await getProviderKeys();
+    } catch (e: any) {
+      // Don't toast — auth tab activation shouldn't bark on transient errors
+      console.warn('Failed to load provider keys:', e.message);
+    }
+  }
+
+  async function saveProvider(provider: ProviderName, value: string) {
+    const trimmed = value.trim();
+    if (!trimmed || savingProvider) return;
+    savingProvider = provider;
+    try {
+      const status = await setProviderKey(provider, trimmed);
+      if (providerKeys) providerKeys = { ...providerKeys, [provider]: status };
+      if (provider === 'openai') openaiInput = ''; else geminiInput = '';
+      toastSuccess(`${provider === 'openai' ? 'OpenAI' : 'Gemini'} key saved`);
+    } catch (e: any) {
+      toastError(e.message);
+    } finally {
+      savingProvider = null;
+    }
+  }
+
+  async function handleClearProvider(provider: ProviderName) {
+    const label = provider === 'openai' ? 'OpenAI' : 'Gemini';
+    if (!confirm(`Clear the saved ${label} API key? The teammate role using it will fall back to the default Anthropic-only path.`)) {
+      return;
+    }
+    try {
+      const status = await clearProviderKey(provider);
+      if (providerKeys) providerKeys = { ...providerKeys, [provider]: status };
+      toastSuccess(`${label} key cleared`);
+    } catch (e: any) {
+      toastError(e.message);
+    }
   }
 
   async function handleOAuthRefresh() {
@@ -318,6 +364,15 @@
     if (activeTab !== 'audit') return;
     runFilter; toolFilter; decisionFilter; typeFilter;
     loadAudit();
+  });
+
+  // Lazy-load provider keys when the Auth tab activates. The Claude OAuth
+  // status is fetched eagerly in loadAll() because it also feeds the
+  // sidebar's "off / OAuth" badge; the BYO-key panels only matter inside
+  // the tab so we wait until it's open.
+  $effect(() => {
+    if (activeTab !== 'auth') return;
+    if (providerKeys === null) loadProviderKeys();
   });
 
   // Donut helpers (pure SVG)
@@ -690,6 +745,96 @@
                 <div class="val" style="color: var(--abort)">{oauthError}</div>
               </div>
             {/if}
+          </div>
+
+          <!-- OpenAI Codex API key ─────────────────────── -->
+          <div class="card-block">
+            <h3>OpenAI Codex</h3>
+            <div class="key-row">
+              <span class="lbl">Status</span>
+              <div class="val">
+                {#if providerKeys?.openai.configured}
+                  <span class="status-tag go">● CONFIGURED</span>
+                  <span class="desc">{providerKeys.openai.masked_key}{providerKeys.openai.last_updated ? ` · updated ${timeAgo(providerKeys.openai.last_updated)}` : ''}</span>
+                {:else}
+                  <span class="status-tag off">NOT SET</span>
+                  <span class="desc">paste an API key — used by the OpenAI Codex teammate role</span>
+                {/if}
+              </div>
+            </div>
+            <div class="key-row">
+              <label for="openai-key-input" class="lbl">Key</label>
+              <div class="val" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
+                <input
+                  id="openai-key-input"
+                  type="password"
+                  bind:value={openaiInput}
+                  placeholder="sk-…"
+                  data-testid="openai-key-input"
+                  autocomplete="off"
+                />
+                <button
+                  class="opbtn primary"
+                  type="button"
+                  onclick={() => saveProvider('openai', openaiInput)}
+                  disabled={savingProvider === 'openai' || !openaiInput.trim()}
+                  data-testid="openai-key-save-btn"
+                >{savingProvider === 'openai' ? 'Saving…' : 'Save'}</button>
+                {#if providerKeys?.openai.configured}
+                  <button
+                    class="opbtn danger"
+                    type="button"
+                    onclick={() => handleClearProvider('openai')}
+                    data-testid="openai-key-clear-btn"
+                  >Clear</button>
+                {/if}
+              </div>
+            </div>
+          </div>
+
+          <!-- Google Gemini API key ────────────────────── -->
+          <div class="card-block">
+            <h3>Google Gemini</h3>
+            <div class="key-row">
+              <span class="lbl">Status</span>
+              <div class="val">
+                {#if providerKeys?.gemini.configured}
+                  <span class="status-tag go">● CONFIGURED</span>
+                  <span class="desc">{providerKeys.gemini.masked_key}{providerKeys.gemini.last_updated ? ` · updated ${timeAgo(providerKeys.gemini.last_updated)}` : ''}</span>
+                {:else}
+                  <span class="status-tag off">NOT SET</span>
+                  <span class="desc">paste an API key — used by the Gemini analyst role</span>
+                {/if}
+              </div>
+            </div>
+            <div class="key-row">
+              <label for="gemini-key-input" class="lbl">Key</label>
+              <div class="val" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
+                <input
+                  id="gemini-key-input"
+                  type="password"
+                  bind:value={geminiInput}
+                  placeholder="AIza…"
+                  data-testid="gemini-key-input"
+                  autocomplete="off"
+                />
+                <button
+                  class="opbtn primary"
+                  type="button"
+                  onclick={() => saveProvider('gemini', geminiInput)}
+                  disabled={savingProvider === 'gemini' || !geminiInput.trim()}
+                  data-testid="gemini-key-save-btn"
+                >{savingProvider === 'gemini' ? 'Saving…' : 'Save'}</button>
+                {#if providerKeys?.gemini.configured}
+                  <button
+                    class="opbtn danger"
+                    type="button"
+                    onclick={() => handleClearProvider('gemini')}
+                    data-testid="gemini-key-clear-btn"
+                  >Clear</button>
+                {/if}
+              </div>
+            </div>
           </div>
         </section>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Every variable below is prefixed with `STATION_`. They can also be placed in a `
 | `STATION_GITHUB_WEBHOOK_SECRET` | _(none)_ | Secret for verifying GitHub webhook HMAC-SHA256 signatures. |
 | `STATION_ALLOWED_ORIGINS` | `["http://localhost:5173", "http://localhost:4173", "http://127.0.0.1:5173", "http://127.0.0.1:4173"]` | CORS allowed origins. Override with a JSON list or comma-separated string. Extend this when the frontend is served from a different origin than the API. |
 | `STATION_LAUNCHER_TOKEN` | _(none — required for compose)_ | Shared secret authenticating dashboard → agent-launcher calls. **`compose.yml` fails fast if unset.** Generate with `openssl rand -hex 32` and put it in `.env` at the repo root. Bare-metal (systemd) deployments only need this when the dashboard and agent run on different hosts. |
+| `STATION_PROVIDER_KEYS_PATH` | `~/.claude-agent-station/provider_keys.json` | Path to the bring-your-own-key store for third-party LLM providers (OpenAI Codex, Google Gemini). Compose mounts this on `station-data` so saved keys survive container rebuilds. The file is chmod 0600 from creation; raw keys are never returned over the API. |
 
 ## Models
 
@@ -101,6 +102,16 @@ Authentication settings are listed in the env-vars table above. Additional behav
 - `STATION_GITHUB_WEBHOOK_SECRET` verifies HMAC-SHA256 signatures on incoming GitHub webhooks.
 
 Exempt from `STATION_API_KEY` auth (verified in `dashboard/backend/app/main.py`): the health router, the internal agent webhook router, the WebSocket log-streaming router (`logs.ws_router` at `/api/logs/ws`, which has its own inline WebSocket auth), the GitHub webhook router, and GitHub App lifecycle endpoints.
+
+### Provider auth (Settings → Auth)
+
+The Auth tab in Settings shows three provider panels:
+
+- **Claude API** — OAuth flow via `/api/oauth/*`; tokens persist to `STATION_CREDENTIALS_PATH` and are auto-refreshed by the dashboard.
+- **OpenAI Codex** — bring-your-own-key. Paste an `sk-…` API key; used by the OpenAI Codex teammate role.
+- **Google Gemini** — bring-your-own-key. Paste an `AIza…` API key; used by the Gemini analyst role.
+
+The OpenAI and Gemini keys are stored as JSON at `STATION_PROVIDER_KEYS_PATH` (chmod 0600), routed through `/api/provider-keys` (`GET` returns masked status, `PUT /{provider}` saves a key, `DELETE /{provider}` clears it). Raw keys are never returned in responses — only a redacted form like `sk-pro…aBc1`.
 
 ### Dispatch telemetry
 


### PR DESCRIPTION
## Summary

- New Settings → Auth tab now shows three panels in order: **Claude API** (existing OAuth, untouched) · **OpenAI Codex** · **Google Gemini**.
- Adds `/api/provider-keys` router (`GET` / `PUT {provider}` / `DELETE {provider}`). GETs return only masked forms (`sk-pro…aBc1`); raw keys are never echoed back.
- Storage is a JSON file at `STATION_PROVIDER_KEYS_PATH` (default `~/.claude-agent-station/provider_keys.json`, compose mounts it on `station-data` so it survives rebuilds). Atomic write, chmod 0600 from creation.
- No new dependencies, no DB schema changes, Claude OAuth panel left untouched.

Mirrors the existing GitHub PAT pattern (`app.services.github_pat` ↔ `app.services.provider_keys`, `routers/github_app.py` ↔ `routers/provider_keys.py`) so the on-disk discipline and env-driven path are identical.

## Test plan

- [x] `pytest dashboard/backend/tests/test_provider_keys.py -q` — 6 cases pass (empty GET, OpenAI PUT redacts, Gemini PUT redacts, DELETE clears, unknown provider 400, empty key 422).
- [x] `npm run build` succeeds in `dashboard/frontend`.
- [ ] Manual: visit `/settings/auth`, confirm three panels render in order and that saving + clearing a key round-trips without a full reload.
- [ ] Manual: confirm `provider_keys.json` lands at `/var/lib/claude-agent-station/` inside the dashboard container after a save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)