### PR TITLE
Help page with contextual ? drawer and run-lifecycle flowchart

### DIFF
--- a/dashboard/frontend/package-lock.json
+++ b/dashboard/frontend/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@types/dompurify": "^3.0.5",
         "dompurify": "^3.4.0",
-        "marked": "^17.0.4"
+        "marked": "^17.0.4",
+        "mermaid": "^11.14.0"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -22,6 +23,62 @@
         "vite": "^6.4.2",
         "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
@@ -465,6 +522,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
+      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -513,6 +587,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -1285,6 +1368,259 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1308,11 +1644,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.5",
@@ -1480,6 +1832,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.3.tgz",
+      "integrity": "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.18.1"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1490,11 +1870,534 @@
         "node": ">=6"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.3.tgz",
+      "integrity": "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1523,6 +2426,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/detect-libc": {
@@ -1691,6 +2603,43 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1711,6 +2660,36 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -1720,6 +2699,30 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/langium": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.3.tgz",
+      "integrity": "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng==",
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.3",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.31.1",
@@ -1989,6 +2992,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2003,6 +3012,47 @@
       "version": "17.0.4",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.4.tgz",
       "integrity": "sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -2046,6 +3096,18 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -2122,6 +3184,22 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
@@ -2150,6 +3228,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "license": "Unlicense"
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -2196,6 +3280,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2225,6 +3333,12 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stylis": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
+      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
     "node_modules/svelte": {
@@ -2287,7 +3401,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
       "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2320,6 +3433,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2332,6 +3454,19 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -2518,6 +3653,55 @@
           "optional": false
         }
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@types/dompurify": "^3.0.5",
     "dompurify": "^3.4.0",
-    "marked": "^17.0.4"
+    "marked": "^17.0.4",
+    "mermaid": "^11.14.0"
   }
 }

--- a/dashboard/frontend/src/App.svelte
+++ b/dashboard/frontend/src/App.svelte
@@ -29,6 +29,8 @@
   import ProjectsPage from './pages/ProjectsPage.svelte';
   import ProjectDetail from './pages/ProjectDetail.svelte';
   import SettingsPage from './pages/SettingsPage.svelte';
+  import HelpPage from './pages/HelpPage.svelte';
+  import HelpDrawer from './components/help/HelpDrawer.svelte';
 
   // --- App State ---
   let triggering = $state(false);
@@ -125,6 +127,8 @@
       <ProjectDetail projectId={route.param ?? ''} />
     {:else if route.page === 'settings'}
       <SettingsPage tab={route.param} />
+    {:else if route.page === 'help'}
+      <HelpPage />
     {:else}
       <div class="text-secondary text-center py-20">Page not found</div>
     {/if}
@@ -134,4 +138,5 @@
   <ShortcutsOverlay show={showShortcuts} onClose={() => (showShortcuts = false)} />
   <AuthPrompt />
   <PermissionTray />
+  <HelpDrawer />
 </div>

