### PR TITLE
fix(agent): surface hook-callback failures as webhook + grep marker

### DIFF
--- a/agent/audit_hook.py
+++ b/agent/audit_hook.py
@@ -47,6 +47,31 @@ EVENT_TYPE = "auto_mode_decision"
 # Truncation limit for stdout_tail / stderr_tail captured in audit_log rows.
 TAIL_LIMIT = 4_000
 
+# Count of pre/post hook callback failures since process start. The bundled
+# Claude CLI occasionally fails to deliver a hook callback to the Python
+# side mid-run ("error: Stream closed" emitted by cli.js sendRequest); when
+# that happens, the post_hook never runs and an audit_log row stays in
+# 'started' state forever. The orchestrator reads this counter at the end
+# of each project's session and surfaces the delta as a webhook event so
+# operators can spot affected runs without grepping launcher.out by hand.
+_HOOK_CB_FAILURE_COUNT = 0
+
+
+def get_hook_callback_failure_count() -> int:
+    """Return the process-lifetime count of pre/post hook callback failures."""
+    return _HOOK_CB_FAILURE_COUNT
+
+
+def _record_hook_failure(phase: str, run_id: str, exc: BaseException) -> None:
+    """Increment the failure counter and emit a grep-stable warning."""
+    global _HOOK_CB_FAILURE_COUNT
+    _HOOK_CB_FAILURE_COUNT += 1
+    # Stable prefix so operators can grep launcher.out for these.
+    logger.warning(
+        "[hook-cb-fail] phase=%s run_id=%s err=%s",
+        phase, run_id, exc,
+    )
+
 CanUseTool = Callable[
     [str, dict[str, Any], ToolPermissionContext],
     Awaitable[PermissionResultAllow | PermissionResultDeny],
@@ -357,7 +382,7 @@ def make_pre_tool_hook(
                     db_path=db_path,
                 )
         except Exception as exc:  # pragma: no cover — defensive
-            logger.warning("audit_hook: pre_hook error: %s", exc)
+            _record_hook_failure("pre", run_id, exc)
         return {}
 
     return pre_hook
@@ -365,7 +390,7 @@ def make_pre_tool_hook(
 
 def make_post_tool_hook(
     *,
-    run_id: str,  # noqa: ARG001 — kept for symmetry / future use
+    run_id: str,
     actor: str = "lead",  # noqa: ARG001
     db_path: str | None = None,
 ):
@@ -385,7 +410,7 @@ def make_post_tool_hook(
                     db_path=db_path,
                 )
         except Exception as exc:  # pragma: no cover — defensive
-            logger.warning("audit_hook: post_hook error: %s", exc)
+            _record_hook_failure("post", run_id, exc)
         return {}
 
     return post_hook

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -44,6 +44,7 @@ from claude_agent_sdk.types import (
 from sqlalchemy import select
 
 from agent.audit_hook import (
+    get_hook_callback_failure_count,
     make_audited_policy,
     make_post_tool_hook,
     make_pre_tool_hook,
@@ -1543,6 +1544,11 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
         workspace = os.path.join(workspaces_dir, repo_name)
         project_branch = project.get("branch") or "main"
 
+        # Snapshot the hook-callback failure counter so we can compute the
+        # per-project delta in the finally block and surface it to the
+        # operator. See agent/audit_hook.py for context.
+        hook_cb_failures_baseline = get_hook_callback_failure_count()
+
         # Refresh the workspace to the tip of the project's default branch
         # before deciding eligibility. Without this, persistent compose
         # volumes keep stale checkouts that hide newly-committed
@@ -1927,6 +1933,25 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                     await control_task
                 except (asyncio.CancelledError, Exception):
                     pass
+
+            # Surface hook-callback failures for this project's session.
+            # The bundled CLI sometimes drops mid-run with "error: Stream
+            # closed", which leaves audit rows stuck in 'started' state and
+            # can lose can_use_tool decisions. Posting the count as a webhook
+            # event lets the operator see affected runs without grepping
+            # launcher.out by hand.
+            hook_cb_failures = get_hook_callback_failure_count() - hook_cb_failures_baseline
+            if hook_cb_failures > 0:
+                logger.warning(
+                    "[hook-cb-fail] run_id=run-%s project=%s total_failures=%d "
+                    "(post_hook never updated some audit_log rows)",
+                    run_id, repo, hook_cb_failures,
+                )
+                post_webhook(config, "hook_failures", {
+                    "run_id": f"run-{run_id}",
+                    "project": repo,
+                    "count": hook_cb_failures,
+                })
 
             # Synthesize fallback employee reports BEFORE removing worktrees:
             # see _synthesize_employee_report. Without this, run-manager.sh

--- a/dashboard/backend/app/routers/webhook.py
+++ b/dashboard/backend/app/routers/webhook.py
@@ -116,6 +116,22 @@ async def receive_run_event(
             }),
         ))
 
+    elif event_name == "hook_failures":
+        # Posted by the orchestrator when the bundled CLI's hook callback
+        # to Python fails mid-run (see agent/audit_hook.py). Persist as an
+        # AgentEvent so dashboard queries can count affected runs without
+        # operators grepping launcher.out by hand.
+        db.add(AgentEvent(
+            workflow_id=f"trace-{event.run_id}",
+            run_id=event.run_id,
+            agent_id=event.agent_id or "lead",
+            event_type="hook_callback_failure",
+            event_data=json.dumps({
+                "project": event.project,
+                "count": event.count,
+            }),
+        ))
+
     else:
         run = await run_lifecycle.handle_unknown(db, event, project_id, run)
 

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -357,6 +357,11 @@ class WebhookRunEvent(BaseModel):
     # Vision misalignment fields
     violated_section: str | None = None
     quote: str | None = None
+    # Hook-callback failure surface — count of pre/post hook callback failures
+    # observed during one project's session (see agent/audit_hook.py). Posted
+    # by the orchestrator when nonzero so operators can spot SDK stream-close
+    # incidents from Mission Control instead of grepping launcher.out.
+    count: int | None = None
     plan_excerpt: str | None = None
     # Narration ("The Bridge" Phase 1): one-sentence present-tense intent
     # statements the agent emits before tool calls so the operator never

--- a/dashboard/backend/tests/test_webhook_hook_failures.py
+++ b/dashboard/backend/tests/test_webhook_hook_failures.py
@@ -1,0 +1,101 @@
+"""Tests for hook_failures webhook event persistence.
+
+The orchestrator posts a `hook_failures` event when the bundled Claude CLI's
+hook callback to Python fails mid-run (see agent/audit_hook.py). The webhook
+router persists each event as an AgentEvent row with
+event_type='hook_callback_failure'.
+"""
+
+import json
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import Base, async_session, engine
+from app.main import app
+from app.models import AgentEvent
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_hook_failures_persists_to_agent_events(client):
+    r = await client.post("/api/webhook/run-event", json={
+        "event": "hook_failures",
+        "run_id": "run-hook-001",
+        "project": "owner/repo",
+        "count": 3,
+    })
+    assert r.status_code in (200, 202)
+
+    async with async_session() as db:
+        rows = (
+            await db.execute(
+                select(AgentEvent).where(AgentEvent.event_type == "hook_callback_failure")
+            )
+        ).scalars().all()
+
+    assert len(rows) == 1
+    assert rows[0].run_id == "run-hook-001"
+    data = json.loads(rows[0].event_data)
+    assert data["project"] == "owner/repo"
+    assert data["count"] == 3
+
+
+@pytest.mark.asyncio
+async def test_hook_failures_agent_id_defaults_to_lead(client):
+    r = await client.post("/api/webhook/run-event", json={
+        "event": "hook_failures",
+        "run_id": "run-hook-002",
+        "project": "owner/repo",
+        "count": 1,
+    })
+    assert r.status_code in (200, 202)
+
+    async with async_session() as db:
+        rows = (
+            await db.execute(
+                select(AgentEvent).where(AgentEvent.run_id == "run-hook-002")
+            )
+        ).scalars().all()
+
+    assert len(rows) == 1
+    assert rows[0].agent_id == "lead"
+
+
+@pytest.mark.asyncio
+async def test_hook_failures_count_is_optional(client):
+    """A payload without an explicit count should still persist; count=None."""
+    r = await client.post("/api/webhook/run-event", json={
+        "event": "hook_failures",
+        "run_id": "run-hook-003",
+        "project": "owner/repo",
+    })
+    assert r.status_code in (200, 202)
+
+    async with async_session() as db:
+        rows = (
+            await db.execute(
+                select(AgentEvent).where(AgentEvent.run_id == "run-hook-003")
+            )
+        ).scalars().all()
+
+    assert len(rows) == 1
+    data = json.loads(rows[0].event_data)
+    assert data["count"] is None


### PR DESCRIPTION
## Summary
Visibility patch for SDK \`error: Stream closed\` failures the bundled CLI emits mid-run. Previously these silently swallowed audit-log updates and \`can_use_tool\` decisions; the operator learned only by grepping \`launcher.out\` by hand.

- \`agent/audit_hook.py\` grows a process-lifetime counter and a stable warning prefix \`[hook-cb-fail]\` carrying phase + run_id.
- \`agent/station_orchestrator.py\` snapshots the counter at each project entry, computes the per-project delta in cleanup, and when > 0 posts a \`hook_failures\` webhook event the dashboard already records.

## What this is *not*
Not a fix for the underlying CLI/SDK stream-close bug. The 30-min \`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT\` already set in \`agent/launcher.py:196\` is not enough on its own — needs a separate investigation. This PR just stops the failures from being silent so we can spot affected runs.

## Repro source
\`run-20260510T150737Z\`'s \`launcher.out\` had multiple \`error: Stream closed\` entries that were not surfaced anywhere in the dashboard.

## Test plan
- [x] \`python3 -c 'import ast; ast.parse(...)'\` clean for both files
- [ ] After deploy, trigger a run and confirm a \`hook_failures\` webhook lands when the CLI throws Stream closed; verify zero noise on healthy runs
- [ ] \`grep '\[hook-cb-fail\]' /var/log/claude-agent/launcher.out\` shows phase + run_id for each failure

## Related
Companion PR #332 fixes the actual blocker (no manager review when teammates skip writing reports). This PR is the observability layer for the failure mode that *might* be contributing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)