### PR TITLE
fix(settings): RUNNING/IDLE/UNREACHABLE service labels in compose mode

### DIFF
--- a/dashboard/backend/app/routers/system.py
+++ b/dashboard/backend/app/routers/system.py
@@ -36,6 +36,12 @@ async def system_status():
         "deploy_mode": service_control.deploy_mode(),
         "service": {
             "active": svc["service_active"],
+            # ``reachable`` distinguishes "launcher up but idle" from
+            # "launcher unresponsive" in compose mode. In systemd mode the
+            # status call either succeeded (reachable) or threw (caller
+            # sees a 5xx), so it's always True here.
+            "reachable": svc.get("error") is None,
+            "error": svc.get("error"),
         },
         "timer": {
             "active": svc["timer_active"],

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -382,7 +382,7 @@ export interface TokenUsage {
 // --- System ---
 export interface SystemStatus {
   deploy_mode: 'systemd' | 'compose';
-  service: { active: boolean; status: string };
+  service: { active: boolean; status?: string; reachable?: boolean; error?: string | null };
   timer: { active: boolean; next_trigger: string | null };
   resources: {
     memory_total_mb?: number;

--- a/dashboard/frontend/src/pages/SettingsPage.svelte
+++ b/dashboard/frontend/src/pages/SettingsPage.svelte
@@ -472,7 +472,15 @@
     <h1>Settings</h1>
     <div class="meta">
       Service
-      {#if systemStatus?.service.active}
+      {#if systemStatus?.deploy_mode === 'compose'}
+        {#if systemStatus?.service.reachable === false}
+          <b style="color: var(--abort)">UNREACHABLE</b>
+        {:else if systemStatus?.service.active}
+          <b style="color: var(--go)">RUNNING</b>
+        {:else}
+          <b style="color: var(--ash)">IDLE</b>
+        {/if}
+      {:else if systemStatus?.service.active}
         <b style="color: var(--go)">ONLINE</b>
       {:else}
         <b style="color: var(--abort)">OFFLINE</b>
@@ -515,7 +523,18 @@
             <div class="key-row">
               <span class="lbl">Status</span>
               <div class="val">
-                {#if systemStatus?.service.active}
+                {#if systemStatus?.deploy_mode === 'compose'}
+                  {#if systemStatus?.service.reachable === false}
+                    <span class="status-tag off">✕ UNREACHABLE</span>
+                    <span class="desc">launcher at <code>$STATION_AGENT_LAUNCHER_URL</code> didn't respond{systemStatus.service.error ? ` — ${systemStatus.service.error}` : ''}</span>
+                  {:else if systemStatus?.service.active}
+                    <span class="status-tag go">● RUNNING</span>
+                    <span class="desc">a run is in flight</span>
+                  {:else}
+                    <span class="status-tag" style="background: var(--paper-3); color: var(--graphite);">○ IDLE</span>
+                    <span class="desc">agent container is up and waiting for a trigger</span>
+                  {/if}
+                {:else if systemStatus?.service.active}
                   <span class="status-tag go">● ONLINE</span>
                 {:else}
                   <span class="status-tag off">OFFLINE</span>


### PR DESCRIPTION
## Summary
`service.active` means "is a run currently in flight," not "is the launcher up." In systemd those coincide; in compose they don't. Result: with the agent container healthy and idle, the Service banner showed **OFFLINE**, which read as "the agent is dead."

This PR distinguishes the three real states in compose mode:

- **● RUNNING** — a run/vision-analyst is in flight (`service.active === true`)
- **○ IDLE** — launcher up, no run in flight (`service.active === false`, `service.reachable === true`)
- **✕ UNREACHABLE** — launcher didn't respond (`service.reachable === false`)

Systemd mode keeps ONLINE / OFFLINE.

## Changes
- `dashboard/backend/app/routers/system.py` — surface `reachable` + `error` on `/api/system/status`. Source already comes from `service_control.get_agent_status()`'s existing `error` field; previously dropped.
- `dashboard/frontend/src/lib/types.ts` — extend `SystemStatus.service` with optional `reachable` + `error`.
- `dashboard/frontend/src/pages/SettingsPage.svelte` — branch on `deploy_mode` at both label sites (page-head banner + Service card).

## Test plan
- [ ] Compose, agent up, no run: Service shows ○ IDLE (was: OFFLINE).
- [ ] Compose, trigger a run from Mission Control: Service flips to ● RUNNING during the run, back to ○ IDLE after.
- [ ] Compose, `docker stop cas-agent`: Service shows ✕ UNREACHABLE with launcher error.
- [ ] Systemd path: labels unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)