### PR TITLE
feat(integration): integration tab + per-project promotion target

### DIFF
--- a/agent/scripts/promote.sh
+++ b/agent/scripts/promote.sh
@@ -205,10 +205,14 @@ for (( i=0; i<project_count; i++ )); do
     fi
 
     base_branch=$(get_project_field "$i" "branch" 2>/dev/null || echo "main")
+    # promotion_target = where the integration meta-PR is opened.
+    # Falls back to base_branch (the project trunk) when unset.
+    promotion_target=$(get_project_field "$i" "promotion_target" 2>/dev/null || echo "")
+    [ -z "$promotion_target" ] && promotion_target="$base_branch"
     setup_script=$(get_project_field "$i" "setup_script" 2>/dev/null || echo "")
     strategy="${STRATEGY_OVERRIDE:-$(json_get "$CONFIG_FILE" "integration.promotion_strategy" 2>/dev/null || echo "batch")}"
 
-    log_info "--- Processing $project (base=$base_branch, strategy=$strategy) ---"
+    log_info "--- Processing $project (base=$base_branch, promotion_target=$promotion_target, strategy=$strategy) ---"
 
     # Ensure workspace exists
     name=$(repo_name "$project")
@@ -218,8 +222,10 @@ for (( i=0; i<project_count; i++ )); do
         continue
     fi
 
-    # Sync dev branch with main before any operation
-    if ! sync_dev_with_main "$project" "$base_branch"; then
+    # Sync dev branch with the promotion target before any operation.
+    # Rebasing onto promotion_target keeps the meta-PR diff minimal
+    # (only the agent's commits, not unrelated trunk drift).
+    if ! sync_dev_with_main "$project" "$promotion_target"; then
         log_warn "Sync failed for $project, skipping"
         overall_exit=1
         continue
@@ -238,7 +244,7 @@ for (( i=0; i<project_count; i++ )); do
 
     # --- Promote (if mode requires it) ---
     if [ "$MODE" = "validate-and-promote" ] || [ "$MODE" = "promote-only" ]; then
-        if promote_to_main "$project" "$base_branch" "$strategy"; then
+        if promote_to_main "$project" "$promotion_target" "$strategy"; then
             log_ok "Promotion complete for $project"
         else
             log_error "Promotion failed for $project"

--- a/dashboard/backend/app/database.py
+++ b/dashboard/backend/app/database.py
@@ -97,6 +97,9 @@ async def _migrate_add_columns(conn) -> None:
         ("runs", "vision_bootstrap_count", "ALTER TABLE runs ADD COLUMN vision_bootstrap_count INTEGER"),
         ("runs", "vision_bootstrap_proposals", "ALTER TABLE runs ADD COLUMN vision_bootstrap_proposals TEXT"),
         ("projects", "last_vision_analyzed_sha", "ALTER TABLE projects ADD COLUMN last_vision_analyzed_sha TEXT"),
+        # Per-project promotion target for the integration meta-PR.
+        # NULL = fall back to projects.branch.
+        ("projects", "promotion_target", "ALTER TABLE projects ADD COLUMN promotion_target TEXT"),
     ]
     # `table` and `sql` below are hardcoded literals from the migrations tuple
     # list above; PRAGMA + ALTER TABLE do not support bound parameters for

--- a/dashboard/backend/app/models.py
+++ b/dashboard/backend/app/models.py
@@ -23,6 +23,9 @@ class Project(Base):
     mode = Column(Text, default="full")
     enabled = Column(Boolean, default=True)
     branch = Column(Text, default="main")
+    # Promotion target for the long-lived integration branch's meta-PR.
+    # NULL means fall back to ``branch``.
+    promotion_target = Column(Text, nullable=True, default=None)
     custom_instructions = Column(Text, nullable=True, default=None)
     setup_script = Column(Text, nullable=True, default=None)
     security_review_enabled = Column(Boolean, default=False)

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -16,6 +16,7 @@ class ProjectCreate(BaseModel):
     mode: str = "full"
     enabled: bool = True
     branch: str = "main"
+    promotion_target: str | None = None
     custom_instructions: str | None = None
     setup_script: str | None = None
     security_review_enabled: bool = False
@@ -29,6 +30,7 @@ class ProjectUpdate(BaseModel):
     mode: str | None = None
     enabled: bool | None = None
     branch: str | None = None
+    promotion_target: str | None = None
     custom_instructions: str | None = None
     setup_script: str | None = None
     security_review_enabled: bool | None = None
