### PR TITLE
fix(agent): synthesize employee reports when teammates skip writing them

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1373,6 +1373,8 @@ def _synthesize_employee_report(
     workspace: str,
     base_branch: str,
     run_id: str,
+    project_mode: str,
+    issue_numbers: list[int],
 ) -> bool:
     """Best-effort fallback when a teammate exits without writing its own
     ``.claude-employee-report.json``.
@@ -1385,7 +1387,7 @@ def _synthesize_employee_report(
     in the worktree branches. To prevent that, this function inspects the
     role's worktree before the orchestrator tears it down and writes a
     minimal report carrying the fields the manager review pipeline needs:
-    branch, base_branch, files changed, commits.
+    branch, base_branch, files changed, commits, mode, issue number(s).
 
     Skipped silently if:
     - The teammate already wrote a report (don't clobber).
@@ -1425,9 +1427,18 @@ def _synthesize_employee_report(
         if not commits and not files:
             return False
 
+        # run-manager.sh reads `issue_number` (singular) for the manager
+        # review package. Use the run's first issue when there's exactly
+        # one; leave null otherwise so the manager doesn't see a misleading
+        # arbitrary pick. The full list lives under `issue_numbers` for
+        # any downstream consumer that needs the multi-issue context.
+        single_issue = issue_numbers[0] if len(issue_numbers) == 1 else None
+
         report = {
             "status": "success",
-            "mode": "full",
+            "mode": project_mode,
+            "issue_number": single_issue,
+            "issue_numbers": issue_numbers,
             "branch": branch,
             "base_branch": base_branch,
             "files_changed": files,
@@ -1921,6 +1932,15 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
             # see _synthesize_employee_report. Without this, run-manager.sh
             # skips manager review when teammates forget to write their own
             # report, even though commits exist on the worktree branches.
+            #
+            # ``issues`` may not be bound if the project loop short-circuited
+            # before issue selection (early exception, empty backlog ``continue``);
+            # default to an empty list so issue_number is left null rather
+            # than crashing the cleanup path.
+            try:
+                _issue_numbers = [int(i["number"]) for i in issues if "number" in i]
+            except NameError:
+                _issue_numbers = []
             for role, wt_path in worktree_paths.items():
                 _synthesize_employee_report(
                     role=role,
@@ -1928,6 +1948,8 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                     workspace=workspace,
                     base_branch=base_branch,
                     run_id=run_id,
+                    project_mode=project_mode,
+                    issue_numbers=_issue_numbers,
                 )
 
             # Clean up worktrees

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1364,6 +1364,103 @@ def _is_work_complete(result_text: str) -> bool:
     ])
 
 
+# ── Employee Report Fallback ──────────────────────────────────
+
+def _synthesize_employee_report(
+    *,
+    role: str,
+    wt_path: str,
+    workspace: str,
+    base_branch: str,
+    run_id: str,
+) -> bool:
+    """Best-effort fallback when a teammate exits without writing its own
+    ``.claude-employee-report.json``.
+
+    The Agent-Teams-mode prompt asks teammates to write per-role reports
+    under ``<workspace>/.claude-employee-report-<index>.json``. When they
+    skip that step, ``run-manager.sh`` finds nothing to review and emits
+    ``"No employee reports found. Skipping manager review"`` — the run
+    completes with no verdict, no push, no PR, even though commits exist
+    in the worktree branches. To prevent that, this function inspects the
+    role's worktree before the orchestrator tears it down and writes a
+    minimal report carrying the fields the manager review pipeline needs:
+    branch, base_branch, files changed, commits.
+
+    Skipped silently if:
+    - The teammate already wrote a report (don't clobber).
+    - The worktree path is missing (already removed).
+    - There are no commits and no diff vs. ``base_branch`` (no work done).
+
+    Returns True if a report file was written.
+    """
+    main_report = Path(workspace) / ".claude-employee-report.json"
+    indexed_report = Path(workspace) / f".claude-employee-report-{role}.json"
+    if main_report.exists() or indexed_report.exists():
+        return False
+    if not os.path.isdir(wt_path):
+        return False
+
+    try:
+        branch_proc = subprocess.run(
+            ["git", "-C", wt_path, "branch", "--show-current"],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+        branch = branch_proc.stdout.strip()
+        if not branch:
+            return False
+
+        commits_proc = subprocess.run(
+            ["git", "-C", wt_path, "log", "--format=%H", f"{base_branch}..HEAD"],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+        commits = [c for c in commits_proc.stdout.splitlines() if c.strip()]
+
+        files_proc = subprocess.run(
+            ["git", "-C", wt_path, "diff", "--name-only", f"{base_branch}..HEAD"],
+            capture_output=True, text=True, check=False, timeout=10,
+        )
+        files = [f for f in files_proc.stdout.splitlines() if f.strip()]
+
+        if not commits and not files:
+            return False
+
+        report = {
+            "status": "success",
+            "mode": "full",
+            "branch": branch,
+            "base_branch": base_branch,
+            "files_changed": files,
+            "commits": commits,
+            "tests_run": False,
+            "tests_passed": False,
+            "confidence": 0.5,
+            "confidence_reasoning": (
+                "Synthesized by orchestrator from worktree git state; the "
+                "teammate did not write its own report. Branch and commits "
+                "are real but tests/quality were not verified by the teammate."
+            ),
+            "notes": (
+                "This report was generated automatically by the orchestrator "
+                "as a fallback so the manager review can proceed. The "
+                "teammate exited without writing "
+                ".claude-employee-report.json."
+            ),
+            "synthesized_by": "orchestrator",
+            "role": role,
+            "run_id": run_id,
+        }
+        indexed_report.write_text(json.dumps(report, indent=2))
+        logger.info(
+            "Synthesized employee report for %s with %d commit(s) on %s",
+            role, len(commits), branch,
+        )
+        return True
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.warning("Failed to synthesize employee report for %s: %s", role, exc)
+        return False
+
+
 # ── Main Orchestration ─────────────────────────────────────────
 
 async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
@@ -1819,6 +1916,19 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                     await control_task
                 except (asyncio.CancelledError, Exception):
                     pass
+
+            # Synthesize fallback employee reports BEFORE removing worktrees:
+            # see _synthesize_employee_report. Without this, run-manager.sh
+            # skips manager review when teammates forget to write their own
+            # report, even though commits exist on the worktree branches.
+            for role, wt_path in worktree_paths.items():
+                _synthesize_employee_report(
+                    role=role,
+                    wt_path=wt_path,
+                    workspace=workspace,
+                    base_branch=base_branch,
+                    run_id=run_id,
+                )
 
             # Clean up worktrees
             for role, wt_path in worktree_paths.items():


### PR DESCRIPTION
## Summary
\`run-manager.sh\` decides whether to run manager review by globbing for \`.claude-employee-report*.json\` under each workspace. When teammates skip writing that file (which happens — the issue-worker prompt asks for it, but it isn't enforced), \`run-manager.sh\` reports "No employee reports found. Skipping manager review (saves session budget)" and the run completes with **no verdict, no push, no PR** even though commits exist on the worktree branches.

This change makes the orchestrator inspect each role's worktree before tearing it down and write a minimal fallback report (branch, base_branch, files_changed, commits) when the teammate didn't write its own. The manager review pipeline then has the signal it needs to do its job.

## Repro
Run \`run-20260510T150737Z\` on \`next-itsm\` (issue #15):
- Three real commits sat on local branches: \`3c9dc39\` (backend), \`b3b174b\` (frontend), \`5c2b71a\` (qa).
- Branches never pushed.
- DB row showed \`verdict: null\`, \`branch: null\`, \`tokens_total: null\`.
- Smoking gun in \`launcher.out\`: "No employee reports found. Skipping manager review."

Root: \`agent/scripts/run-manager.sh:2826\` looks for an artifact (\`.claude-employee-report.json\`) the post-2026-04 Agent Teams orchestrator never produces.

## Test plan
- [x] \`python3 -c "import ast; ast.parse(...)"\` — orchestrator parses
- [ ] Trigger a fresh run on \`next-itsm\` and observe a non-null verdict + branches pushed
- [ ] Re-trigger when a teammate genuinely produces no work (eligibility skip case): the synthesizer correctly skips with no diff vs. base

## Out of scope
The bundled CLI's \`error: Stream closed\` mid-run is a separate concern tracked in a follow-up PR — it doesn't break this fix's preconditions (the synthesizer is git-state driven, not hook-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)