### PR TITLE
fix(help): resolve CSS vars for Mermaid theme

### DIFF
--- a/dashboard/frontend/src/components/help/MermaidDiagram.svelte
+++ b/dashboard/frontend/src/components/help/MermaidDiagram.svelte
@@ -19,6 +19,15 @@
     (window as unknown as { openHelpDrawer?: (s: string) => void }).openHelpDrawer = openHelpDrawer;
   }
 
+  // Resolve a CSS custom property to its computed color, falling back if
+  // the variable isn't defined. Mermaid's theme engine needs literal
+  // hex/rgb values — it cannot parse `var(--x)`.
+  function resolveColor(varName: string, fallback: string): string {
+    if (typeof window === 'undefined') return fallback;
+    const v = getComputedStyle(document.documentElement).getPropertyValue(varName).trim();
+    return v || fallback;
+  }
+
   onMount(() => {
     let cancelled = false;
 
@@ -31,10 +40,10 @@
           theme: 'base',
           securityLevel: 'loose',
           themeVariables: {
-            primaryColor: 'var(--color-surface-1, #1f2937)',
-            primaryTextColor: 'var(--color-text, #e5e7eb)',
-            primaryBorderColor: 'var(--color-border, #374151)',
-            lineColor: 'var(--color-border, #6b7280)',
+            primaryColor: resolveColor('--color-surface-1', '#1f2937'),
+            primaryTextColor: resolveColor('--color-text', '#e5e7eb'),
+            primaryBorderColor: resolveColor('--color-border', '#374151'),
+            lineColor: resolveColor('--color-border', '#6b7280'),
             fontFamily: 'inherit',
           },
         });

--- a/dashboard/frontend/src/components/help/MermaidDiagram.svelte
+++ b/dashboard/frontend/src/components/help/MermaidDiagram.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import { openHelpDrawer } from '../../lib/help-drawer.svelte';
+  import { appearance } from '../../lib/appearance.svelte';
 
   let { source }: { source: string } = $props();
 
-  let host: HTMLDivElement;
+  let host = $state<HTMLDivElement | null>(null);
   let error = $state<string | null>(null);
 
   // Mermaid `click <node> call openHelpDrawer("section")` directives need a
@@ -28,22 +28,35 @@
     return v || fallback;
   }
 
-  onMount(() => {
-    let cancelled = false;
+  // Re-render whenever the theme changes. Mermaid bakes themeVariables into
+  // the SVG at render time, so a `var(--x)` reference can't carry the
+  // toggle through; we resolve and re-render instead. The reactive read
+  // of `appearance.theme` is what wires this `$effect` to the rune.
+  $effect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    appearance.theme; // dependency
+    if (!host) return;
 
+    let cancelled = false;
     (async () => {
       try {
         const mermaid = (await import('mermaid')).default;
-        if (cancelled) return;
+        if (cancelled || !host) return;
         mermaid.initialize({
           startOnLoad: false,
           theme: 'base',
           securityLevel: 'loose',
           themeVariables: {
+            // Node fill: surface-1 (translucent, theme-matched).
             primaryColor: resolveColor('--color-surface-1', '#1f2937'),
-            primaryTextColor: resolveColor('--color-text', '#e5e7eb'),
-            primaryBorderColor: resolveColor('--color-border', '#374151'),
-            lineColor: resolveColor('--color-border', '#6b7280'),
+            // Node text: --color-primary (high-contrast text token).
+            primaryTextColor: resolveColor('--color-primary', '#e5e7eb'),
+            // Node border + edges: --color-primary again. The `--color-border`
+            // token is a 10% / 30% alpha rgba designed for subtle hairlines
+            // on glass surfaces — Mermaid edges need to be readable, so use
+            // the higher-contrast text token instead.
+            primaryBorderColor: resolveColor('--color-primary', '#374151'),
+            lineColor: resolveColor('--color-primary', '#6b7280'),
             fontFamily: 'inherit',
           },
         });
@@ -52,6 +65,7 @@
         if (cancelled || !host) return;
         host.innerHTML = svg;
         bindFunctions?.(host);
+        error = null;
       } catch (e) {
         if (cancelled) return;
         error = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
## Summary
Fixes "Diagram failed to render: Unsupported color format" on the Help page flowchart.

Mermaid's themeVariables engine doesn't understand CSS \`var()\` references — it expects literal hex/rgb. Resolve via \`getComputedStyle(document.documentElement)\` at render time so the diagram still tracks the active theme.

## Test plan
- [x] tsc clean
- [ ] Reload \`/help\` — flowchart renders, no error
- [ ] Toggle theme — flowchart re-renders correctly on next mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)