@@ -44,6 +46,7 @@ class ProjectOut(BaseModel):
     mode: str
     enabled: bool
     branch: str
+    promotion_target: str | None = None
     custom_instructions: str | None = None
     setup_script: str | None = None
     security_review_enabled: bool = False

--- a/dashboard/backend/app/services/config_sync.py
+++ b/dashboard/backend/app/services/config_sync.py
@@ -72,6 +72,9 @@ async def sync_config_to_db(db: AsyncSession) -> int:
             existing.mode = proj_data.get("mode", existing.mode)
             existing.enabled = proj_data.get("enabled", True)
             existing.branch = proj_data.get("branch", existing.branch or "main")
+            existing.promotion_target = proj_data.get(
+                "promotion_target", existing.promotion_target
+            )
             existing.custom_instructions = proj_data.get(
                 "custom_instructions", existing.custom_instructions
             )
@@ -88,6 +91,7 @@ async def sync_config_to_db(db: AsyncSession) -> int:
                 mode=proj_data.get("mode", "full"),
                 enabled=proj_data.get("enabled", True),
                 branch=proj_data.get("branch", "main"),
+                promotion_target=proj_data.get("promotion_target"),
                 custom_instructions=proj_data.get("custom_instructions"),
                 setup_script=proj_data.get("setup_script"),
                 security_review_enabled=proj_data.get("security_review_enabled", False),
@@ -114,6 +118,7 @@ async def sync_db_to_config(db: AsyncSession) -> None:
             "mode": p.mode,
             **({"enabled": p.enabled} if not p.enabled else {}),
             **({"branch": p.branch} if p.branch != "main" else {}),
+            **({"promotion_target": p.promotion_target} if p.promotion_target else {}),
             **({"custom_instructions": p.custom_instructions} if p.custom_instructions else {}),
             **({"setup_script": p.setup_script} if p.setup_script else {}),
             **({"security_review_enabled": True} if p.security_review_enabled else {}),

--- a/dashboard/backend/tests/test_config_sync.py
+++ b/dashboard/backend/tests/test_config_sync.py
@@ -252,3 +252,120 @@ async def test_sync_db_to_config_includes_disabled(setup_db, tmp_path):
     assert len(written["projects"]) == 1
     assert written["projects"][0]["repo"] == "owner/disabled"
     assert written["projects"][0].get("enabled") is False
