### PR TITLE
fix(settings): hide duplicate Service actions in compose mode

### DIFF
--- a/dashboard/frontend/src/pages/SettingsPage.svelte
+++ b/dashboard/frontend/src/pages/SettingsPage.svelte
@@ -545,12 +545,25 @@
             </div>
             <div class="key-row">
               <span class="lbl">Actions</span>
-              <div class="val" style="display: flex; gap: 8px; flex-wrap: wrap;">
-                <button class="opbtn" onclick={() => handleServiceAction('start')}>Start</button>
-                {#if systemStatus?.deploy_mode !== 'compose'}
+              <div class="val" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: center;">
+                {#if systemStatus?.deploy_mode === 'compose'}
+                  <!--
+                    In compose mode the agent container is always up; the
+                    Start/Stop buttons route to the same launcher endpoint
+                    as Mission Control's "Trigger Run" / live-run Stop, so
+                    we expose them in one place rather than two. The Settings
+                    surface stays informational (status, schedule, deploy mode).
+                  -->
+                  <span class="desc">
+                    Run cycle controls live on
+                    <a href="/mission-control" data-testid="mc-link" style="color: var(--data); text-decoration: none;">Mission Control</a>
+                    — the agent container is always up; "Start" there triggers a run cycle.
+                  </span>
+                {:else}
+                  <button class="opbtn" onclick={() => handleServiceAction('start')}>Start</button>
                   <button class="opbtn" onclick={() => handleServiceAction('restart')}>Restart</button>
+                  <button class="opbtn danger" onclick={() => handleServiceAction('stop')}>Stop Service</button>
                 {/if}
-                <button class="opbtn danger" onclick={() => handleServiceAction('stop')}>Stop Service</button>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
In compose mode the Service Start/Stop buttons on **Settings → General** are duplicates of Mission Control's existing **Trigger Run** button and live-run Stop — both route to `service_control.start_agent_service()` / `stop_agent_service()` under the hood. The agent container is always running; "Start" never meant "start a daemon," it always meant "trigger a run cycle."

Hide the buttons in compose mode and point at Mission Control. Systemd mode is unchanged since it really does control a long-running unit.

## Why
- Removes a duplicate UX path (and the implication that the agent service can be off in compose mode, when it can't).
- Settings stays informational: status, schedule, deploy mode, resources.

## Changes
- `dashboard/frontend/src/pages/SettingsPage.svelte` — single conditional: if `deploy_mode === 'compose'`, render a one-line hint linking to `/mission-control` instead of the three buttons.

## Test plan
- [ ] Rebuild dashboard image, open Settings → General — Service card shows the Mission Control hint, no Start/Stop/Restart buttons.
- [ ] On a systemd deployment (or with `STATION_DEPLOY_MODE=systemd`), the three buttons render unchanged.
- [ ] Mission Control's existing Trigger Run still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)