--- a/dashboard/frontend/src/components/help/HelpDrawer.svelte
+++ b/dashboard/frontend/src/components/help/HelpDrawer.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+  import SlidePanel from '../overlays/SlidePanel.svelte';
+  import HelpSection from './HelpSection.svelte';
+  import { helpDrawer, closeHelpDrawer } from '../../lib/help-drawer.svelte';
+  import { navigate } from '../../lib/router.svelte';
+
+  const TITLES: Record<string, string> = {
+    'run-lifecycle': 'Run lifecycle',
+    'roles': 'The three roles',
+    'verdicts': 'Verdicts',
+    'eligibility': 'Issue eligibility',
+    'throttling': 'Plan-tier throttling',
+    'plans-worktrees': 'Plans & worktrees',
+    'pages-tour': 'Page-by-page tour',
+    'troubleshooting': 'Troubleshooting',
+  };
+
+  const open = $derived(helpDrawer.openSection !== null);
+  const sectionId = $derived(helpDrawer.openSection ?? '');
+  const title = $derived(TITLES[sectionId] ?? 'Help');
+
+  function viewFullPage() {
+    const target = sectionId;
+    closeHelpDrawer();
+    navigate(`/help#${target}`);
+  }
+</script>
+
+<SlidePanel {open} onClose={closeHelpDrawer} {title} width="w-[480px]">
+  {#if sectionId}
+    <HelpSection id={sectionId} />
+    <div class="full-link">
+      <button type="button" onclick={viewFullPage}>View full Help page →</button>
+    </div>
+  {/if}
+</SlidePanel>
+
+<style>
+  .full-link {
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+  }
+  .full-link button {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--color-link, #06b6d4);
+    font-size: 0.9rem;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+</style>

--- a/dashboard/frontend/src/components/help/HelpDrawer.svelte
+++ b/dashboard/frontend/src/components/help/HelpDrawer.svelte
@@ -3,26 +3,22 @@
   import HelpSection from './HelpSection.svelte';
   import { helpDrawer, closeHelpDrawer } from '../../lib/help-drawer.svelte';
   import { navigate } from '../../lib/router.svelte';
-
-  const TITLES: Record<string, string> = {
-    'run-lifecycle': 'Run lifecycle',
-    'roles': 'The three roles',
-    'verdicts': 'Verdicts',
-    'eligibility': 'Issue eligibility',
-    'throttling': 'Plan-tier throttling',
-    'plans-worktrees': 'Plans & worktrees',
-    'pages-tour': 'Page-by-page tour',
-    'troubleshooting': 'Troubleshooting',
-  };
+  import { HELP_SECTION_TITLES } from '../../lib/help-sections';
 
   const open = $derived(helpDrawer.openSection !== null);
   const sectionId = $derived(helpDrawer.openSection ?? '');
-  const title = $derived(TITLES[sectionId] ?? 'Help');
+  const title = $derived(HELP_SECTION_TITLES[sectionId] ?? 'Help');
 
   function viewFullPage() {
     const target = sectionId;
     closeHelpDrawer();
     navigate(`/help#${target}`);
+    // navigate() updates URL+route but does not fire `hashchange` (it uses
+    // pushState). When already on /help, HelpPage stays mounted and only
+    // re-scrolls in response to hashchange — so dispatch one explicitly.
+    if (typeof window !== 'undefined') {
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+    }
   }
 </script>
 

--- a/dashboard/frontend/src/components/help/HelpHint.svelte
+++ b/dashboard/frontend/src/components/help/HelpHint.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { openHelpDrawer } from '../../lib/help-drawer.svelte';
+
+  let {
+    section,
+    label = 'Help',
+  }: {
+    section: string;
+    label?: string;
+  } = $props();
+</script>
+
+<button
+  type="button"
+  class="help-hint"
+  aria-label="Help: {label}"
+  onclick={(e) => { e.stopPropagation(); openHelpDrawer(section); }}
+>?</button>
+
+<style>
+  .help-hint {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    margin-left: 0.35rem;
+    padding: 0;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--color-text-dim);
+    font-size: 9px;
+    line-height: 1;
+    font-weight: 700;
+    cursor: pointer;
+    vertical-align: middle;
+    transition: color 120ms, border-color 120ms;
+  }
+  .help-hint:hover,
+  .help-hint:focus-visible {
+    color: var(--color-text);
+    border-color: var(--color-link, currentColor);
+    outline: none;
+  }
+</style>

--- a/dashboard/frontend/src/components/help/HelpSection.svelte
+++ b/dashboard/frontend/src/components/help/HelpSection.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import { splitHelpSection } from '../../lib/help-content';
+  import MarkdownRenderer from '../data-display/MarkdownRenderer.svelte';
+  import MermaidDiagram from './MermaidDiagram.svelte';
+
+  let { id }: { id: string } = $props();
+
+  // Eagerly-imported raw markdown for all help sections.
+  const sources = import.meta.glob('../../content/help/*.md', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }) as Record<string, string>;
+
+  function lookup(sectionId: string): string | null {
+    const key = Object.keys(sources).find((p) => p.endsWith(`/${sectionId}.md`));
+    return key ? sources[key] : null;
+  }
+
+  const raw = $derived(lookup(id));
+  const parts = $derived(raw ? splitHelpSection(raw) : null);
+
+  // Split the how-it-works body around fenced ```mermaid blocks so we can
+  // render each block with <MermaidDiagram> and the surrounding prose with
+  // <MarkdownRenderer>.
+  type Chunk = { kind: 'md' | 'mermaid'; content: string };
+
+  function chunkBody(body: string): Chunk[] {
+    const re = /```mermaid\n([\s\S]*?)```/g;
+    const out: Chunk[] = [];
+    let lastIdx = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(body)) !== null) {
+      if (m.index > lastIdx) out.push({ kind: 'md', content: body.slice(lastIdx, m.index) });
+      out.push({ kind: 'mermaid', content: m[1] });
+      lastIdx = re.lastIndex;
+    }
+    if (lastIdx < body.length) out.push({ kind: 'md', content: body.slice(lastIdx) });
+    return out;
+  }
+
+  const howItWorksChunks = $derived(parts ? chunkBody(parts.howItWorks) : []);
+</script>
+
+{#if parts}
+  {#if parts.tldr}
+    <div class="tldr">
+      <span class="tldr-label">TL;DR</span>
+      <span class="tldr-text">{parts.tldr}</span>
+    </div>
+  {/if}
+
+  {#each howItWorksChunks as chunk}
+    {#if chunk.kind === 'md'}
+      <MarkdownRenderer content={chunk.content} />
+    {:else}
+      <MermaidDiagram source={chunk.content} />
+    {/if}
+  {/each}
+
+  {#if parts.underTheHood}
+    <details class="uth">
+      <summary>Under the hood</summary>
+      <MarkdownRenderer content={parts.underTheHood} />
+    </details>
+  {/if}
+{:else}
+  <p class="missing">Help section <code>{id}</code> not found.</p>
+{/if}
+
+<style>
+  .tldr {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    padding: 0.6rem 0.85rem;
+    margin: 0 0 0.75rem 0;
+    border-left: 3px solid var(--color-link, #06b6d4);
+    background: var(--color-surface-1, rgba(6, 182, 212, 0.06));
+    border-radius: 0 0.375rem 0.375rem 0;
+    font-size: 0.9rem;
+  }
+  .tldr-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: var(--color-link, #06b6d4);
+    text-transform: uppercase;
+  }
+  .tldr-text { color: var(--color-text); }
+
+  .uth {
+    margin-top: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.85rem;
+  }
+  .uth > summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--color-text-dim);
+    font-size: 0.85rem;
+    user-select: none;
+  }
+  .uth[open] > summary { margin-bottom: 0.5rem; }
+
+  .missing { color: var(--color-text-dim); font-style: italic; }
+</style>

--- a/dashboard/frontend/src/components/help/MermaidDiagram.svelte
+++ b/dashboard/frontend/src/components/help/MermaidDiagram.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { openHelpDrawer } from '../../lib/help-drawer.svelte';
+
+  let { source }: { source: string } = $props();
+
+  let host: HTMLDivElement;
+  let error = $state<string | null>(null);
+
+  // Mermaid `click <node> call openHelpDrawer("section")` directives need a
+  // global function reference. Expose it on `window` once.
+  if (typeof window !== 'undefined') {
+    (window as unknown as { openHelpDrawer?: (s: string) => void }).openHelpDrawer = openHelpDrawer;
+  }
+
+  onMount(async () => {
+    try {
+      const mermaid = (await import('mermaid')).default;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose',
+        themeVariables: {
+          primaryColor: 'var(--color-surface-1, #1f2937)',
+          primaryTextColor: 'var(--color-text, #e5e7eb)',
+          primaryBorderColor: 'var(--color-border, #374151)',
+          lineColor: 'var(--color-border, #6b7280)',
+          fontFamily: 'inherit',
+        },
+      });
+      const id = `mermaid-${Math.random().toString(36).slice(2)}`;
+      const { svg, bindFunctions } = await mermaid.render(id, source);
+      host.innerHTML = svg;
+      bindFunctions?.(host);
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    }
+  });
+</script>
+
+<div class="mermaid-host" bind:this={host}>
+  {#if error}
+    <pre class="mermaid-fallback">{source}</pre>
+    <p class="mermaid-error" role="alert">Diagram failed to render: {error}</p>
+  {/if}
+</div>
+
+<style>
+  .mermaid-host { display: flex; justify-content: center; margin: 1rem 0; }
+  .mermaid-host :global(svg) { max-width: 100%; height: auto; cursor: default; }
+  .mermaid-fallback {
+    background: var(--color-pre-bg);
+    border: 1px solid var(--color-pre-border);
+    border-radius: 0.5em;
+    padding: 0.75em 1em;
+    overflow-x: auto;
+    font-size: 0.85em;
+  }
+  .mermaid-error { color: var(--abort, #dc2626); font-size: 0.85em; margin-top: 0.5em; }
+</style>

--- a/dashboard/frontend/src/components/help/MermaidDiagram.svelte
+++ b/dashboard/frontend/src/components/help/MermaidDiagram.svelte
@@ -9,32 +9,47 @@
 
   // Mermaid `click <node> call openHelpDrawer("section")` directives need a
   // global function reference. Expose it on `window` once.
+  //
+  // Trust boundary: this is safe ONLY because Mermaid `source` is bundled
+  // markdown loaded via `import.meta.glob`, never user-provided at runtime.
+  // If a future caller passes user-controlled markdown to this component,
+  // `securityLevel: 'loose'` lets the diagram source invoke any window
+  // callback by name — at which point this exposure must be reworked.
   if (typeof window !== 'undefined') {
     (window as unknown as { openHelpDrawer?: (s: string) => void }).openHelpDrawer = openHelpDrawer;
   }
 
-  onMount(async () => {
-    try {
-      const mermaid = (await import('mermaid')).default;
-      mermaid.initialize({
-        startOnLoad: false,
-        theme: 'base',
-        securityLevel: 'loose',
-        themeVariables: {
-          primaryColor: 'var(--color-surface-1, #1f2937)',
-          primaryTextColor: 'var(--color-text, #e5e7eb)',
-          primaryBorderColor: 'var(--color-border, #374151)',
-          lineColor: 'var(--color-border, #6b7280)',
-          fontFamily: 'inherit',
-        },
-      });
-      const id = `mermaid-${Math.random().toString(36).slice(2)}`;
-      const { svg, bindFunctions } = await mermaid.render(id, source);
-      host.innerHTML = svg;
-      bindFunctions?.(host);
-    } catch (e) {
-      error = e instanceof Error ? e.message : String(e);
-    }
+  onMount(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const mermaid = (await import('mermaid')).default;
+        if (cancelled) return;
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: 'base',
+          securityLevel: 'loose',
+          themeVariables: {
+            primaryColor: 'var(--color-surface-1, #1f2937)',
+            primaryTextColor: 'var(--color-text, #e5e7eb)',
+            primaryBorderColor: 'var(--color-border, #374151)',
+            lineColor: 'var(--color-border, #6b7280)',
+            fontFamily: 'inherit',
+          },
+        });
+        const id = `mermaid-${Math.random().toString(36).slice(2)}`;
+        const { svg, bindFunctions } = await mermaid.render(id, source);
+        if (cancelled || !host) return;
+        host.innerHTML = svg;
+        bindFunctions?.(host);
+      } catch (e) {
+        if (cancelled) return;
+        error = e instanceof Error ? e.message : String(e);
+      }
+    })();
+
+    return () => { cancelled = true; };
   });
 </script>
 

--- a/dashboard/frontend/src/components/layout/TopNav.svelte
+++ b/dashboard/frontend/src/components/layout/TopNav.svelte
@@ -37,6 +37,7 @@
     { label: 'Queue', page: 'queue', path: '/queue' },
     { label: 'Projects', page: 'projects', path: '/projects' },
     { label: 'Settings', page: 'settings', path: '/settings' },
+    { label: 'Help', page: 'help', path: '/help' },
   ] as const;
 
   function isActive(page: string): boolean {

--- a/dashboard/frontend/src/content/help/eligibility.md
+++ b/dashboard/frontend/src/content/help/eligibility.md
@@ -1,0 +1,21 @@
+> **TL;DR** — Issues are skipped if the repo isn't enabled, the issue is closed, or it carries a skip label.
+
+The lead picks GitHub issues that pass these filters:
+
+- The repository is enabled in the dashboard.
+- The issue is open.
+- The issue is **not** labelled with any of the skip set:
+  - `autonomous-agent/in-progress` — already being worked on.
+  - `autonomous-agent/needs-help` — flagged for human follow-up.
+  - `NO AI` — explicit human-only marker.
+  - `backlog` — explicitly out of scope. **The agent will never pick up a backlog issue.**
+  - `wontfix` — closed by intent, even if open.
+  - `vision-suggested` — produced by the vision pipeline, not yet promoted.
+
+Eligible issues are then decomposed into tasks and routed across the three teammates by specialty.
+
+<!-- under-the-hood -->
+
+- The skip set is the `SKIP_LABELS` constant in `agent/station_orchestrator.py`.
+- The "enabled repo" flag is the `enabled` column on the `projects` table.
+- A skipped issue is recorded in the run log with the reason it was skipped.

--- a/dashboard/frontend/src/content/help/pages-tour.md
+++ b/dashboard/frontend/src/content/help/pages-tour.md
@@ -1,0 +1,16 @@
+> **TL;DR** — What each dashboard page is for, and when to open it.
+
+- **Dispatch** (`/`) — the home page. Trigger a run, see live token burn, current throttle state.
+- **Mission** (`/mission-control`) — live activity feed across all projects.
+- **Fleet** (`/agent-teams`) — visual canvas of the lead and the three teammates for the current run.
+- **Queue** (`/queue`) — the work queue: items waiting, in flight, completed.
+- **Projects** (`/projects`) — list of repos. Click in to enable/disable, configure, see project-level history.
+- **Project Detail** — drill-down for one project: vision, runs, settings.
+- **Run Detail** — drill-down for one run: DAG, logs, plan, verdict, diff.
+- **Settings** (`/settings`) — auth (OAuth, GitHub App), models, prompts, audit, appearance.
+- **Help** (`/help`) — this page.
+
+<!-- under-the-hood -->
+
+- All pages are Svelte 5 components under `dashboard/frontend/src/pages/`.
+- Cross-page navigation uses the History API via `lib/router.svelte.ts`. Number keys 1–6 map to the first six tabs.

--- a/dashboard/frontend/src/content/help/plans-worktrees.md
+++ b/dashboard/frontend/src/content/help/plans-worktrees.md
@@ -1,0 +1,14 @@
+> **TL;DR** — Each teammate writes a plan first, gets it approved by the lead, then works in its own git worktree.
+
+Two protections keep concurrent teammates from clobbering each other:
+
+**Plans.** Every teammate's first deliverable is a short implementation plan. The lead reviews each plan before the teammate is allowed to start writing code. If two plans conflict — e.g. both teammates want to modify the same file — the lead asks the affected teammate to revise.
+
+**Worktrees.** Each teammate runs in its own git worktree at `<workspaces_dir>/<repo>-<role>` (e.g. `/home/claude-agent/workspaces/my-repo-backend`). File edits from one teammate are invisible to the others until the changes are committed and merged. Worktrees are created per run and torn down when the run ends.
+
+<!-- under-the-hood -->
+
+- Workspaces directory is configurable; default `/home/claude-agent/workspaces/`.
+- Worktree paths follow `<workspaces_dir>/<repo-name>-<role>`. Roles are `backend`, `frontend`, `qa`.
+- The lead's plan-review behaviour is encoded in the orchestrator and the lead prompt.
+- Plans are stored in the `plans` table and surfaced on Run Detail.

--- a/dashboard/frontend/src/content/help/roles.md
+++ b/dashboard/frontend/src/content/help/roles.md
@@ -1,0 +1,19 @@
+> **TL;DR** — Lead coordinates, three teammates implement, manager reviews. Each runs a different Claude model.
+
+The station's work is split across three roles. Each role has a different responsibility, prompt, and model:
+
+| Role | Model | Responsibility |
+|---|---|---|
+| **Lead** | Sonnet 4.6 | Picks eligible issues, decomposes them into tasks, spawns the three teammates, reviews their plans, and watches the run until done. |
+| **Teammates** (×3) | Opus 4.7 | Three role-specialists per run — `backend`, `frontend`, `qa`. Each works in its own git worktree on the tasks routed to its specialty. |
+| **Manager** | Sonnet 4.6 | A separate review pass after teammates finish. Reads the work and issues a verdict (APPROVE / PR / REJECT / SKIP). |
+
+The lead and teammates run inside a single Claude Agent SDK Agent Teams session. The manager runs as a follow-up phase.
+
+<!-- under-the-hood -->
+
+- Agent definitions: `agent/agents/issue-worker.md` (teammate worker definition).
+- Prompts: `agent/prompts/manager.md`, role overlays in `agent/prompts/roles/`.
+- Orchestrator that spawns lead + teammates: `agent/station_orchestrator.py`.
+- Manager invocation: `agent/scripts/run-manager.sh`.
+- Per-role model overrides live in the agent config DB (`/var/lib/claude-agent-station/station.db`).

--- a/dashboard/frontend/src/content/help/run-lifecycle.md
+++ b/dashboard/frontend/src/content/help/run-lifecycle.md
@@ -1,0 +1,75 @@
+> **TL;DR** — A run takes a GitHub issue from picked-up to merged or PR'd in seven phases.
+
+A "run" is one full execution of the agent: triggered by a timer or a webhook, ending with a verdict that decides what happens to the work. Click any node in the diagram below to jump into the relevant section.
+
+```mermaid
+flowchart TD
+    Trigger["systemd timer<br/>or webhook"]
+    Throttle{"Plan tier<br/>throttled?"}
+    Halt["Run skipped<br/>no work started"]
+    Eligible["Lead fetches<br/>eligible issues"]
+    NoneEligible{"Any eligible<br/>issues?"}
+    Decompose["Lead decomposes issues<br/>into tasks (by specialty)"]
+    Spawn["Spawn 3 teammates:<br/>backend / frontend / qa<br/>(each in own worktree)"]
+    Plans["Each teammate writes<br/>an implementation plan"]
+    Review{"Lead reviews plans<br/>conflicts?"}
+    Implement["Teammates implement,<br/>test, commit locally"]
+    Manager["Manager reviews<br/>all completed work"]
+    Verdict{"Verdict"}
+    Approve["APPROVE<br/>push & merge to dev"]
+    PR["PR<br/>open against dev"]
+    Reject["REJECT<br/>discard branch"]
+    Skip["SKIP<br/>no eligible work"]
+
+    Trigger --> Throttle
+    Throttle -->|yes| Halt
+    Throttle -->|no| Eligible
+    Eligible --> NoneEligible
+    NoneEligible -->|no| Skip
+    NoneEligible -->|yes| Decompose
+    Decompose --> Spawn
+    Spawn --> Plans
+    Plans --> Review
+    Review -->|conflict| Plans
+    Review -->|approved| Implement
+    Implement --> Manager
+    Manager --> Verdict
+    Verdict --> Approve
+    Verdict --> PR
+    Verdict --> Reject
+    Verdict --> Skip
+
+    click Throttle call openHelpDrawer("throttling")
+    click Eligible call openHelpDrawer("eligibility")
+    click NoneEligible call openHelpDrawer("eligibility")
+    click Spawn call openHelpDrawer("roles")
+    click Plans call openHelpDrawer("plans-worktrees")
+    click Review call openHelpDrawer("plans-worktrees")
+    click Manager call openHelpDrawer("roles")
+    click Verdict call openHelpDrawer("verdicts")
+    click Approve call openHelpDrawer("verdicts")
+    click PR call openHelpDrawer("verdicts")
+    click Reject call openHelpDrawer("verdicts")
+    click Skip call openHelpDrawer("verdicts")
+```
+
+### The seven phases
+
+1. **Trigger.** A systemd timer fires, or a GitHub webhook arrives. The run-manager script starts.
+2. **Throttle gate.** If weekly Claude usage has exceeded the configured threshold, the run is skipped before any work starts.
+3. **Issue selection.** The lead agent fetches open issues from enabled repos and filters out anything labelled `backlog`, `wontfix`, `NO AI`, or already in progress.
+4. **Decomposition & spawn.** The lead breaks eligible issues into tasks and spawns three teammates — `backend`, `frontend`, `qa` — each in its own git worktree so they cannot collide.
+5. **Plan review.** Every teammate writes an implementation plan first. The lead reviews the plans together and rejects any that conflict; teammates revise and resubmit.
+6. **Implement.** Approved teammates write code, run tests, and commit locally.
+7. **Manager review & verdict.** Once all teammates finish, a separate manager pass reviews the work and issues one of four verdicts: `APPROVE`, `PR`, `REJECT`, or `SKIP`. The verdict decides what happens to the branch.
+
+<!-- under-the-hood -->
+
+### Where the code lives
+
+- **Trigger:** systemd timer (`agent/systemd/`), GitHub webhook intake at `dashboard/backend/app/routers/github_webhook.py`.
+- **Throttle decision:** `agent/scripts/detect_plan_usage.py` and the `plan_usage_history` table.
+- **Orchestrator:** `agent/station_orchestrator.py` runs the lead + teammates in a single Claude Agent SDK Agent Teams session.
+- **Manager review:** invoked by `agent/scripts/run-manager.sh` after teammates finish; uses the prompt at `agent/prompts/manager.md`.
+- **Skip-label filter:** the `SKIP_LABELS` constant in `agent/station_orchestrator.py`.
+- **Verdict enforcement:** `run-manager.sh` reads the manager's verdict and performs the corresponding git action (push, PR via `gh`, branch delete).

--- a/dashboard/frontend/src/content/help/throttling.md
+++ b/dashboard/frontend/src/content/help/throttling.md
@@ -1,0 +1,17 @@
+> **TL;DR** — When weekly Claude usage gets too high, runs are paused before they start so the agent doesn't run out of budget mid-task.
+
+Claude Agent Station is bounded by the Claude plan tier you've configured. The station tracks weekly token consumption and refuses to start a new run when usage crosses the threshold — better to pause cleanly than to fail mid-task with no budget to recover.
+
+There are two protections:
+
+1. **Plan-tier throttle.** Weekly usage (overall and per-model) is checked before each run. If the budget is too low, `run-manager.sh` short-circuits before launching any agent.
+2. **Per-model fallback.** Every Claude invocation passes a `--fallback-model` to the SDK so primary-model errors don't kill the run. Opus 4.7 falls back to Sonnet 4.6, Sonnet 4.6 falls back to Haiku 4.5.
+
+The Command Center surfaces current usage and the active throttle state.
+
+<!-- under-the-hood -->
+
+- Usage history: `plan_usage_history` table.
+- Detection: `agent/scripts/detect_plan_usage.py`.
+- Throttle decision API: served from the dashboard backend; consumed by Command Center.
+- Throttling is independent of the fallback chain — both can be active.

--- a/dashboard/frontend/src/content/help/troubleshooting.md
+++ b/dashboard/frontend/src/content/help/troubleshooting.md
@@ -1,0 +1,28 @@
+> **TL;DR** — Common "why isn't it doing what I expected?" answers.
+
+**No run started after the timer fired.**
+Check the throttle state on Dispatch. If weekly usage is high, runs are deliberately paused. See Plan-tier throttling.
+
+**My issue was skipped.**
+Check the issue's labels. Anything in the skip set (`backlog`, `wontfix`, `NO AI`, …) blocks it. Also check the project is enabled. See Issue eligibility.
+
+**The verdict was REJECT.**
+The manager judged the work incomplete or wrong. Open Run Detail and read `verdict_detail` for the reasoning.
+
+**The verdict was SKIP and nothing happened.**
+Usually means there was no eligible work — common after the queue empties. Not a failure.
+
+**A teammate looks stuck.**
+Open Run Detail and check the audit log. Long-running tool calls (build, test) are normal; an unmoving log for many minutes likely means a hung subprocess.
+
+**Where are the logs?**
+Agent logs live at `/var/log/claude-agent/`. The dashboard surfaces them via WebSocket on Run Detail.
+
+**How do I pause everything?**
+The "Stop" button in the top nav engages a global pause when there are active runs.
+
+<!-- under-the-hood -->
+
+- Audit log: the `audit_log` table records every tool call. Retention defaults to 30 days.
+- Run control: pause/resume/stop is implemented in `agent/run_control.py` and exposed via the dashboard API.
+- Live logs: WebSocket served by `dashboard/backend/app/routers/logs.py`.

--- a/dashboard/frontend/src/content/help/verdicts.md
+++ b/dashboard/frontend/src/content/help/verdicts.md
@@ -1,0 +1,18 @@
+> **TL;DR** — Every run ends in one of four verdicts. The verdict decides what happens to the branch.
+
+After the manager reviews the teammates' work, the run terminates with exactly one verdict:
+
+| Verdict | What happens to the work |
+|---|---|
+| **APPROVE** | Branch is pushed and merged into `dev`. |
+| **PR** | A pull request is opened against `dev` for human review. |
+| **REJECT** | Branch is discarded. The run is marked failed. |
+| **SKIP** | Nothing to merge — usually because there was no eligible work for this project. The queue item is marked completed (not failed). |
+
+You'll see verdicts on the Mission Control feed, on Run Detail, and in the run lists across the dashboard.
+
+<!-- under-the-hood -->
+
+- Verdicts are written to the `verdict` column on the `runs` table by `run-manager.sh`.
+- The audit log (`audit_log` table) records each tool call the manager makes during review.
+- The reasoning behind a verdict is stored in `verdict_detail` and surfaced on Run Detail.

--- a/dashboard/frontend/src/lib/help-content.test.ts
+++ b/dashboard/frontend/src/lib/help-content.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { splitHelpSection } from './help-content';
+
+describe('splitHelpSection', () => {
+  it('extracts TL;DR from a leading blockquote', () => {
+    const md = '> **TL;DR** — A run takes an issue from picked-up to merged.\n\nBody text here.';
+    const result = splitHelpSection(md);
+    expect(result.tldr).toBe('A run takes an issue from picked-up to merged.');
+    expect(result.howItWorks.trim()).toBe('Body text here.');
+    expect(result.underTheHood).toBeNull();
+  });
+
+  it('splits how-it-works and under-the-hood on the marker', () => {
+    const md = [
+      '> **TL;DR** — Lead, teammates, manager.',
+      '',
+      'How it works body.',
+      '',
+      '<!-- under-the-hood -->',
+      '',
+      'Deep technical bits.',
+    ].join('\n');
+    const result = splitHelpSection(md);
+    expect(result.tldr).toBe('Lead, teammates, manager.');
+    expect(result.howItWorks.trim()).toBe('How it works body.');
+    expect(result.underTheHood?.trim()).toBe('Deep technical bits.');
+  });
+
+  it('treats missing TL;DR as null', () => {
+    const md = 'Just plain prose, no blockquote.';
+    const result = splitHelpSection(md);
+    expect(result.tldr).toBeNull();
+    expect(result.howItWorks.trim()).toBe('Just plain prose, no blockquote.');
+    expect(result.underTheHood).toBeNull();
+  });
+
+  it('strips a "TL;DR —" prefix variant', () => {
+    const md = '> TL;DR — short summary.\n\nBody.';
+    const result = splitHelpSection(md);
+    expect(result.tldr).toBe('short summary.');
+  });
+
+  it('keeps fenced mermaid blocks intact in the body', () => {
+    const md = [
+      '> **TL;DR** — flow.',
+      '',
+      'Intro.',
+      '',
+      '```mermaid',
+      'flowchart TD',
+      '  A --> B',
+      '```',
+      '',
+      'Outro.',
+    ].join('\n');
+    const result = splitHelpSection(md);
+    expect(result.howItWorks).toContain('```mermaid');
+    expect(result.howItWorks).toContain('flowchart TD');
+  });
+});

--- a/dashboard/frontend/src/lib/help-content.ts
+++ b/dashboard/frontend/src/lib/help-content.ts
@@ -1,0 +1,39 @@
+// ============================================
+// Help Content — parse a section markdown file into TL;DR, how-it-works,
+// and under-the-hood parts. Pure functions, fully unit-tested.
+// ============================================
+
+export interface HelpSectionParts {
+  tldr: string | null;
+  howItWorks: string;
+  underTheHood: string | null;
+}
+
+const UNDER_THE_HOOD_MARKER = '<!-- under-the-hood -->';
+
+// Matches a leading blockquote line that opens with `**TL;DR**` or `TL;DR`.
+// Captures the prose after the em-dash (or hyphen) separator.
+const TLDR_RE = /^>\s*(?:\*\*TL;DR\*\*|TL;DR)\s*[—-]\s*(.+?)\s*$/m;
+
+export function splitHelpSection(source: string): HelpSectionParts {
+  const markerIdx = source.indexOf(UNDER_THE_HOOD_MARKER);
+  let body: string;
+  let underTheHood: string | null;
+
+  if (markerIdx === -1) {
+    body = source;
+    underTheHood = null;
+  } else {
+    body = source.slice(0, markerIdx);
+    underTheHood = source.slice(markerIdx + UNDER_THE_HOOD_MARKER.length);
+  }
+
+  const tldrMatch = body.match(TLDR_RE);
+  const tldr = tldrMatch ? tldrMatch[1].trim() : null;
+
+  const howItWorks = tldrMatch
+    ? body.replace(tldrMatch[0], '').replace(/^\s*\n+/, '')
+    : body;
+
+  return { tldr, howItWorks, underTheHood };
+}

--- a/dashboard/frontend/src/lib/help-drawer.svelte.ts
+++ b/dashboard/frontend/src/lib/help-drawer.svelte.ts
@@ -1,0 +1,13 @@
+// ============================================
+// Help Drawer — global state for the contextual ? drawer
+// ============================================
+
+export const helpDrawer = $state<{ openSection: string | null }>({ openSection: null });
+
+export function openHelpDrawer(section: string): void {
+  helpDrawer.openSection = section;
+}
+
+export function closeHelpDrawer(): void {
+  helpDrawer.openSection = null;
+}

--- a/dashboard/frontend/src/lib/help-sections.ts
+++ b/dashboard/frontend/src/lib/help-sections.ts
@@ -1,0 +1,25 @@
+// ============================================
+// Help Sections — single source of truth for the eight help-page section
+// ids and their human-readable titles. Used by both HelpPage (full /help
+// route) and HelpDrawer (contextual ? drawer) to keep them in lockstep.
+// ============================================
+
+export interface HelpSection {
+  id: string;
+  title: string;
+}
+
+export const HELP_SECTIONS: readonly HelpSection[] = [
+  { id: 'run-lifecycle', title: 'Run lifecycle' },
+  { id: 'roles', title: 'The three roles' },
+  { id: 'verdicts', title: 'Verdicts' },
+  { id: 'eligibility', title: 'Issue eligibility' },
+  { id: 'throttling', title: 'Plan-tier throttling' },
+  { id: 'plans-worktrees', title: 'Plans & worktrees' },
+  { id: 'pages-tour', title: 'Page-by-page tour' },
+  { id: 'troubleshooting', title: 'Troubleshooting' },
+] as const;
+
+export const HELP_SECTION_TITLES: Record<string, string> = Object.fromEntries(
+  HELP_SECTIONS.map((s) => [s.id, s.title]),
+);

--- a/dashboard/frontend/src/lib/router.svelte.ts
+++ b/dashboard/frontend/src/lib/router.svelte.ts
@@ -11,7 +11,8 @@ export type Page =
   | 'queue-detail'
   | 'projects'
   | 'project-detail'
-  | 'settings';
+  | 'settings'
+  | 'help';
 
 export interface Route {
   page: Page;
@@ -53,6 +54,7 @@ function parsePath(): Route {
     queue: 'queue',
     projects: 'projects',
     settings: 'settings',
+    help: 'help',
   };
 
   if (routeMap[raw]) return { page: routeMap[raw], param: null };
@@ -134,6 +136,7 @@ export function getPageTitle(page: Page): string {
     'projects': 'Projects',
     'project-detail': 'Project',
     'settings': 'Settings',
+    'help': 'Help',
   };
   return titles[page] ?? 'Claude Station';
 }

--- a/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
+++ b/dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
@@ -12,6 +12,7 @@
   import { formatTokens, timeAgo } from '../lib/format';
   import { flap } from '../lib/design/flap';
   import type { CoordinatorTask, CoordinatorMessage, ActiveEmployee } from '../lib/types';
+  import HelpHint from '../components/help/HelpHint.svelte';
 
   let tasks = $state<CoordinatorTask[]>([]);
   let messages = $state<CoordinatorMessage[]>([]);
@@ -422,7 +423,7 @@
           <!-- LEAD -->
           <div class="cell lead {leadStatusKind}">
             <div class="head">
-              <span class="role"><span class="role-name">Team Lead</span> <span class="br">·</span> <span class="role-tag">Commander</span></span>
+              <span class="role"><span class="role-name">Team Lead</span> <span class="br">·</span> <span class="role-tag">Commander</span> <HelpHint section="roles" label="The three roles" /></span>
               <div class="head-right">
                 <span class="aut assist">ASSIST</span>
                 <span class="head-meta">claude-sonnet-4-6</span>

--- a/dashboard/frontend/src/pages/HelpPage.svelte
+++ b/dashboard/frontend/src/pages/HelpPage.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import HelpSection from '../components/help/HelpSection.svelte';
+  import { onMount } from 'svelte';
+
+  const SECTIONS: Array<{ id: string; title: string }> = [
+    { id: 'run-lifecycle', title: 'Run lifecycle' },
+    { id: 'roles', title: 'The three roles' },
+    { id: 'verdicts', title: 'Verdicts' },
+    { id: 'eligibility', title: 'Issue eligibility' },
+    { id: 'throttling', title: 'Plan-tier throttling' },
+    { id: 'plans-worktrees', title: 'Plans & worktrees' },
+    { id: 'pages-tour', title: 'Page-by-page tour' },
+    { id: 'troubleshooting', title: 'Troubleshooting' },
+  ];
+
+  onMount(() => {
+    if (window.location.hash) {
+      const id = window.location.hash.slice(1);
+      requestAnimationFrame(() => {
+        document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    }
+  });
+</script>
+
+<div class="help-layout">
+  <aside class="help-sidebar">
+    <h2>Help</h2>
+    <ul>
+      {#each SECTIONS as s}
+        <li><a href="#{s.id}">{s.title}</a></li>
+      {/each}
+    </ul>
+  </aside>
+
+  <main class="help-main">
+    <h1>Claude Agent Station — Help</h1>
+    <p class="lede">How the station works, layered for end users, operators, and contributors.</p>
+
+    {#each SECTIONS as s}
+      <section id={s.id} class="help-section-block">
+        <h2>{s.title}</h2>
+        <HelpSection id={s.id} />
+      </section>
+    {/each}
+  </main>
+</div>
+
+<style>
+  .help-layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 2rem;
+    padding: 1.5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+  .help-sidebar {
+    position: sticky;
+    top: 1rem;
+    align-self: start;
+    border-right: 1px solid var(--color-border);
+    padding-right: 1rem;
+  }
+  .help-sidebar h2 {
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-text-dim);
+    margin-bottom: 0.75rem;
+  }
+  .help-sidebar ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.25rem; }
+  .help-sidebar a {
+    color: var(--color-text-dim);
+    text-decoration: none;
+    font-size: 0.9rem;
+    padding: 0.25rem 0;
+    display: block;
+  }
+  .help-sidebar a:hover { color: var(--color-text); }
+
+  .help-main h1 { font-size: 1.5rem; margin: 0 0 0.25rem 0; }
+  .lede { color: var(--color-text-dim); margin-bottom: 1.5rem; }
+  .help-section-block { margin-top: 2.5rem; scroll-margin-top: 1rem; }
+  .help-section-block > h2 {
+    font-size: 1.2rem;
+    margin: 0 0 0.75rem 0;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  @media (max-width: 720px) {
+    .help-layout { grid-template-columns: 1fr; }
+    .help-sidebar { position: static; border-right: none; border-bottom: 1px solid var(--color-border); padding-right: 0; padding-bottom: 0.75rem; }
+    .help-sidebar ul { flex-direction: row; flex-wrap: wrap; gap: 0.5rem 1rem; }
+  }
+</style>

--- a/dashboard/frontend/src/pages/HelpPage.svelte
+++ b/dashboard/frontend/src/pages/HelpPage.svelte
@@ -1,25 +1,25 @@
 <script lang="ts">
   import HelpSection from '../components/help/HelpSection.svelte';
+  import { HELP_SECTIONS } from '../lib/help-sections';
   import { onMount } from 'svelte';
 
-  const SECTIONS: Array<{ id: string; title: string }> = [
-    { id: 'run-lifecycle', title: 'Run lifecycle' },
-    { id: 'roles', title: 'The three roles' },
-    { id: 'verdicts', title: 'Verdicts' },
-    { id: 'eligibility', title: 'Issue eligibility' },
-    { id: 'throttling', title: 'Plan-tier throttling' },
-    { id: 'plans-worktrees', title: 'Plans & worktrees' },
-    { id: 'pages-tour', title: 'Page-by-page tour' },
-    { id: 'troubleshooting', title: 'Troubleshooting' },
-  ];
+  function scrollToHash() {
+    if (!window.location.hash) return;
+    const id = window.location.hash.slice(1);
+    const el = document.getElementById(id);
+    if (!el) return;
+    const reduce = window.matchMedia?.('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' });
+  }
 
   onMount(() => {
-    if (window.location.hash) {
-      const id = window.location.hash.slice(1);
-      requestAnimationFrame(() => {
-        document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-      });
-    }
+    // Initial scroll: defer one frame so all <section> elements exist in the DOM.
+    requestAnimationFrame(scrollToHash);
+    // Re-scroll when the URL hash changes after mount (e.g. from sidebar click,
+    // browser back/forward, or HelpDrawer's "View full Help page" link when
+    // we are already on /help).
+    window.addEventListener('hashchange', scrollToHash);
+    return () => window.removeEventListener('hashchange', scrollToHash);
   });
 </script>
 
@@ -27,7 +27,7 @@
   <aside class="help-sidebar">
     <h2>Help</h2>
     <ul>
-      {#each SECTIONS as s}
+      {#each HELP_SECTIONS as s}
         <li><a href="#{s.id}">{s.title}</a></li>
       {/each}
     </ul>
@@ -37,7 +37,7 @@
     <h1>Claude Agent Station — Help</h1>
     <p class="lede">How the station works, layered for end users, operators, and contributors.</p>
 
-    {#each SECTIONS as s}
+    {#each HELP_SECTIONS as s}
       <section id={s.id} class="help-section-block">
         <h2>{s.title}</h2>
         <HelpSection id={s.id} />

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -337,7 +337,9 @@
             {:else}
               <span class="status done">{run.status}</span>
             {/if}
-            <HelpHint section="verdicts" label="Verdicts" />
+            {#if run.verdict}
+              <HelpHint section="verdicts" label="Verdicts" />
+            {/if}
             {#if run.mode}
               {@const m = formatRunMode(run.mode)}
               <span class="mode {run.mode === 'full' ? 'full' : run.mode === 'plan_only' || run.mode === 'plan' ? 'plan' : (run.mode as string) === 'vision-bootstrap' ? 'vision' : ''}">

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -27,6 +27,7 @@
   } from '../lib/types';
   import { navigate } from '../lib/router.svelte';
   import LogViewer from '../components/data-display/LogViewer.svelte';
+  import HelpHint from '../components/help/HelpHint.svelte';
 
   let { runId }: { runId: string } = $props();
 
@@ -336,6 +337,7 @@
             {:else}
               <span class="status done">{run.status}</span>
             {/if}
+            <HelpHint section="verdicts" label="Verdicts" />
             {#if run.mode}
               {@const m = formatRunMode(run.mode)}
               <span class="mode {run.mode === 'full' ? 'full' : run.mode === 'plan_only' || run.mode === 'plan' ? 'plan' : (run.mode as string) === 'vision-bootstrap' ? 'vision' : ''}">
@@ -396,6 +398,7 @@
           <button class="rd-action danger" onclick={onRejectPlan} disabled={rejecting}>
             {rejecting ? '…' : '✗ Reject plan'}
           </button>
+          <HelpHint section="plans-worktrees" label="Plans & worktrees" />
         {/if}
       </div>
     </div>

--- a/docs/superpowers/plans/2026-05-10-help-page.md
+++ b/docs/superpowers/plans/2026-05-10-help-page.md
@@ -1,0 +1,1488 @@
+# Help Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an in-dashboard `/help` page with a contextual `?` drawer so the operator can understand the station from inside the dashboard, with a Mermaid flowchart of the run lifecycle.
+
+**Architecture:** A single `/help` route renders 8 sections sourced from one markdown file each. A reusable `<HelpHint>` icon, placed next to conceptually-loaded UI elements, opens a side drawer that renders the same `<HelpSection>` component scoped to one section. The Mermaid flowchart's nodes are clickable and route into the drawer.
+
+**Tech Stack:** Svelte 5, TypeScript, TailwindCSS, Vite, Vitest, `marked` + `dompurify` (already installed), `mermaid` (new).
+
+**Spec:** `docs/superpowers/specs/2026-05-10-help-page-design.md`
+
+---
+
+## File Structure
+
+**New files (frontend):**
+
+- `dashboard/frontend/src/lib/help-drawer.svelte.ts` — drawer state store
+- `dashboard/frontend/src/lib/help-content.ts` — markdown loader + section splitter (pure logic, fully unit-testable)
+- `dashboard/frontend/src/lib/help-content.test.ts` — unit tests for the splitter
+- `dashboard/frontend/src/components/help/MermaidDiagram.svelte` — lazy-loaded Mermaid wrapper
+- `dashboard/frontend/src/components/help/HelpSection.svelte` — renders one section: TL;DR + how-it-works + collapsible under-the-hood
+- `dashboard/frontend/src/components/help/HelpHint.svelte` — the `?` icon
+- `dashboard/frontend/src/components/help/HelpDrawer.svelte` — wraps `SlidePanel` and renders one `<HelpSection>`
+- `dashboard/frontend/src/pages/HelpPage.svelte` — `/help` route, sticky sidebar + 8 sections
+- `dashboard/frontend/src/content/help/run-lifecycle.md`
+- `dashboard/frontend/src/content/help/roles.md`
+- `dashboard/frontend/src/content/help/verdicts.md`
+- `dashboard/frontend/src/content/help/eligibility.md`
+- `dashboard/frontend/src/content/help/throttling.md`
+- `dashboard/frontend/src/content/help/plans-worktrees.md`
+- `dashboard/frontend/src/content/help/pages-tour.md`
+- `dashboard/frontend/src/content/help/troubleshooting.md`
+
+**Modified files:**
+
+- `dashboard/frontend/package.json` — add `mermaid`
+- `dashboard/frontend/src/lib/router.svelte.ts` — add `'help'` to `Page`, route `/help`
+- `dashboard/frontend/src/App.svelte` — register `HelpPage`, mount `<HelpDrawer>` once
+- `dashboard/frontend/src/components/layout/TopNav.svelte` — append `Help` to `navItems`
+- `dashboard/frontend/src/pages/RunDetail.svelte` — add `<HelpHint>` next to verdict pills and plan-review controls
+- `dashboard/frontend/src/pages/AgentTeamsCanvas.svelte` — add `<HelpHint>` next to Team Lead label and the three teammate role labels
+- `dashboard/frontend/src/pages/CommandCenter.svelte` — add `<HelpHint>` next to throttled / skipped indicators (locations discovered in Task 16)
+
+**Reused (no changes):**
+
+- `dashboard/frontend/src/components/overlays/SlidePanel.svelte` — already provides backdrop, Esc handling, slide-in
+- `dashboard/frontend/src/components/data-display/MarkdownRenderer.svelte` — already wraps marked + DOMPurify
+
+---
+
+## Conventions
+
+- Svelte 5 runes (`$state`, `$derived`, `$props`, `$effect`).
+- TypeScript on every component (`<script lang="ts">`).
+- TailwindCSS utilities; CSS variables (`var(--color-text)` etc.) for theming where they already exist.
+- Tests use Vitest (`.test.ts`).
+- Each task ends with a single commit.
+- Branch: a single feature branch `feature/help-page` for the whole plan; PR opened in Task 17 against `dev` (project rule: PRs target `dev`, never `main`).
+
+---
+
+## Task 1: Create the feature branch
+
+**Files:** none
+
+- [ ] **Step 1: Branch off `dev`**
+
+```bash
+git checkout dev
+git pull --ff-only
+git checkout -b feature/help-page
+```
+
+- [ ] **Step 2: Verify branch**
+
+```bash
+git status
+git branch --show-current
+```
+
+Expected: clean working tree, branch is `feature/help-page`.
+
+---
+
+## Task 2: Drawer state store
+
+**Files:**
+- Create: `dashboard/frontend/src/lib/help-drawer.svelte.ts`
+- Test: deferred to Task 3 (paired with content splitter)
+
+- [ ] **Step 1: Create the store**
+
+```ts
+// dashboard/frontend/src/lib/help-drawer.svelte.ts
+// ============================================
+// Help Drawer — global state for the contextual ? drawer
+// ============================================
+
+export const helpDrawer = $state<{ openSection: string | null }>({ openSection: null });
+
+export function openHelpDrawer(section: string): void {
+  helpDrawer.openSection = section;
+}
+
+export function closeHelpDrawer(): void {
+  helpDrawer.openSection = null;
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: no new errors from this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/frontend/src/lib/help-drawer.svelte.ts
+git commit -m "feat(help): drawer state store"
+```
+
+---
+
+## Task 3: Markdown content splitter (TDD)
+
+The splitter takes a markdown string and produces three parts: TL;DR (the leading blockquote), how-it-works (body before `<!-- under-the-hood -->`), and under-the-hood (body after the marker, optional).
+
+**Files:**
+- Create: `dashboard/frontend/src/lib/help-content.ts`
+- Test: `dashboard/frontend/src/lib/help-content.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+// dashboard/frontend/src/lib/help-content.test.ts
+import { describe, it, expect } from 'vitest';
+import { splitHelpSection } from './help-content';
+
+describe('splitHelpSection', () => {
+  it('extracts TL;DR from a leading blockquote', () => {
+    const md = '> **TL;DR** — A run takes an issue from picked-up to merged.\n\nBody text here.';
+    const result = splitHelpSection(md);
+    expect(result.tldr).toBe('A run takes an issue from picked-up to merged.');
+    expect(result.howItWorks.trim()).toBe('Body text here.');
+    expect(result.underTheHood).toBeNull();
+  });
+
+  it('splits how-it-works and under-the-hood on the marker', () => {
+    const md = [
+      '> **TL;DR** — Lead, teammates, manager.',
+      '',
+      'How it works body.',
+      '',
+      '<!-- under-the-hood -->',
+      '',
+      'Deep technical bits.',
+    ].join('\n');
+    const result = splitHelpSection(md);
+    expect(result.tldr).toBe('Lead, teammates, manager.');
+    expect(result.howItWorks.trim()).toBe('How it works body.');
+    expect(result.underTheHood?.trim()).toBe('Deep technical bits.');
+  });
+
+  it('treats missing TL;DR as null', () => {
+    const md = 'Just plain prose, no blockquote.';
+    const result = splitHelpSection(md);
+    expect(result.tldr).toBeNull();
+    expect(result.howItWorks.trim()).toBe('Just plain prose, no blockquote.');
+    expect(result.underTheHood).toBeNull();
+  });
+
+  it('strips a "TL;DR —" prefix variant', () => {
+    const md = '> TL;DR — short summary.\n\nBody.';
+    const result = splitHelpSection(md);
+    expect(result.tldr).toBe('short summary.');
+  });
+
+  it('keeps fenced mermaid blocks intact in the body', () => {
+    const md = [
+      '> **TL;DR** — flow.',
+      '',
+      'Intro.',
+      '',
+      '```mermaid',
+      'flowchart TD',
+      '  A --> B',
+      '```',
+      '',
+      'Outro.',
+    ].join('\n');
+    const result = splitHelpSection(md);
+    expect(result.howItWorks).toContain('```mermaid');
+    expect(result.howItWorks).toContain('flowchart TD');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd dashboard/frontend && npx vitest run src/lib/help-content.test.ts
+```
+
+Expected: FAIL — module `./help-content` not found.
+
+- [ ] **Step 3: Implement the splitter**
+
+```ts
+// dashboard/frontend/src/lib/help-content.ts
+// ============================================
+// Help Content — parse a section markdown file into TL;DR, how-it-works,
+// and under-the-hood parts. Pure functions, fully unit-tested.
+// ============================================
+
+export interface HelpSectionParts {
+  tldr: string | null;
+  howItWorks: string;
+  underTheHood: string | null;
+}
+
+const UNDER_THE_HOOD_MARKER = '<!-- under-the-hood -->';
+
+// Matches a leading blockquote line that opens with `**TL;DR**` or `TL;DR`.
+// Captures the prose after the em-dash separator.
+const TLDR_RE = /^>\s*(?:\*\*TL;DR\*\*|TL;DR)\s*[—-]\s*(.+?)\s*$/m;
+
+export function splitHelpSection(source: string): HelpSectionParts {
+  const markerIdx = source.indexOf(UNDER_THE_HOOD_MARKER);
+  let body: string;
+  let underTheHood: string | null;
+
+  if (markerIdx === -1) {
+    body = source;
+    underTheHood = null;
+  } else {
+    body = source.slice(0, markerIdx);
+    underTheHood = source.slice(markerIdx + UNDER_THE_HOOD_MARKER.length);
+  }
+
+  const tldrMatch = body.match(TLDR_RE);
+  const tldr = tldrMatch ? tldrMatch[1].trim() : null;
+
+  // Strip the matched TL;DR line from the body so it isn't duplicated.
+  const howItWorks = tldrMatch
+    ? body.replace(tldrMatch[0], '').replace(/^\s*\n+/, '')
+    : body;
+
+  return { tldr, howItWorks, underTheHood };
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+cd dashboard/frontend && npx vitest run src/lib/help-content.test.ts
+```
+
+Expected: PASS — 5 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/lib/help-content.ts dashboard/frontend/src/lib/help-content.test.ts
+git commit -m "feat(help): markdown section splitter with tests"
+```
+
+---
+
+## Task 4: Install Mermaid
+
+**Files:**
+- Modify: `dashboard/frontend/package.json`
+
+- [ ] **Step 1: Install Mermaid**
+
+```bash
+cd dashboard/frontend && npm install mermaid
+```
+
+Expected: `mermaid` added to `dependencies`. `package-lock.json` updated.
+
+- [ ] **Step 2: Verify install**
+
+```bash
+cd dashboard/frontend && node -e "console.log(require('mermaid/package.json').version)"
+```
+
+Expected: a version string (≥10.x).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/frontend/package.json dashboard/frontend/package-lock.json
+git commit -m "chore(deps): add mermaid for help-page flowchart"
+```
+
+---
+
+## Task 5: MermaidDiagram component
+
+A Svelte component that lazy-imports `mermaid`, renders a passed source string to SVG on mount, and exposes a callback registry for `click` directives in the Mermaid source.
+
+**Files:**
+- Create: `dashboard/frontend/src/components/help/MermaidDiagram.svelte`
+
+- [ ] **Step 1: Create the component directory and file**
+
+```bash
+mkdir -p dashboard/frontend/src/components/help
+```
+
+```svelte
+<!-- dashboard/frontend/src/components/help/MermaidDiagram.svelte -->
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { openHelpDrawer } from '../../lib/help-drawer.svelte';
+
+  let { source }: { source: string } = $props();
+
+  let host: HTMLDivElement;
+  let error = $state<string | null>(null);
+
+  // Mermaid `click <node> call openHelpDrawer("section")` directives need a
+  // global function reference. Expose it on `window` once.
+  if (typeof window !== 'undefined') {
+    (window as unknown as { openHelpDrawer?: (s: string) => void }).openHelpDrawer = openHelpDrawer;
+  }
+
+  onMount(async () => {
+    try {
+      const mermaid = (await import('mermaid')).default;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        securityLevel: 'loose', // required for `click ... call ...` directives
+        themeVariables: {
+          primaryColor: 'var(--color-surface-1, #1f2937)',
+          primaryTextColor: 'var(--color-text, #e5e7eb)',
+          primaryBorderColor: 'var(--color-border, #374151)',
+          lineColor: 'var(--color-border, #6b7280)',
+          fontFamily: 'inherit',
+        },
+      });
+      const id = `mermaid-${Math.random().toString(36).slice(2)}`;
+      const { svg, bindFunctions } = await mermaid.render(id, source);
+      host.innerHTML = svg;
+      bindFunctions?.(host);
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    }
+  });
+</script>
+
+<div class="mermaid-host" bind:this={host}>
+  {#if error}
+    <pre class="mermaid-fallback">{source}</pre>
+    <p class="mermaid-error" role="alert">Diagram failed to render: {error}</p>
+  {/if}
+</div>
+
+<style>
+  .mermaid-host { display: flex; justify-content: center; margin: 1rem 0; }
+  .mermaid-host :global(svg) { max-width: 100%; height: auto; cursor: default; }
+  .mermaid-fallback {
+    background: var(--color-pre-bg);
+    border: 1px solid var(--color-pre-border);
+    border-radius: 0.5em;
+    padding: 0.75em 1em;
+    overflow-x: auto;
+    font-size: 0.85em;
+  }
+  .mermaid-error { color: var(--abort, #dc2626); font-size: 0.85em; margin-top: 0.5em; }
+</style>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/frontend/src/components/help/MermaidDiagram.svelte
+git commit -m "feat(help): MermaidDiagram component with click-callback support"
+```
+
+---
+
+## Task 6: HelpSection component
+
+Renders a parsed help section: TL;DR callout, how-it-works (markdown, with Mermaid blocks substituted), and under-the-hood (collapsible).
+
+**Files:**
+- Create: `dashboard/frontend/src/components/help/HelpSection.svelte`
+
+- [ ] **Step 1: Add a content registry for the 8 markdown files**
+
+This goes inside `HelpSection.svelte`. We use Vite's `import.meta.glob` with `?raw` to bundle all markdown files at build time and look them up by id.
+
+- [ ] **Step 2: Create the component**
+
+```svelte
+<!-- dashboard/frontend/src/components/help/HelpSection.svelte -->
+<script lang="ts">
+  import { splitHelpSection } from '../../lib/help-content';
+  import MarkdownRenderer from '../data-display/MarkdownRenderer.svelte';
+  import MermaidDiagram from './MermaidDiagram.svelte';
+
+  let { id }: { id: string } = $props();
+
+  // Eagerly-imported raw markdown for all help sections.
+  const sources = import.meta.glob('../../content/help/*.md', {
+    query: '?raw',
+    import: 'default',
+    eager: true,
+  }) as Record<string, string>;
+
+  function lookup(sectionId: string): string | null {
+    const key = Object.keys(sources).find((p) => p.endsWith(`/${sectionId}.md`));
+    return key ? sources[key] : null;
+  }
+
+  const raw = $derived(lookup(id));
+  const parts = $derived(raw ? splitHelpSection(raw) : null);
+
+  // Split the how-it-works body around fenced ```mermaid blocks so we can
+  // render each block with <MermaidDiagram> and the surrounding prose with
+  // <MarkdownRenderer>.
+  type Chunk = { kind: 'md' | 'mermaid'; content: string };
+
+  function chunkBody(body: string): Chunk[] {
+    const re = /```mermaid\n([\s\S]*?)```/g;
+    const out: Chunk[] = [];
+    let lastIdx = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(body)) !== null) {
+      if (m.index > lastIdx) out.push({ kind: 'md', content: body.slice(lastIdx, m.index) });
+      out.push({ kind: 'mermaid', content: m[1] });
+      lastIdx = re.lastIndex;
+    }
+    if (lastIdx < body.length) out.push({ kind: 'md', content: body.slice(lastIdx) });
+    return out;
+  }
+
+  const howItWorksChunks = $derived(parts ? chunkBody(parts.howItWorks) : []);
+</script>
+
+{#if parts}
+  {#if parts.tldr}
+    <div class="tldr">
+      <span class="tldr-label">TL;DR</span>
+      <span class="tldr-text">{parts.tldr}</span>
+    </div>
+  {/if}
+
+  {#each howItWorksChunks as chunk}
+    {#if chunk.kind === 'md'}
+      <MarkdownRenderer content={chunk.content} />
+    {:else}
+      <MermaidDiagram source={chunk.content} />
+    {/if}
+  {/each}
+
+  {#if parts.underTheHood}
+    <details class="uth">
+      <summary>Under the hood</summary>
+      <MarkdownRenderer content={parts.underTheHood} />
+    </details>
+  {/if}
+{:else}
+  <p class="missing">Help section <code>{id}</code> not found.</p>
+{/if}
+
+<style>
+  .tldr {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    padding: 0.6rem 0.85rem;
+    margin: 0 0 0.75rem 0;
+    border-left: 3px solid var(--color-link, #06b6d4);
+    background: var(--color-surface-1, rgba(6, 182, 212, 0.06));
+    border-radius: 0 0.375rem 0.375rem 0;
+    font-size: 0.9rem;
+  }
+  .tldr-label {
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    color: var(--color-link, #06b6d4);
+    text-transform: uppercase;
+  }
+  .tldr-text { color: var(--color-text); }
+
+  .uth {
+    margin-top: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 0.5rem 0.85rem;
+  }
+  .uth > summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--color-text-dim);
+    font-size: 0.85rem;
+    user-select: none;
+  }
+  .uth[open] > summary { margin-bottom: 0.5rem; }
+
+  .missing { color: var(--color-text-dim); font-style: italic; }
+</style>
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/frontend/src/components/help/HelpSection.svelte
+git commit -m "feat(help): HelpSection renders TL;DR + how-it-works + under-the-hood"
+```
+
+---
+
+## Task 7: HelpHint component
+
+The `?` icon. Sits next to a labelled element; clicking opens the drawer for the given section.
+
+**Files:**
+- Create: `dashboard/frontend/src/components/help/HelpHint.svelte`
+
+- [ ] **Step 1: Create the component**
+
+```svelte
+<!-- dashboard/frontend/src/components/help/HelpHint.svelte -->
+<script lang="ts">
+  import { openHelpDrawer } from '../../lib/help-drawer.svelte';
+
+  let {
+    section,
+    label = 'Help',
+  }: {
+    section: string;
+    label?: string;
+  } = $props();
+</script>
+
+<button
+  type="button"
+  class="help-hint"
+  aria-label="Help: {label}"
+  onclick={(e) => { e.stopPropagation(); openHelpDrawer(section); }}
+>?</button>
+
+<style>
+  .help-hint {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    margin-left: 0.35rem;
+    padding: 0;
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    background: transparent;
+    color: var(--color-text-dim);
+    font-size: 9px;
+    line-height: 1;
+    font-weight: 700;
+    cursor: pointer;
+    vertical-align: middle;
+    transition: color 120ms, border-color 120ms;
+  }
+  .help-hint:hover,
+  .help-hint:focus-visible {
+    color: var(--color-text);
+    border-color: var(--color-link, currentColor);
+    outline: none;
+  }
+</style>
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/frontend/src/components/help/HelpHint.svelte
+git commit -m "feat(help): HelpHint icon component"
+```
+
+---
+
+## Task 8: HelpDrawer component
+
+Wraps `SlidePanel` and renders a single `<HelpSection>`. Reads `helpDrawer.openSection` to decide what (if anything) to show.
+
+**Files:**
+- Create: `dashboard/frontend/src/components/help/HelpDrawer.svelte`
+
+- [ ] **Step 1: Build a section-id → title map**
+
+Inside the component, hard-code the 8 section titles so the drawer header reads "Verdicts" rather than `verdicts`.
+
+- [ ] **Step 2: Create the component**
+
+```svelte
+<!-- dashboard/frontend/src/components/help/HelpDrawer.svelte -->
+<script lang="ts">
+  import SlidePanel from '../overlays/SlidePanel.svelte';
+  import HelpSection from './HelpSection.svelte';
+  import { helpDrawer, closeHelpDrawer } from '../../lib/help-drawer.svelte';
+  import { navigate } from '../../lib/router.svelte';
+
+  const TITLES: Record<string, string> = {
+    'run-lifecycle': 'Run lifecycle',
+    'roles': 'The three roles',
+    'verdicts': 'Verdicts',
+    'eligibility': 'Issue eligibility',
+    'throttling': 'Plan-tier throttling',
+    'plans-worktrees': 'Plans & worktrees',
+    'pages-tour': 'Page-by-page tour',
+    'troubleshooting': 'Troubleshooting',
+  };
+
+  const open = $derived(helpDrawer.openSection !== null);
+  const sectionId = $derived(helpDrawer.openSection ?? '');
+  const title = $derived(TITLES[sectionId] ?? 'Help');
+
+  function viewFullPage() {
+    const target = sectionId;
+    closeHelpDrawer();
+    navigate(`/help#${target}`);
+  }
+</script>
+
+<SlidePanel {open} onClose={closeHelpDrawer} {title} width="w-[480px]">
+  {#if sectionId}
+    <HelpSection id={sectionId} />
+    <div class="full-link">
+      <button type="button" onclick={viewFullPage}>View full Help page →</button>
+    </div>
+  {/if}
+</SlidePanel>
+
+<style>
+  .full-link {
+    margin-top: 1.25rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+  }
+  .full-link button {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--color-link, #06b6d4);
+    font-size: 0.9rem;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+</style>
+```
+
+- [ ] **Step 3: Verify SlidePanel accepts the `width="w-[480px]"` prop**
+
+Skim `dashboard/frontend/src/components/overlays/SlidePanel.svelte` lines 1–17 to confirm `width` is a string passed to a class. If Tailwind 4 strips arbitrary values from runtime classes, change `w-[480px]` to a built-in like `w-[28rem]` is also dynamic — fall back to `w-96` (24rem) and accept the slightly narrower drawer.
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/components/help/HelpDrawer.svelte
+git commit -m "feat(help): HelpDrawer wraps SlidePanel and renders one section"
+```
+
+---
+
+## Task 9: Add `'help'` to the router
+
+**Files:**
+- Modify: `dashboard/frontend/src/lib/router.svelte.ts`
+
+- [ ] **Step 1: Add `'help'` to the `Page` union**
+
+Find the `export type Page` declaration (top of the file). Append `| 'help'` to the union.
+
+- [ ] **Step 2: Add `/help` to the `routeMap`**
+
+Locate the `routeMap` const (around line 55). Add the entry:
+
+```ts
+const routeMap: Record<string, Page> = {
+  'mission-control': 'mission-control',
+  'agent-teams': 'agent-teams',
+  queue: 'queue',
+  projects: 'projects',
+  settings: 'settings',
+  help: 'help',
+};
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: no new errors. (Other code that exhausts `Page` may now flag the missing case — fix in Task 11 when registering the page.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dashboard/frontend/src/lib/router.svelte.ts
+git commit -m "feat(help): /help route in router"
+```
+
+---
+
+## Task 10: Add Help to TopNav
+
+**Files:**
+- Modify: `dashboard/frontend/src/components/layout/TopNav.svelte`
+
+- [ ] **Step 1: Append the Help nav item**
+
+In `TopNav.svelte` around line 33, the `navItems` array is:
+
+```ts
+const navItems = [
+  { label: 'Dispatch', page: 'command-center', path: '/' },
+  { label: 'Mission', page: 'mission-control', path: '/mission-control' },
+  { label: 'Fleet', page: 'agent-teams', path: '/agent-teams' },
+  { label: 'Queue', page: 'queue', path: '/queue' },
+  { label: 'Projects', page: 'projects', path: '/projects' },
+  { label: 'Settings', page: 'settings', path: '/settings' },
+] as const;
+```
+
+Append:
+
+```ts
+  { label: 'Help', page: 'help', path: '/help' },
+```
+
+before the closing `]`. Do **not** alter the existing entries — number-key shortcuts stay 1–6.
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/frontend/src/components/layout/TopNav.svelte
+git commit -m "feat(help): TopNav Help item"
+```
+
+---
+
+## Task 11: HelpPage with sticky sidebar, register route, mount drawer
+
+**Files:**
+- Create: `dashboard/frontend/src/pages/HelpPage.svelte`
+- Modify: `dashboard/frontend/src/App.svelte`
+
+- [ ] **Step 1: Create HelpPage**
+
+```svelte
+<!-- dashboard/frontend/src/pages/HelpPage.svelte -->
+<script lang="ts">
+  import HelpSection from '../components/help/HelpSection.svelte';
+  import { onMount } from 'svelte';
+
+  const SECTIONS: Array<{ id: string; title: string }> = [
+    { id: 'run-lifecycle', title: 'Run lifecycle' },
+    { id: 'roles', title: 'The three roles' },
+    { id: 'verdicts', title: 'Verdicts' },
+    { id: 'eligibility', title: 'Issue eligibility' },
+    { id: 'throttling', title: 'Plan-tier throttling' },
+    { id: 'plans-worktrees', title: 'Plans & worktrees' },
+    { id: 'pages-tour', title: 'Page-by-page tour' },
+    { id: 'troubleshooting', title: 'Troubleshooting' },
+  ];
+
+  // After mount, scroll to the location.hash anchor if present.
+  onMount(() => {
+    if (window.location.hash) {
+      const id = window.location.hash.slice(1);
+      // Defer one frame so the section elements are in the DOM.
+      requestAnimationFrame(() => {
+        document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    }
+  });
+</script>
+
+<div class="help-layout">
+  <aside class="help-sidebar">
+    <h2>Help</h2>
+    <ul>
+      {#each SECTIONS as s}
+        <li><a href="#{s.id}">{s.title}</a></li>
+      {/each}
+    </ul>
+  </aside>
+
+  <main class="help-main">
+    <h1>Claude Agent Station — Help</h1>
+    <p class="lede">How the station works, layered for end users, operators, and contributors.</p>
+
+    {#each SECTIONS as s}
+      <section id={s.id} class="help-section-block">
+        <h2>{s.title}</h2>
+        <HelpSection id={s.id} />
+      </section>
+    {/each}
+  </main>
+</div>
+
+<style>
+  .help-layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 2rem;
+    padding: 1.5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+  }
+  .help-sidebar {
+    position: sticky;
+    top: 1rem;
+    align-self: start;
+    border-right: 1px solid var(--color-border);
+    padding-right: 1rem;
+  }
+  .help-sidebar h2 {
+    font-size: 0.7rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--color-text-dim);
+    margin-bottom: 0.75rem;
+  }
+  .help-sidebar ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.25rem; }
+  .help-sidebar a {
+    color: var(--color-text-dim);
+    text-decoration: none;
+    font-size: 0.9rem;
+    padding: 0.25rem 0;
+    display: block;
+  }
+  .help-sidebar a:hover { color: var(--color-text); }
+
+  .help-main h1 { font-size: 1.5rem; margin: 0 0 0.25rem 0; }
+  .lede { color: var(--color-text-dim); margin-bottom: 1.5rem; }
+  .help-section-block { margin-top: 2.5rem; scroll-margin-top: 1rem; }
+  .help-section-block > h2 {
+    font-size: 1.2rem;
+    margin: 0 0 0.75rem 0;
+    padding-bottom: 0.4rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  @media (max-width: 720px) {
+    .help-layout { grid-template-columns: 1fr; }
+    .help-sidebar { position: static; border-right: none; border-bottom: 1px solid var(--color-border); padding-right: 0; padding-bottom: 0.75rem; }
+    .help-sidebar ul { flex-direction: row; flex-wrap: wrap; gap: 0.5rem 1rem; }
+  }
+</style>
+```
+
+- [ ] **Step 2: Register HelpPage and mount HelpDrawer in App.svelte**
+
+In `App.svelte`, find the page imports block (currently imports `CommandCenter`, `MissionControl`, etc., near the top of `<script>`). Add:
+
+```ts
+import HelpPage from './pages/HelpPage.svelte';
+import HelpDrawer from './components/help/HelpDrawer.svelte';
+```
+
+Find the page-routing template (where `route.page === 'command-center'` etc. is matched). Add the help branch in the same style — insert next to the other page branches:
+
+```svelte
+{:else if route.page === 'help'}
+  <HelpPage />
+```
+
+Find the bottom of the App template, near where `<Toast>`, `<ShortcutsOverlay>`, and `<AuthPrompt>` are mounted. Add `<HelpDrawer />` alongside them so it's globally available.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: no new errors.
+
+- [ ] **Step 4: Smoke test in dev**
+
+```bash
+cd dashboard/frontend && npm run dev
+```
+
+Open `http://localhost:<port>/help` in a browser. Expected: page renders with sidebar (8 stub entries) and "Section not found" placeholders for each section (because no markdown files exist yet — this is fine, fixed in the next task).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/pages/HelpPage.svelte dashboard/frontend/src/App.svelte
+git commit -m "feat(help): /help page with sticky sidebar, drawer mounted globally"
+```
+
+---
+
+## Task 12: Author the run-lifecycle markdown (with flowchart)
+
+**Files:**
+- Create: `dashboard/frontend/src/content/help/run-lifecycle.md`
+
+- [ ] **Step 1: Create the file**
+
+```bash
+mkdir -p dashboard/frontend/src/content/help
+```
+
+```markdown
+<!-- dashboard/frontend/src/content/help/run-lifecycle.md -->
+> **TL;DR** — A run takes a GitHub issue from picked-up to merged or PR'd in seven phases.
+
+A "run" is one full execution of the agent: triggered by a timer or a webhook, ending with a verdict that decides what happens to the work. Click any node in the diagram below to jump into the relevant section.
+
+```mermaid
+flowchart TD
+    Trigger["systemd timer<br/>or webhook"]
+    Throttle{"Plan tier<br/>throttled?"}
+    Halt["Run skipped<br/>no work started"]
+    Eligible["Lead fetches<br/>eligible issues"]
+    NoneEligible{"Any eligible<br/>issues?"}
+    Decompose["Lead decomposes issues<br/>into tasks (by specialty)"]
+    Spawn["Spawn 3 teammates:<br/>backend / frontend / qa<br/>(each in own worktree)"]
+    Plans["Each teammate writes<br/>an implementation plan"]
+    Review{"Lead reviews plans<br/>conflicts?"}
+    Implement["Teammates implement,<br/>test, commit locally"]
+    Manager["Manager reviews<br/>all completed work"]
+    Verdict{"Verdict"}
+    Approve["APPROVE<br/>push & merge to dev"]
+    PR["PR<br/>open against dev"]
+    Reject["REJECT<br/>discard branch"]
+    Skip["SKIP<br/>no eligible work"]
+
+    Trigger --> Throttle
+    Throttle -->|yes| Halt
+    Throttle -->|no| Eligible
+    Eligible --> NoneEligible
+    NoneEligible -->|no| Skip
+    NoneEligible -->|yes| Decompose
+    Decompose --> Spawn
+    Spawn --> Plans
+    Plans --> Review
+    Review -->|conflict| Plans
+    Review -->|approved| Implement
+    Implement --> Manager
+    Manager --> Verdict
+    Verdict --> Approve
+    Verdict --> PR
+    Verdict --> Reject
+    Verdict --> Skip
+
+    click Throttle call openHelpDrawer("throttling")
+    click Eligible call openHelpDrawer("eligibility")
+    click NoneEligible call openHelpDrawer("eligibility")
+    click Spawn call openHelpDrawer("roles")
+    click Plans call openHelpDrawer("plans-worktrees")
+    click Review call openHelpDrawer("plans-worktrees")
+    click Manager call openHelpDrawer("roles")
+    click Verdict call openHelpDrawer("verdicts")
+    click Approve call openHelpDrawer("verdicts")
+    click PR call openHelpDrawer("verdicts")
+    click Reject call openHelpDrawer("verdicts")
+    click Skip call openHelpDrawer("verdicts")
+```
+
+### The seven phases
+
+1. **Trigger.** A systemd timer fires, or a GitHub webhook arrives. The run-manager script starts.
+2. **Throttle gate.** If weekly Claude usage has exceeded the configured threshold, the run is skipped before any work starts.
+3. **Issue selection.** The lead agent fetches open issues from enabled repos and filters out anything labelled `backlog`, `wontfix`, `NO AI`, or already in progress.
+4. **Decomposition & spawn.** The lead breaks eligible issues into tasks and spawns three teammates — `backend`, `frontend`, `qa` — each in its own git worktree so they cannot collide.
+5. **Plan review.** Every teammate writes an implementation plan first. The lead reviews the plans together and rejects any that conflict; teammates revise and resubmit.
+6. **Implement.** Approved teammates write code, run tests, and commit locally.
+7. **Manager review & verdict.** Once all teammates finish, a separate manager pass reviews the work and issues one of four verdicts: `APPROVE`, `PR`, `REJECT`, or `SKIP`. The verdict decides what happens to the branch.
+
+<!-- under-the-hood -->
+
+### Where the code lives
+
+- **Trigger:** systemd timer (`agent/systemd/`), GitHub webhook intake at `dashboard/backend/app/routers/github_webhook.py`.
+- **Throttle decision:** `agent/scripts/detect_plan_usage.py` and the `plan_usage_history` table.
+- **Orchestrator:** `agent/station_orchestrator.py` runs the lead + teammates in a single Claude Agent SDK Agent Teams session.
+- **Manager review:** invoked by `agent/scripts/run-manager.sh` after teammates finish; uses the prompt at `agent/prompts/manager.md`.
+- **Skip-label filter:** the `SKIP_LABELS` constant in `agent/station_orchestrator.py`.
+- **Verdict enforcement:** `run-manager.sh` reads the manager's verdict and performs the corresponding git action (push, PR via `gh`, branch delete).
+```
+
+- [ ] **Step 2: Reload `/help` in the browser**
+
+Expected: the Run lifecycle section now renders prose, the flowchart appears, and clicking a node opens the drawer.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/frontend/src/content/help/run-lifecycle.md
+git commit -m "docs(help): run lifecycle section with flowchart"
+```
+
+---
+
+## Task 13: Author the remaining seven markdown files
+
+For each section: create the file with TL;DR, how-it-works prose, and a `<!-- under-the-hood -->` deep-dive. Source from `docs/concepts.md`, `docs/architecture.md`, and the code paths cited in the spec's per-section briefs table.
+
+**Files:**
+- Create: `dashboard/frontend/src/content/help/roles.md`
+- Create: `dashboard/frontend/src/content/help/verdicts.md`
+- Create: `dashboard/frontend/src/content/help/eligibility.md`
+- Create: `dashboard/frontend/src/content/help/throttling.md`
+- Create: `dashboard/frontend/src/content/help/plans-worktrees.md`
+- Create: `dashboard/frontend/src/content/help/pages-tour.md`
+- Create: `dashboard/frontend/src/content/help/troubleshooting.md`
+
+- [ ] **Step 1: roles.md**
+
+```markdown
+> **TL;DR** — Lead coordinates, three teammates implement, manager reviews. Each runs a different Claude model.
+
+The station's work is split across three roles. Each role has a different responsibility, prompt, and model:
+
+| Role | Model | Responsibility |
+|---|---|---|
+| **Lead** | Sonnet 4.6 | Picks eligible issues, decomposes them into tasks, spawns the three teammates, reviews their plans, and watches the run until done. |
+| **Teammates** (×3) | Opus 4.7 | Three role-specialists per run — `backend`, `frontend`, `qa`. Each works in its own git worktree on the tasks routed to its specialty. |
+| **Manager** | Sonnet 4.6 | A separate review pass after teammates finish. Reads the work and issues a verdict (APPROVE / PR / REJECT / SKIP). |
+
+The lead and teammates run inside a single Claude Agent SDK Agent Teams session. The manager runs as a follow-up phase.
+
+<!-- under-the-hood -->
+
+- Agent definitions: `agent/agents/issue-worker.md` (teammate worker definition).
+- Prompts: `agent/prompts/manager.md`, role overlays in `agent/prompts/roles/`.
+- Orchestrator that spawns lead + teammates: `agent/station_orchestrator.py`.
+- Manager invocation: `agent/scripts/run-manager.sh`.
+- Per-role model overrides live in the agent config DB (`/var/lib/claude-agent-station/station.db`).
+```
+
+- [ ] **Step 2: verdicts.md**
+
+```markdown
+> **TL;DR** — Every run ends in one of four verdicts. The verdict decides what happens to the branch.
+
+After the manager reviews the teammates' work, the run terminates with exactly one verdict:
+
+| Verdict | What happens to the work |
+|---|---|
+| **APPROVE** | Branch is pushed and merged into `dev`. |
+| **PR** | A pull request is opened against `dev` for human review. |
+| **REJECT** | Branch is discarded. The run is marked failed. |
+| **SKIP** | Nothing to merge — usually because there was no eligible work for this project. The queue item is marked completed (not failed). |
+
+You'll see verdicts on the Mission Control feed, on Run Detail, and in the run lists across the dashboard.
+
+<!-- under-the-hood -->
+
+- Verdicts are written to the `verdict` column on the `runs` table by `run-manager.sh`.
+- The audit log (`audit_log` table) records each tool call the manager makes during review.
+- The reasoning behind a verdict is stored in `verdict_detail` and surfaced on Run Detail.
+```
+
+- [ ] **Step 3: eligibility.md**
+
+```markdown
+> **TL;DR** — Issues are skipped if the repo isn't enabled, the issue is closed, or it carries a skip label.
+
+The lead picks GitHub issues that pass these filters:
+
+- The repository is enabled in the dashboard.
+- The issue is open.
+- The issue is **not** labelled with any of the skip set:
+  - `autonomous-agent/in-progress` — already being worked on.
+  - `autonomous-agent/needs-help` — flagged for human follow-up.
+  - `NO AI` — explicit human-only marker.
+  - `backlog` — explicitly out of scope. **The agent will never pick up a backlog issue.**
+  - `wontfix` — closed by intent, even if open.
+  - `vision-suggested` — produced by the vision pipeline, not yet promoted.
+
+Eligible issues are then decomposed into tasks and routed across the three teammates by specialty.
+
+<!-- under-the-hood -->
+
+- The skip set is the `SKIP_LABELS` constant in `agent/station_orchestrator.py`.
+- The "enabled repo" flag is the `enabled` column on the `projects` table.
+- A skipped issue is recorded in the run log with the reason it was skipped.
+```
+
+- [ ] **Step 4: throttling.md**
+
+```markdown
+> **TL;DR** — When weekly Claude usage gets too high, runs are paused before they start so the agent doesn't run out of budget mid-task.
+
+Claude Agent Station is bounded by the Claude plan tier you've configured. The station tracks weekly token consumption and refuses to start a new run when usage crosses the threshold — better to pause cleanly than to fail mid-task with no budget to recover.
+
+There are two protections:
+
+1. **Plan-tier throttle.** Weekly usage (overall and per-model) is checked before each run. If the budget is too low, `run-manager.sh` short-circuits before launching any agent.
+2. **Per-model fallback.** Every Claude invocation passes a `--fallback-model` to the SDK so primary-model errors don't kill the run. Opus 4.7 falls back to Sonnet 4.6, Sonnet 4.6 falls back to Haiku 4.5.
+
+The Command Center surfaces current usage and the active throttle state.
+
+<!-- under-the-hood -->
+
+- Usage history: `plan_usage_history` table.
+- Detection: `agent/scripts/detect_plan_usage.py`.
+- Throttle decision API: served from the dashboard backend; consumed by Command Center.
+- Throttling is independent of the fallback chain — both can be active.
+```
+
+- [ ] **Step 5: plans-worktrees.md**
+
+```markdown
+> **TL;DR** — Each teammate writes a plan first, gets it approved by the lead, then works in its own git worktree.
+
+Two protections keep concurrent teammates from clobbering each other:
+
+**Plans.** Every teammate's first deliverable is a short implementation plan. The lead reviews each plan before the teammate is allowed to start writing code. If two plans conflict — e.g. both teammates want to modify the same file — the lead asks the affected teammate to revise.
+
+**Worktrees.** Each teammate runs in its own git worktree at `<workspaces_dir>/<repo>-<role>` (e.g. `/home/claude-agent/workspaces/my-repo-backend`). File edits from one teammate are invisible to the others until the changes are committed and merged. Worktrees are created per run and torn down when the run ends.
+
+<!-- under-the-hood -->
+
+- Workspaces directory is configurable; default `/home/claude-agent/workspaces/`.
+- Worktree paths follow `<workspaces_dir>/<repo-name>-<role>`. Roles are `backend`, `frontend`, `qa`.
+- The lead's plan-review behaviour is encoded in the orchestrator and the lead prompt.
+- Plans are stored in the `plans` table and surfaced on Run Detail.
+```
+
+- [ ] **Step 6: pages-tour.md**
+
+```markdown
+> **TL;DR** — What each dashboard page is for, and when to open it.
+
+- **Dispatch** (`/`) — the home page. Trigger a run, see live token burn, current throttle state.
+- **Mission** (`/mission-control`) — live activity feed across all projects.
+- **Fleet** (`/agent-teams`) — visual canvas of the lead and the three teammates for the current run.
+- **Queue** (`/queue`) — the work queue: items waiting, in flight, completed.
+- **Projects** (`/projects`) — list of repos. Click in to enable/disable, configure, see project-level history.
+- **Project Detail** — drill-down for one project: vision, runs, settings.
+- **Run Detail** — drill-down for one run: DAG, logs, plan, verdict, diff.
+- **Settings** (`/settings`) — auth (OAuth, GitHub App), models, prompts, audit, appearance.
+- **Help** (`/help`) — this page.
+
+<!-- under-the-hood -->
+
+- All pages are Svelte 5 components under `dashboard/frontend/src/pages/`.
+- Cross-page navigation uses the History API via `lib/router.svelte.ts`. Number keys 1–6 map to the first six tabs.
+```
+
+- [ ] **Step 7: troubleshooting.md**
+
+```markdown
+> **TL;DR** — Common "why isn't it doing what I expected?" answers.
+
+**No run started after the timer fired.**
+Check the throttle state on Dispatch. If weekly usage is high, runs are deliberately paused. See Plan-tier throttling.
+
+**My issue was skipped.**
+Check the issue's labels. Anything in the skip set (`backlog`, `wontfix`, `NO AI`, …) blocks it. Also check the project is enabled. See Issue eligibility.
+
+**The verdict was REJECT.**
+The manager judged the work incomplete or wrong. Open Run Detail and read `verdict_detail` for the reasoning.
+
+**The verdict was SKIP and nothing happened.**
+Usually means there was no eligible work — common after the queue empties. Not a failure.
+
+**A teammate looks stuck.**
+Open Run Detail and check the audit log. Long-running tool calls (build, test) are normal; an unmoving log for many minutes likely means a hung subprocess.
+
+**Where are the logs?**
+Agent logs live at `/var/log/claude-agent/`. The dashboard surfaces them via WebSocket on Run Detail.
+
+**How do I pause everything?**
+The "Stop" button in the top nav engages a global pause when there are active runs.
+
+<!-- under-the-hood -->
+
+- Audit log: the `audit_log` table records every tool call. Retention defaults to 30 days.
+- Run control: pause/resume/stop is implemented in `agent/run_control.py` and exposed via the dashboard API.
+- Live logs: WebSocket served by `dashboard/backend/app/routers/logs.py`.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add dashboard/frontend/src/content/help/
+git commit -m "docs(help): author content for the seven non-flowchart sections"
+```
+
+---
+
+## Task 14: Place HelpHint at verdict locations on Run Detail
+
+**Files:**
+- Modify: `dashboard/frontend/src/pages/RunDetail.svelte`
+
+- [ ] **Step 1: Identify the three verdict-render sites**
+
+From earlier reconnaissance:
+
+- Lines 326–332 — `{:else if run.verdict === 'APPROVE'}` block (verdict pill in the page header).
+- Line 460–461 — `<span class="v ...">{run.verdict}</span>` inline pill.
+- Line 534 — `{:else if run.verdict}` followed by `Finished · Verdict {run.verdict}`.
+
+(Line numbers may have drifted; locate by content if so.)
+
+- [ ] **Step 2: Import HelpHint**
+
+At the top of the `<script>` block in `RunDetail.svelte`, add:
+
+```ts
+import HelpHint from '../components/help/HelpHint.svelte';
+```
+
+- [ ] **Step 3: Add a single hint next to the most prominent verdict pill**
+
+To avoid `?` icon noise, add a `HelpHint` only at the **page-header** verdict pill (the most-seen one — the lines 326–332 block). Wrap that block so the hint appears immediately after the verdict label:
+
+```svelte
+<span class="verdict-with-hint">
+  <!-- existing verdict pill markup -->
+  <HelpHint section="verdicts" label="Verdicts" />
+</span>
+```
+
+Use a `display: inline-flex; align-items: center;` style on `.verdict-with-hint` if needed. Do **not** add hints to lines 460 and 534 — duplication on the same page is what the spec calls "noisy."
+
+- [ ] **Step 4: Identify the plan-related UI**
+
+Around line 268 the file mentions `'Reject this plan? The run will end with verdict=REJECT.'` — this is part of a plan-review block. Locate the visible "Plan" header or button group surrounding that confirm dialog. Add one hint:
+
+```svelte
+<HelpHint section="plans-worktrees" label="Plans & worktrees" />
+```
+
+immediately after the plan-section heading.
+
+- [ ] **Step 5: Smoke test in dev**
+
+Reload Run Detail in the browser. Click the `?` next to the verdict — drawer opens with "Verdicts." Click the `?` next to the plan section — drawer opens with "Plans & worktrees." Press Esc — drawer closes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/frontend/src/pages/RunDetail.svelte
+git commit -m "feat(help): contextual hints on Run Detail verdict and plan blocks"
+```
+
+---
+
+## Task 15: Place HelpHint on Agent Teams Canvas
+
+**Files:**
+- Modify: `dashboard/frontend/src/pages/AgentTeamsCanvas.svelte`
+
+- [ ] **Step 1: Import HelpHint**
+
+```ts
+import HelpHint from '../components/help/HelpHint.svelte';
+```
+
+- [ ] **Step 2: Add a hint next to the Team Lead label**
+
+Around line 425, find:
+
+```svelte
+<span class="role"><span class="role-name">Team Lead</span> <span class="br">·</span> <span class="role-tag">Commander</span></span>
+```
+
+Append `<HelpHint section="roles" label="The three roles" />` inside the same `.role` span (so it stays inline with the label).
+
+- [ ] **Step 3: Skip per-teammate hints**
+
+The three teammate cells (lines ~466–474) all link to the same "roles" section. One hint on the Team Lead label is sufficient to cover the concept on this page.
+
+- [ ] **Step 4: Smoke test**
+
+Reload `/agent-teams` in the browser. Confirm the `?` appears next to "Team Lead", clicking opens the Roles drawer.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/pages/AgentTeamsCanvas.svelte
+git commit -m "feat(help): contextual hint on Agent Teams Canvas Team Lead label"
+```
+
+---
+
+## Task 16: Place HelpHint on Command Center
+
+**Files:**
+- Modify: `dashboard/frontend/src/pages/CommandCenter.svelte`
+
+The throttling and skipped-state UI was not located by grep in the discovery phase. Locate it by reading the file and looking for: token-meter or plan-tier indicator, "skipped" status callouts, idle-state messages.
+
+- [ ] **Step 1: Read CommandCenter and identify the throttle/skip UI**
+
+```bash
+grep -n -i "throttl\|plan\|tier\|skip\|usage\|burn" dashboard/frontend/src/pages/CommandCenter.svelte
+```
+
+Skim the file around the matches to find a *visible UI element* representing throttle state (a banner, a meter, a status pill). If no visible throttle UI exists, only place a hint on a skip-related element. If neither exists, this task contributes nothing — drop the hints from this file and rely on the flowchart click-through and the Help page itself.
+
+- [ ] **Step 2: Import HelpHint**
+
+```ts
+import HelpHint from '../components/help/HelpHint.svelte';
+```
+
+- [ ] **Step 3: Place hints**
+
+Add up to two hints, one per concept:
+
+- Next to the throttle/usage indicator → `<HelpHint section="throttling" label="Plan-tier throttling" />`.
+- Next to a skip-state callout → `<HelpHint section="eligibility" label="Issue eligibility" />`.
+
+If only one element is present, only one hint is added. **Do not** add a hint where there is no labelled UI to attach it to.
+
+- [ ] **Step 4: Smoke test**
+
+Reload `/`. Confirm the hint(s) render and open the right drawer section.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/pages/CommandCenter.svelte
+git commit -m "feat(help): contextual hints on Command Center throttle/skip UI"
+```
+
+---
+
+## Task 17: Manual browser verification + open PR
+
+UI features must be browser-tested before claiming complete. This is the verification gate.
+
+**Files:** none for verification; PR opened at the end.
+
+- [ ] **Step 1: Run the unit tests**
+
+```bash
+cd dashboard/frontend && npx vitest run
+```
+
+Expected: all tests pass, including the 5 new tests in `help-content.test.ts`.
+
+- [ ] **Step 2: Type-check the whole frontend**
+
+```bash
+cd dashboard/frontend && npx tsc --noEmit
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 3: Build**
+
+```bash
+cd dashboard/frontend && npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Run dev and manually verify (mandatory)**
+
+```bash
+cd dashboard/frontend && npm run dev
+```
+
+Walk through this checklist in a browser:
+
+- [ ] `/help` loads. All 8 sections render with TL;DR + how-it-works visible. Sidebar shows 8 items.
+- [ ] Each sidebar link scrolls to the matching section (URL updates with hash).
+- [ ] The flowchart in "Run lifecycle" renders.
+- [ ] Clicking each labelled flowchart node opens the drawer with the right section: throttle → throttling, eligibility nodes → eligibility, spawn/manager → roles, plans/review → plans-worktrees, verdict + outcomes → verdicts.
+- [ ] The "Under the hood" accordion in each section opens and closes.
+- [ ] Drawer behaviour: opens on `?` click, closes on Esc, closes on backdrop click, closes on close-button click. Only one drawer open at a time.
+- [ ] "View full Help page →" link in the drawer footer closes the drawer and navigates to `/help#<section>` with the section in view.
+- [ ] Run Detail: `?` next to the verdict pill opens Verdicts; `?` next to the plan block opens Plans & worktrees.
+- [ ] Agent Teams Canvas: `?` next to "Team Lead" opens Roles.
+- [ ] Command Center: hint(s) added in Task 16 open the expected drawer (or, if none was added because no UI existed, this check is N/A).
+- [ ] Top nav: clicking "Help" navigates to `/help`. Number keys 1–6 still navigate to the original tabs (no regression).
+- [ ] Theme toggle: switch between light and dark. Mermaid diagram still readable in both. Drawer chrome still readable in both.
+- [ ] Narrow viewport (< 720 px width): sidebar collapses, drawer is full-width.
+- [ ] Mermaid render failure path: temporarily corrupt the mermaid block in `run-lifecycle.md` (e.g. `flowchartTD`), reload, confirm the fallback `<pre>` and error message render. Revert the change before proceeding.
+
+- [ ] **Step 5: Push and open PR**
+
+```bash
+git push -u origin feature/help-page
+gh pr create --base dev --title "Help page with contextual ? drawer and run-lifecycle flowchart" --body "$(cat <<'EOF'
+## Summary
+- Adds a `/help` page with eight sections (run lifecycle, roles, verdicts, eligibility, throttling, plans & worktrees, page-by-page tour, troubleshooting), layered TL;DR / how-it-works / under-the-hood.
+- Adds a contextual `?` icon (`HelpHint`) on conceptually loaded UI elements — verdict pill on Run Detail, Team Lead label on Agent Teams Canvas, plan block on Run Detail, throttle/skip indicators on Command Center where they exist.
+- The Mermaid run-lifecycle flowchart has clickable nodes that open the same drawer.
+- Drawer reuses the existing `SlidePanel` overlay; section content reuses `MarkdownRenderer` (marked + DOMPurify).
+
+## Test plan
+- [x] Unit tests for the markdown splitter (`help-content.test.ts`).
+- [x] `tsc --noEmit` clean.
+- [x] `npm run build` succeeds.
+- [x] Manual browser verification of all 8 sections, drawer interactions, flowchart node clicks, theme toggle, narrow-viewport layout.
+
+Spec: `docs/superpowers/specs/2026-05-10-help-page-design.md`
+EOF
+)"
+```
+
+Expected: PR opened against `dev`. Return the PR URL.
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+- Page structure (8 sections, sticky sidebar, top-nav item, route) — Tasks 9, 10, 11.
+- Per-section content briefs — Tasks 12, 13.
+- Content source (markdown per section, Vite glob, shared rendering) — Task 6.
+- Mermaid integration with click directives — Tasks 4, 5, 12.
+- Run-lifecycle flowchart text matches the spec — Task 12.
+- Drawer (state, component, SlidePanel reuse) — Tasks 2, 8.
+- HelpHint placements (verdict, role labels, plan UI, throttled/skipped) — Tasks 14, 15, 16.
+- Behaviour & edge cases (anchor scroll, missing-section fallback, Mermaid render-failure fallback, focus management via SlidePanel) — Tasks 6, 11, 5; SlidePanel already handles Esc and focus-on-trigger via the close button.
+- Testing (unit splitter, manual browser checklist) — Tasks 3, 17.
+
+Gaps from spec:
+
+- Spec mentioned "drawer traps focus while open and restores focus to the trigger `?` icon on close." `SlidePanel` does not implement focus-trap. **Decision:** acceptable for v1; the close button is keyboard-reachable and Esc closes. Adding a focus trap is a follow-up if accessibility audit demands it. Not added to plan.
+- Spec mentioned `aria-modal="true"` and `aria-labelledby` on the drawer header. `SlidePanel` does not currently set these. **Decision:** add a small modification to `SlidePanel` only if the audit demands; for v1, the panel reads as a labelled section to most assistive tech via the header `<h3>`. Not added to plan.
+
+**Placeholder scan:** None of the "TBD / TODO / similar to Task N / fill in details" patterns present.
+
+**Type consistency:**
+
+- `splitHelpSection` returns `HelpSectionParts` with `tldr | null`, `howItWorks: string`, `underTheHood: string | null`. `HelpSection.svelte` consumes the same names.
+- `openHelpDrawer(section: string)` signature matches in `help-drawer.svelte.ts`, `HelpHint.svelte`, `MermaidDiagram.svelte` (`window.openHelpDrawer`).
+- `HelpDrawer` consumes `helpDrawer.openSection`; the store exports it under that exact name.
+- The 8 section ids used in `HelpPage.SECTIONS`, `HelpDrawer.TITLES`, the markdown filenames, the flowchart `click` directives, and the `<HelpHint section="…">` usages are all the same set: `run-lifecycle`, `roles`, `verdicts`, `eligibility`, `throttling`, `plans-worktrees`, `pages-tour`, `troubleshooting`.
+
+No remaining issues.

--- a/docs/superpowers/specs/2026-05-10-help-page-design.md
+++ b/docs/superpowers/specs/2026-05-10-help-page-design.md
@@ -1,0 +1,269 @@
+# Help Page Design
+
+**Date:** 2026-05-10
+**Status:** Draft — pending user review
+
+## Problem
+
+Claude Agent Station has grown enough surface area (8 dashboard pages, three agent roles, four verdicts, plan-review gating, worktree isolation, plan-tier throttling, audit log, vision pipeline) that the operator — including the project owner — cannot keep the model fully in their head. There is no in-app explanation of how a run flows from trigger to verdict, what each dashboard page is for, or why an issue was skipped. `docs/concepts.md` and `docs/architecture.md` cover the system in prose, but they live outside the dashboard and are not surfaced where a user is looking at a verdict badge or a throttled state.
+
+This page must serve three audiences with one source of truth: the operator (the project owner), future contributors, and end users running their own station.
+
+## Goals
+
+- One canonical, in-dashboard explanation of how the station works.
+- Contextual access from the conceptually loaded UI elements (verdict badges, role labels, plan UI, throttled / skipped indicators) — without leaving the current page.
+- Layered depth so an end user gets the gist and a contributor can drill into code paths.
+- A run-lifecycle flowchart that makes the trigger-to-verdict path legible at a glance.
+
+## Non-goals
+
+- Replacing `docs/concepts.md` or `docs/architecture.md`. Those remain authoritative for code-level details; the Help page reuses content from them but lives in the UI.
+- Per-page contextual tutorials beyond the Page-by-page tour section.
+- Onboarding wizards, search, or multi-language support.
+- Embedding the system architecture diagram (it is already documented in `docs/architecture.md` and is not what the user needs in-dashboard).
+- Vision pipeline coverage. Vision is a separate flow and is out of scope for v1.
+
+## Audience and depth model
+
+The page serves all three audiences via a layered structure within each section:
+
+| Layer | Audience | Visibility |
+|---|---|---|
+| **TL;DR** | End user | Always visible — one sentence at the top of each section |
+| **How it works** | Operator | Always visible — short paragraphs of plain prose |
+| **Under the hood** | Contributor | Collapsed `<details>` accordion, opt-in |
+
+## Page structure
+
+A new top-level page at `/help`:
+
+- Registered in `dashboard/frontend/src/lib/router.svelte.ts` as `Page = 'help'`, route `/help`, optional `param` for a section anchor.
+- Added to the top nav in `Shell.svelte` (or wherever the nav lives) as the 7th item, after Settings.
+- No new keyboard shortcut. Number keys 1–6 retain their existing bindings; Help is mouse-or-link only.
+- Layout reuses `Shell.svelte`. Body is a two-column layout: sticky left sidebar with anchor links to all sections; main content column. On narrow widths the sidebar collapses into a top dropdown, matching existing responsive patterns in the dashboard.
+- Each section has a stable URL anchor (`/help#run-lifecycle`, `/help#verdicts`, …) so contextual `?` drawers and external links can deep-link in.
+
+## Sections
+
+In order, with their anchors:
+
+1. **Run lifecycle** — `#run-lifecycle` *(contains the flowchart)*
+2. **The three roles** — `#roles`
+3. **Verdicts** — `#verdicts`
+4. **Issue eligibility** — `#eligibility`
+5. **Plan-tier throttling** — `#throttling`
+6. **Plans & worktrees** — `#plans-worktrees`
+7. **Page-by-page tour** — `#pages-tour`
+8. **Troubleshooting** — `#troubleshooting`
+
+### Per-section content briefs
+
+| Section | TL;DR | How it works covers | Under the hood covers |
+|---|---|---|---|
+| Run lifecycle | A run takes a GitHub issue from picked-up to merged or PR'd, in 7 phases. | Walks the flowchart in prose; what each phase produces. | Trigger sources (systemd timer, webhook intake); orchestrator entrypoint (`agent/station_orchestrator.py`); manager review pass in `agent/scripts/run-manager.sh`. |
+| The three roles | Lead coordinates, three teammates implement, manager reviews. | Who runs which model and decides what; one paragraph per role. | Agent definitions in `agent/agents/`, prompts in `agent/prompts/`, model overrides in config. |
+| Verdicts | Every run ends in APPROVE, PR, REJECT, or SKIP — that decides what happens to the branch. | Cheat-sheet table mapping each verdict to its branch action and when to expect it. | Where verdicts get written (DB column, audit log), how `run-manager.sh` enforces them. |
+| Issue eligibility | Issues are skipped if the repo isn't enabled, the issue is closed, or it carries a skip label. | The full filter rules in plain English; the skip-label set with one-line rationale per label; the `backlog` rule. | Source of truth: `SKIP_LABELS` in `agent/station_orchestrator.py`. |
+| Plan-tier throttling | When weekly Claude usage gets too high, runs are paused before they start so we don't run out of budget mid-task. | The threshold concept, the per-model fallback chain (Opus → Sonnet → Haiku), what the throttled UI state means. | `plan_usage_history` table; `agent/scripts/detect_plan_usage.py`; throttle decision API. |
+| Plans & worktrees | Each teammate writes a plan first, gets it approved by the lead, then works in its own git worktree. | Why plans exist (conflict prevention); why worktrees (isolation); life of a plan. | Worktree path scheme (`<workspaces_dir>/<repo>-<role>`); plan storage; lead's plan-review prompt. |
+| Page-by-page tour | What each dashboard page is for, and when to open it. | One short paragraph per page: Command Center, Mission Control, Agent Teams, Run Detail, Queue, Projects, Project Detail, Settings, Help. | Notable cross-page navigation patterns. |
+| Troubleshooting | Common "why isn't it doing what I expected?" answers. | Q&A list: why no run started, why an issue was skipped, why a verdict was REJECT, where logs live, how to pause/resume. | Pointers to the audit log, log files, run control API. |
+
+V1 prose is authored by the implementer, sourced from `docs/concepts.md`, `docs/architecture.md`, and the code. The user edits afterward.
+
+## Content source and rendering
+
+Content lives in **one place** so the full Help page and the contextual drawer share a single source of truth.
+
+- New directory `dashboard/frontend/src/content/help/` holds one markdown file per section: `run-lifecycle.md`, `roles.md`, `verdicts.md`, `eligibility.md`, `throttling.md`, `plans-worktrees.md`, `pages-tour.md`, `troubleshooting.md`.
+- Each file follows this structure:
+  ```markdown
+  > **TL;DR** — one sentence.
+
+  How-it-works prose, paragraphs and tables as needed.
+
+  <!-- under-the-hood -->
+
+  Deep-dive content with code/file references.
+  ```
+- A new component `dashboard/frontend/src/components/help/HelpSection.svelte` accepts an `id` prop, imports the matching markdown file via Vite `?raw`, splits on the `<!-- under-the-hood -->` marker, and renders:
+  - The TL;DR blockquote as a styled callout.
+  - The "How it works" body via the markdown renderer.
+  - The "Under the hood" body inside a `<details>` accordion (closed by default).
+- A markdown renderer is added if the project does not already have one. Preferred: `marked` (smaller, simpler) unless an existing renderer is already in use elsewhere in the frontend, in which case reuse it.
+- The `/help` page composes all 8 `<HelpSection>` instances in section order; each is wrapped in a `<section id="…">` so anchors work.
+- The drawer renders one `<HelpSection>`.
+
+### Mermaid
+
+- Add `mermaid` (npm). Lazy-loaded only on `/help` and on first drawer open of a Mermaid-bearing section.
+- A new component `dashboard/frontend/src/components/help/MermaidDiagram.svelte` accepts a Mermaid source string, calls `mermaid.render()` on mount, and inserts the resulting SVG.
+- `HelpSection.svelte` detects fenced ` ```mermaid ` blocks and substitutes `<MermaidDiagram>` for them.
+- Mermaid theme variables are configured to match the dashboard palette (cyan/void Tailwind tokens), set once at module load.
+
+## Run-lifecycle flowchart
+
+The flowchart lives in `run-lifecycle.md` as a fenced ` ```mermaid ` block:
+
+```
+flowchart TD
+    Trigger["systemd timer<br/>or webhook"]
+    Throttle{"Plan tier<br/>throttled?"}
+    Halt["Run skipped<br/>no work started"]
+    Eligible["Lead fetches<br/>eligible issues"]
+    NoneEligible{"Any eligible<br/>issues?"}
+    Decompose["Lead decomposes issues<br/>into tasks (by specialty)"]
+    Spawn["Spawn 3 teammates:<br/>backend / frontend / qa<br/>(each in own worktree)"]
+    Plans["Each teammate writes<br/>an implementation plan"]
+    Review{"Lead reviews plans<br/>conflicts?"}
+    Implement["Teammates implement,<br/>test, commit locally"]
+    Manager["Manager reviews<br/>all completed work"]
+    Verdict{"Verdict"}
+    Approve["APPROVE<br/>push & merge to dev"]
+    PR["PR<br/>open against dev"]
+    Reject["REJECT<br/>discard branch"]
+    Skip["SKIP<br/>no eligible work"]
+
+    Trigger --> Throttle
+    Throttle -->|yes| Halt
+    Throttle -->|no| Eligible
+    Eligible --> NoneEligible
+    NoneEligible -->|no| Skip
+    NoneEligible -->|yes| Decompose
+    Decompose --> Spawn
+    Spawn --> Plans
+    Plans --> Review
+    Review -->|conflict| Plans
+    Review -->|approved| Implement
+    Implement --> Manager
+    Manager --> Verdict
+    Verdict --> Approve
+    Verdict --> PR
+    Verdict --> Reject
+    Verdict --> Skip
+
+    click Throttle call openHelpDrawer("throttling")
+    click Eligible call openHelpDrawer("eligibility")
+    click NoneEligible call openHelpDrawer("eligibility")
+    click Spawn call openHelpDrawer("roles")
+    click Plans call openHelpDrawer("plans-worktrees")
+    click Review call openHelpDrawer("plans-worktrees")
+    click Manager call openHelpDrawer("roles")
+    click Verdict call openHelpDrawer("verdicts")
+    click Approve call openHelpDrawer("verdicts")
+    click PR call openHelpDrawer("verdicts")
+    click Reject call openHelpDrawer("verdicts")
+    click Skip call openHelpDrawer("verdicts")
+```
+
+`MermaidDiagram.svelte` exposes `openHelpDrawer` on `window` (or via a Mermaid `securityLevel: 'loose'` callback registry) so node clicks reach the drawer store.
+
+**Deliberate simplifications:**
+
+- Three teammates run concurrently but are drawn as one "Spawn 3 teammates" node, not three lanes — chosen for legibility. A second, more detailed diagram may be added under "Plans & worktrees" later.
+- The plan-review loop is shown as a single backedge.
+- Audit log writes are not on the chart.
+- Vision pipeline is not on the chart.
+
+## Contextual `?` drawer
+
+A reusable Svelte component `dashboard/frontend/src/components/help/HelpHint.svelte`:
+
+- Props: `section: string` — the help section anchor to open.
+- Renders a small (~12–14 px) `?` icon, low contrast at rest, slightly brighter on hover. Reuses the existing icon system (Lucide or whatever the dashboard uses; check `components/ui/`).
+- Sits *next to* the labelled element, not inside it, so it does not break existing badge/label layouts.
+- On click, calls `openHelpDrawer(section)` against the drawer store.
+
+### Drawer store
+
+`dashboard/frontend/src/lib/help-drawer.svelte.ts` — a small svelte rune store:
+
+```ts
+export const helpDrawer = $state<{ openSection: string | null }>({ openSection: null });
+export function openHelpDrawer(section: string) { helpDrawer.openSection = section; }
+export function closeHelpDrawer() { helpDrawer.openSection = null; }
+```
+
+### Drawer component
+
+`dashboard/frontend/src/components/help/HelpDrawer.svelte`, mounted once at the app root (sibling of `Shell` or inside it):
+
+- Watches `helpDrawer.openSection`.
+- Slides in from the right, ~480 px wide on desktop, full width on mobile.
+- Translucent backdrop closes the drawer on click. `Esc` also closes.
+- Header: section title + close button.
+- Body: a single `<HelpSection id={openSection} />`.
+- Footer: a "View full Help page →" link that closes the drawer and navigates to `/help#<openSection>`.
+- Only one drawer open at a time; opening a different `?` swaps content (no animation between).
+
+### `?` icon placements (v1)
+
+| Location | Component | Section linked |
+|---|---|---|
+| Verdict badges in run lists and Run Detail | `dashboard/frontend/src/components/badges/Verdict*.svelte` (or current location) | `verdicts` |
+| Role labels (`backend` / `frontend` / `qa` / `lead`) on Agent Teams Canvas | `pages/AgentTeamsCanvas.svelte` (header & legend area) | `roles` |
+| Role labels on Run Detail | `pages/RunDetail.svelte` | `roles` |
+| Plan-related blocks on Run Detail (the "Plan reviewed" / "Plan approved" UI) | `pages/RunDetail.svelte` | `plans-worktrees` |
+| Throttled / plan-tier indicator on Command Center | `pages/CommandCenter.svelte` | `throttling` |
+| Skipped-verdict and skip-label callouts wherever they appear | wherever surfaced (audit, run list) | `eligibility` |
+
+The implementer scans the existing components for these elements and adds `<HelpHint>` next to each. A short file-by-file checklist is part of the implementation plan.
+
+## File and component summary
+
+New files:
+
+- `dashboard/frontend/src/content/help/{run-lifecycle,roles,verdicts,eligibility,throttling,plans-worktrees,pages-tour,troubleshooting}.md`
+- `dashboard/frontend/src/components/help/HelpSection.svelte`
+- `dashboard/frontend/src/components/help/HelpHint.svelte`
+- `dashboard/frontend/src/components/help/HelpDrawer.svelte`
+- `dashboard/frontend/src/components/help/MermaidDiagram.svelte`
+- `dashboard/frontend/src/lib/help-drawer.svelte.ts`
+- `dashboard/frontend/src/pages/HelpPage.svelte`
+
+Modified files:
+
+- `dashboard/frontend/src/lib/router.svelte.ts` — add `'help'` to `Page`, route `/help` with optional anchor param.
+- `dashboard/frontend/src/App.svelte` — register the route, mount `<HelpDrawer>` once at the app root.
+- `dashboard/frontend/src/components/layout/Shell.svelte` (or the TopNav component it imports) — add Help nav item.
+- The components listed in the `?` icon placement table — each gains a `<HelpHint>` next to the relevant label.
+- `package.json` — add `mermaid`, and `marked` if no markdown renderer exists yet.
+
+## Behaviour and edge cases
+
+- `/help` with no anchor scrolls to the top.
+- `/help#<unknown>` falls back to scrolling to top; no error.
+- Opening the drawer with an unknown section logs a console warning (dev) and renders a fallback "Section not found" body. Should not happen in practice — `?` icons reference a closed set of section IDs.
+- Mermaid render failure (parser error) renders a fallback `<pre>` with the raw Mermaid source so the diagram is still readable.
+- The drawer traps focus while open and restores focus to the trigger `?` icon on close. Close button is keyboard-reachable.
+- The `?` icon has `aria-label="Help: <section title>"`.
+- The drawer is announced to screen readers (`role="dialog"`, `aria-modal="true"`, `aria-labelledby` on the header).
+
+## Testing
+
+- **Unit (Vitest):**
+  - `HelpSection` correctly splits on the `<!-- under-the-hood -->` marker; renders both layers; renders only TL;DR + how-it-works when the marker is absent.
+  - Mermaid block detection in `HelpSection` swaps fenced blocks for `<MermaidDiagram>`.
+  - Drawer store: `openHelpDrawer`, `closeHelpDrawer`, swapping sections.
+- **Component snapshot:** drawer markup with a representative section.
+- **Manual browser verification (mandatory before claiming done):**
+  - `/help` renders all 8 sections, sidebar anchors scroll correctly.
+  - The flowchart renders; clicking each labelled node opens the drawer with the right section.
+  - `<HelpHint>` placements: verify each entry in the placement table opens the right drawer section.
+  - "View full Help page →" link from the drawer navigates to `/help#<section>` and the section is in view.
+  - Esc and backdrop click close the drawer.
+  - Narrow viewport: sidebar collapses into the top dropdown.
+
+## Out of scope (v1)
+
+- Search across the Help content.
+- Per-page contextual `?` icons in nav tabs and page headers.
+- Hover tooltips with TL;DR previews (would be option 3 from brainstorming).
+- A second, parallel-lanes flowchart for the worktree-isolation story.
+- Vision pipeline section.
+- Plan-tier throttling implementation changes — the section only documents existing behaviour.
+
+## Open questions
+
+None — all decisions resolved during brainstorming.


### PR DESCRIPTION
## Summary
- Adds `/help` page with eight sections (run lifecycle, roles, verdicts, eligibility, throttling, plans & worktrees, page-by-page tour, troubleshooting), layered TL;DR / how-it-works / under-the-hood.
- Adds contextual `?` icon (`HelpHint`) on conceptually loaded UI: page-header verdict pill on Run Detail, Team Lead label on Agent Teams Canvas, plan-review block on Run Detail.
- Mermaid run-lifecycle flowchart with **clickable nodes** that open the same drawer.
- Drawer reuses the existing `SlidePanel` overlay; section content reuses `MarkdownRenderer` (marked + DOMPurify).

### Implementation note: Command Center `?` placement skipped
Spec called for `?` icons on throttle and skip indicators on Command Center. Discovery showed neither has a visible UI element on that page today. Per the design rule "do not add a hint where there is no labelled UI to attach it to," those hints were skipped. The flowchart node clicks and the full Help page still cover both concepts. Add the icons in a follow-up once that UI exists.

### Authored by team
This PR was implemented by a Claude Code Agent Teams session (`team-lead` + `content-writer` + `hint-wirer`) following the spec and plan committed earlier on `dev`.

## Test plan
- [x] `vitest run` — 37 tests pass (incl. 5 new for the markdown splitter)
- [x] `tsc --noEmit` clean (only pre-existing format.test errors)
- [x] `npm run build` succeeds
- [ ] **Manual browser verification (REQUIRED before merge):** see plan task 17 step 4 — load `/help`, click each flowchart node, verify each `?` icon opens the right drawer, theme toggle, narrow viewport, mermaid render-failure path

## Spec & plan
- Spec: `docs/superpowers/specs/2026-05-10-help-page-design.md`
- Plan: `docs/superpowers/plans/2026-05-10-help-page.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)