+
+
+# ---------------------------------------------------------------------------
+# promotion_target round-trip (PR #341)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_sync_config_to_db_reads_promotion_target(setup_db):
+    """JSON promotion_target is persisted to the DB column."""
+    config = {
+        "projects": [
+            {"repo": "owner/with-target", "branch": "main", "promotion_target": "dev"},
+        ]
+    }
+    with patch("app.services.config_sync._read_config_json", return_value=config):
+        async with async_session() as session:
+            await sync_config_to_db(session)
+
+    async with async_session() as session:
+        from sqlalchemy import select
+        result = await session.execute(select(Project).where(Project.repo == "owner/with-target"))
+        project = result.scalar_one()
+        assert project.promotion_target == "dev"
+
+
+@pytest.mark.asyncio
+async def test_sync_config_to_db_missing_promotion_target_is_null(setup_db):
+    """When JSON omits promotion_target, the DB column is NULL (fall back to branch)."""
+    config = {"projects": [{"repo": "owner/no-target", "branch": "main"}]}
+    with patch("app.services.config_sync._read_config_json", return_value=config):
+        async with async_session() as session:
+            await sync_config_to_db(session)
+
+    async with async_session() as session:
+        from sqlalchemy import select
+        result = await session.execute(select(Project).where(Project.repo == "owner/no-target"))
+        project = result.scalar_one()
+        assert project.promotion_target is None
+
+
+@pytest.mark.asyncio
+async def test_sync_db_to_config_writes_promotion_target(setup_db, tmp_path):
+    """sync_db_to_config emits promotion_target only when set."""
+    async with async_session() as session:
+        session.add(Project(
+            repo="owner/with-target", priority="medium", mode="full",
+            enabled=True, branch="main", promotion_target="dev",
+        ))
+        session.add(Project(
+            repo="owner/no-target", priority="medium", mode="full",
+            enabled=True, branch="main", promotion_target=None,
+        ))
+        await session.commit()
+
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps({"projects": []}))
+
+    with patch("app.services.config_sync.settings") as mock_settings:
+        mock_settings.config_path = str(config_file)
+        async with async_session() as session:
+            await sync_db_to_config(session)
+
+    written = json.loads(config_file.read_text())
+    by_repo = {p["repo"]: p for p in written["projects"]}
+
+    assert by_repo["owner/with-target"]["promotion_target"] == "dev"
+    # Unset target is omitted entirely (consistent with branch/custom_instructions)
+    assert "promotion_target" not in by_repo["owner/no-target"]
+
+
+@pytest.mark.asyncio
+async def test_promotion_target_round_trip(setup_db, tmp_path):
+    """A full JSON -> DB -> JSON cycle preserves promotion_target."""
+    starting = {
+        "projects": [
+            {"repo": "owner/round-trip", "branch": "main", "promotion_target": "dev"},
+        ]
+    }
+    config_file = tmp_path / "config.json"
+    config_file.write_text(json.dumps(starting))
+
+    with patch("app.services.config_sync.settings") as mock_settings, \
+         patch("app.services.config_sync._read_config_json", return_value=starting):
+        mock_settings.config_path = str(config_file)
+        async with async_session() as session:
+            await sync_config_to_db(session)
+            await sync_db_to_config(session)
+
+    rewritten = json.loads(config_file.read_text())
+    assert rewritten["projects"][0]["promotion_target"] == "dev"
+
+
+@pytest.mark.asyncio
+async def test_sync_config_to_db_updates_promotion_target(setup_db):
+    """Re-syncing JSON with a new promotion_target updates the existing row."""
+    async with async_session() as session:
+        session.add(Project(
+            repo="owner/update-target", priority="medium", mode="full",
+            enabled=True, branch="main", promotion_target="dev",
+        ))
+        await session.commit()
+
+    # Re-sync with a different target
+    config = {
+        "projects": [
+            {"repo": "owner/update-target", "branch": "main", "promotion_target": "staging"},
+        ]
+    }
+    with patch("app.services.config_sync._read_config_json", return_value=config):
+        async with async_session() as session:
+            await sync_config_to_db(session)
+
+    async with async_session() as session:
+        from sqlalchemy import select
+        result = await session.execute(select(Project).where(Project.repo == "owner/update-target"))
+        project = result.scalar_one()
+        assert project.promotion_target == "staging"

--- a/dashboard/backend/tests/test_projects.py
+++ b/dashboard/backend/tests/test_projects.py
@@ -199,6 +199,50 @@ async def test_project_defaults_to_assisted(client, sample_project):
     assert data["max_budget_usd"] is None
 
 
+# --- promotion_target (PR #341) ---
+
+@pytest.mark.asyncio
+@patch("app.routers.projects.sync_db_to_config", new_callable=AsyncMock)
+async def test_create_project_with_promotion_target(mock_sync, client):
+    """POST /api/projects accepts and persists promotion_target."""
+    resp = await client.post("/api/projects", json={
+        "repo": "owner/with-target",
+        "branch": "main",
+        "promotion_target": "dev",
+    })
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["branch"] == "main"
+    assert data["promotion_target"] == "dev"
+
+
+@pytest.mark.asyncio
+async def test_promotion_target_defaults_to_null(client, sample_project):
+    """promotion_target is NULL when unset (signals fall-back to branch)."""
+    resp = await client.get(f"/api/projects/{sample_project.id}")
+    assert resp.status_code == 200
+    assert resp.json()["promotion_target"] is None
+
+
+@pytest.mark.asyncio
+@patch("app.routers.projects.sync_db_to_config", new_callable=AsyncMock)
+async def test_update_project_sets_and_clears_promotion_target(mock_sync, client, sample_project):
+    """PUT can set promotion_target and later clear it back to NULL."""
+    # Set
+    resp = await client.put(f"/api/projects/{sample_project.id}", json={
+        "promotion_target": "dev",
+    })
+    assert resp.status_code == 200
+    assert resp.json()["promotion_target"] == "dev"
+
+    # Clear (None falls back to branch behaviour)
+    resp = await client.put(f"/api/projects/{sample_project.id}", json={
+        "promotion_target": None,
+    })
+    assert resp.status_code == 200
+    assert resp.json()["promotion_target"] is None
+
+
 # --- Delete project ---
 
 @pytest.mark.asyncio

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -36,6 +36,7 @@ export interface Project {
   mode: AgentMode;
   enabled: boolean;
   branch: string;
+  promotion_target: string | null;
   custom_instructions: string | null;
   setup_script: string | null;
   security_review_enabled: boolean;
@@ -51,6 +52,7 @@ export interface ProjectCreate {
   mode?: AgentMode;
   enabled?: boolean;
   branch?: string;
+  promotion_target?: string | null;
   custom_instructions?: string;
   setup_script?: string;
   security_review_enabled?: boolean;

--- a/dashboard/frontend/src/pages/ProjectDetail.svelte
+++ b/dashboard/frontend/src/pages/ProjectDetail.svelte
@@ -314,6 +314,9 @@
               <h3>Project Snapshot</h3>
               <div class="key-row"><span class="key-label">Repo</span><span class="val">{project.repo}</span></div>
               <div class="key-row"><span class="key-label">Branch</span><span class="val">{project.branch}</span></div>
+              {#if project.promotion_target}
+                <div class="key-row"><span class="key-label">Promotion target</span><span class="val">{project.promotion_target}</span></div>
+              {/if}
               <div class="key-row"><span class="key-label">Mode</span><span class="val">{project.mode}</span></div>
               <div class="key-row"><span class="key-label">Autonomy</span><span class="val">{project.autonomy_level}</span></div>
               <div class="key-row">
@@ -356,6 +359,24 @@
                     value={project.branch}
                     onchange={(e) => { project!.branch = (e.currentTarget as HTMLInputElement).value; save('branch', project!.branch); }}
                   />
+                </span>
+              </div>
+              <div class="key-row">
+                <span class="key-label">Promotion target</span>
+                <span class="val">
+                  <input
+                    data-testid="project-promotion-target"
+                    placeholder="(defaults to branch)"
+                    value={project.promotion_target ?? ''}
+                    onchange={(e) => {
+                      const v = (e.currentTarget as HTMLInputElement).value.trim();
+                      project!.promotion_target = v || null;
+                      save('promotion_target', project!.promotion_target);
+                    }}
+                  />
+                  <small style="color: var(--graphite); display: block; margin-top: 4px;">
+                    Branch the integration meta-PR opens against. Leave empty to fall back to <code>{project.branch}</code>.
+                  </small>
                 </span>
               </div>
               <div class="key-row">

--- a/dashboard/frontend/src/pages/SettingsPage.svelte
+++ b/dashboard/frontend/src/pages/SettingsPage.svelte
@@ -17,7 +17,7 @@
   let { tab = null }: { tab?: string | null } = $props();
 
   // ── Tabs ─────────────────────────────────────────────
-  const TAB_ORDER = ['general', 'models', 'auth', 'github', 'prompts', 'audit', 'appearance'] as const;
+  const TAB_ORDER = ['general', 'models', 'auth', 'github', 'integration', 'prompts', 'audit', 'appearance'] as const;
   type TabKey = typeof TAB_ORDER[number];
 
   // Map legacy/historical tab names so old deep-links keep working.
@@ -497,6 +497,7 @@
           {#if t === 'models'}<span class="meta">5 roles</span>
           {:else if t === 'auth'}<span class="meta">{authStatus?.logged_in && !authStatus?.expired ? 'OAuth' : 'off'}</span>
           {:else if t === 'github'}<span class="meta">{githubStatus?.pat_set ? 'PAT' : (githubStatus?.state === 'installed' ? 'App' : 'off')}</span>
+          {:else if t === 'integration'}<span class="meta">{config?.integration?.enabled ? 'on' : 'off'}</span>
           {:else if t === 'prompts'}<span class="meta">{promptCount}</span>
           {:else if t === 'audit'}<span class="meta">{auditDecisionCount} / 30d</span>
           {/if}
@@ -955,6 +956,105 @@
                 </div>
               </div>
             {/if}
+          </div>
+        </section>
+
+      <!-- INTEGRATION ─────────────────────────────────── -->
+      {:else if activeTab === 'integration'}
+        <section class="tab-pane active" data-testid="integration-tab">
+          <div class="card-block">
+            <h3>Integration Branch</h3>
+            <p class="desc" style="margin: 0 0 12px 0;">
+              When enabled, agent work for each project lands on a long-lived integration branch
+              (e.g. <code>claude-agent-station</code>). A single meta-PR consolidates that work into
+              each project's promotion target (configured per-project on the Projects page).
+            </p>
+
+            <div class="key-row">
+              <label for="int-enabled" class="lbl">Enabled</label>
+              <div class="val">
+                <input
+                  id="int-enabled"
+                  type="checkbox"
+                  data-testid="integration-enabled"
+                  checked={!!config?.integration?.enabled}
+                  onchange={(e) => saveConfig('integration', { ...(config.integration ?? {}), enabled: (e.target as HTMLInputElement).checked })}
+                />
+                <span class="desc">turn on the integration-branch flow for all projects</span>
+              </div>
+            </div>
+
+            <div class="key-row">
+              <label for="int-dev-branch" class="lbl">Integration branch</label>
+              <div class="val">
+                <input
+                  id="int-dev-branch"
+                  type="text"
+                  data-testid="integration-dev-branch"
+                  placeholder="autonomous/dev"
+                  value={config?.integration?.dev_branch ?? ''}
+                  onchange={(e) => saveConfig('integration', { ...(config.integration ?? {}), dev_branch: (e.target as HTMLInputElement).value.trim() || 'autonomous/dev' })}
+                />
+                <span class="desc">branch name in each target repo (default <code>autonomous/dev</code>)</span>
+              </div>
+            </div>
+
+            <div class="key-row">
+              <label for="int-strategy" class="lbl">Promotion strategy</label>
+              <div class="val">
+                <select
+                  id="int-strategy"
+                  data-testid="integration-strategy"
+                  value={config?.integration?.promotion_strategy ?? 'batch'}
+                  onchange={(e) => saveConfig('integration', { ...(config.integration ?? {}), promotion_strategy: (e.target as HTMLSelectElement).value })}
+                >
+                  <option value="batch">batch — one PR with all features</option>
+                  <option value="individual">individual — one PR per feature</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="key-row">
+              <label for="int-auto-validate" class="lbl">Auto-validate</label>
+              <div class="val">
+                <input
+                  id="int-auto-validate"
+                  type="checkbox"
+                  data-testid="integration-auto-validate"
+                  checked={config?.integration?.auto_validate !== false}
+                  onchange={(e) => saveConfig('integration', { ...(config.integration ?? {}), auto_validate: (e.target as HTMLInputElement).checked })}
+                />
+                <span class="desc">run the project's test suite on the integration branch after each merge</span>
+              </div>
+            </div>
+
+            <div class="key-row">
+              <label for="int-auto-promote" class="lbl">Auto-promote</label>
+              <div class="val">
+                <input
+                  id="int-auto-promote"
+                  type="checkbox"
+                  data-testid="integration-auto-promote"
+                  checked={!!config?.integration?.auto_promote}
+                  onchange={(e) => saveConfig('integration', { ...(config.integration ?? {}), auto_promote: (e.target as HTMLInputElement).checked })}
+                />
+                <span class="desc">open the meta-PR automatically once validation passes</span>
+              </div>
+            </div>
+
+            <div class="key-row">
+              <label for="int-auto-bisect" class="lbl">Auto-bisect</label>
+              <div class="val">
+                <input
+                  id="int-auto-bisect"
+                  type="checkbox"
+                  data-testid="integration-auto-bisect"
+                  checked={config?.integration?.auto_bisect !== false}
+                  onchange={(e) => saveConfig('integration', { ...(config.integration ?? {}), auto_bisect: (e.target as HTMLInputElement).checked })}
+                />
+                <span class="desc">revert the last merge if validation breaks the integration branch</span>
+              </div>
+            </div>
           </div>
         </section>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,7 +148,8 @@ Examples: `analyze + auto` runs read-only investigation without any approval pro
 | `priority` | string | `"medium"` | Scheduling priority: `high`, `medium`, or `low`. |
 | `mode` | string | `"full"` | Project mode — see [Project mode](#project-mode) below. |
 | `enabled` | boolean | `true` | Whether the project is picked up by the scheduler. |
-| `branch` | string | `"main"` | Default branch the agent targets. |
+| `branch` | string | `"main"` | Default branch the agent targets (the project trunk). |
+| `promotion_target` | string\|null | _(none)_ | Branch the integration meta-PR opens against. When unset, falls back to `branch`. See [Integration branch](#integration-branch). |
 | `custom_instructions` | string | _(none)_ | Extra instructions appended to the agent prompt for this project. |
 | `setup_script` | string | _(none)_ | Single command run before each agent run (e.g. `npm install`). Must not contain shell metacharacters and is capped at 1024 characters; for richer setup, commit a script to the repo and reference its path here. |
 | `security_review_enabled` | boolean | `false` | Whether a security review pass is added to the agent's workflow. |
@@ -233,6 +234,47 @@ When a project has `docs/vision.md`, two automatic triggers fire the vision anal
 - **Trigger B (vision commit):** committing a new vision via the dashboard fires the analyst when the document SHA changes. Idempotent on identical re-commits via `Project.last_vision_analyzed_sha`.
 
 Both produce `Run.mode = vision-bootstrap` rows that surface in the Runs list and Mission Control. Issues land with the `vision-suggested` label; remove the label to accept (the orchestrator's `SKIP_LABELS` blocks autonomous implementation until then).
+
+## Integration branch
+
+When `integration.enabled` is true, each project gets a long-lived integration branch
+(`integration.dev_branch`, default `autonomous/dev`). Agent work that earns an
+`APPROVE` verdict is merged into that branch instead of being PR'd to the trunk one
+feature at a time. The integration branch is later promoted into the project's
+`promotion_target` (or `branch`, if no target is set) via a single meta-PR opened by
+`agent/scripts/promote.sh`.
+
+### Top-level config (`manager-config.json`)
+
+These keys live under `integration.*` and apply to every project:
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Turns on the integration-branch flow. |
+| `dev_branch` | string | `"autonomous/dev"` | Branch name created in each target repo (e.g. `claude-agent-station`). |
+| `promotion_strategy` | string | `"batch"` | `batch` opens one meta-PR with N commits; `individual` opens one PR per cherry-picked commit. |
+| `auto_validate` | boolean | `true` | Run the project's test suite on the integration branch after each merge (`agent/scripts/integration-branch.sh::validate_dev`). |
+| `auto_promote` | boolean | `false` | When validation passes, open the meta-PR automatically. |
+| `auto_bisect` | boolean | `true` | If validation fails, revert the last merge on the integration branch to identify the culprit. |
+
+These can also be edited in **Settings → Integration**, which writes through the same
+`PUT /api/config` endpoint.
+
+### Per-project `promotion_target`
+
+`promotion_target` is the PR base used when the integration branch is promoted. When
+unset, the meta-PR opens against the project's `branch` field. Typical setup:
+
+- `branch: "main"` — the project trunk (also used as the initial base when first
+  creating the integration branch and as the conceptual source-of-truth).
+- `promotion_target: "dev"` — where the integration meta-PR opens. Keeps `main`
+  protected and lets the user promote `dev → main` separately.
+
+`promote.sh` also rebases the integration branch onto `promotion_target` before
+opening the meta-PR, so the PR diff contains only the agent's commits — not unrelated
+trunk drift.
+
+Edit per-project in **Projects → Settings → Promotion target**.
 
 ## Conflict resolution
 


### PR DESCRIPTION
## Summary
- Adds a **Settings → Integration** tab so the long-lived integration branch flow can be configured from the dashboard (no more editing `manager-config.json` by hand).
- Adds a per-project **`promotion_target`** field — the branch the integration meta-PR opens against. Falls back to `branch` when unset.
- `promote.sh` rebases the integration branch onto `promotion_target` before opening the meta-PR, so the diff stays minimal (only the agent's commits, not trunk drift).

## Why
Run #330 skipped because there were no eligible issues, but the open PR (#600 in `laboef1900/ai-kb-creator`) flagged a UX gap: integration mode was technically supported in code but only via the on-disk JSON config — there was no UI to turn it on, and no way to point a project's meta-PR at `dev` while keeping `branch = main`.

## Changes
- **DB**: `projects.promotion_target TEXT NULL` (migration runs on backend startup).
- **Backend**: schemas, projects router, `services/config_sync.py` carry `promotion_target` through JSON↔DB sync.
- **Agent**: `agent/scripts/promote.sh` reads `promotion_target`, uses it for both sync and meta-PR base.
- **Frontend**: new Integration tab in `SettingsPage.svelte`; `promotion_target` input on `ProjectDetail.svelte`.
- **Docs**: `docs/configuration.md` — new "Integration branch" section and `promotion_target` row in the project table.

## Test plan
- [ ] Run backend, confirm `_migrate_add_columns` adds `projects.promotion_target`.
- [ ] Open Settings → Integration, toggle `enabled`, set `dev_branch = claude-agent-station`, save.
- [ ] Open a project's detail page, set `promotion_target = dev`, save → reload, value persists.
- [ ] `GET /api/projects/:id` returns the new field; `GET /api/config` returns `integration`.
- [ ] Inspect `manager-config.json` — `projects[].promotion_target` and top-level `integration` are written.
- [ ] On a sandbox repo with `integration.enabled = true`, trigger a Full run, let an APPROVE merge into the integration branch, then run `agent/scripts/promote.sh` — confirm the meta-PR targets `promotion_target`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)