### PR TITLE
fix(runs): orphan stale coordinator_tasks when parent run finishes

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -129,8 +129,18 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
     # This covers the coordinated path where the Python coordinator spawns
     # employees via task_started events instead of employee_start events.
     if len(employees) <= 1:
+        # Only synthesize from coordinator_tasks whose parent run is still
+        # in a non-terminal state. Without this guard, stale rows linger
+        # after the parent run completes and the API resurrects them as
+        # phantom running employees. See issue #345.
         coord_result = await db.execute(
-            select(CoordinatorTask).where(CoordinatorTask.status == "running")
+            select(CoordinatorTask)
+            .join(Run, Run.run_id == CoordinatorTask.run_id, isouter=True)
+            .where(
+                CoordinatorTask.status == "running",
+                Run.status.in_(("running", "reviewing", "plan_reviewing"))
+                | (Run.status.is_(None)),
+            )
         )
         coord_tasks = coord_result.scalars().all()
 

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -138,7 +138,7 @@ async def get_active_employees(db: AsyncSession = Depends(get_db)):
             .join(Run, Run.run_id == CoordinatorTask.run_id, isouter=True)
             .where(
                 CoordinatorTask.status == "running",
-                Run.status.in_(("running", "reviewing", "plan_reviewing"))
+                Run.status.in_(["running", "plan_reviewing", "reviewing"])
                 | (Run.status.is_(None)),
             )
         )

--- a/dashboard/backend/app/services/run_lifecycle.py
+++ b/dashboard/backend/app/services/run_lifecycle.py
@@ -181,6 +181,21 @@ async def handle_finished(
     run.turns = event.turns
     run.duration_ms = event.duration_ms
     run.finished_at = datetime.now(timezone.utc)
+
+    # Cascade: any coordinator_tasks still claimed/running for this run are
+    # marked 'orphaned' so /api/runs/active-employees does not resurrect
+    # them as phantom employees after the parent run has finalised.
+    # See issue #345 / spec 2026-05-11-run-lifecycle-overhaul-design.md.
+    from app.models import CoordinatorTask
+    await db.execute(
+        update(CoordinatorTask)
+        .where(
+            CoordinatorTask.run_id == event.run_id,
+            CoordinatorTask.status.in_(("claimed", "running")),
+        )
+        .values(status="orphaned", claimed_at=None)
+    )
+
     run.model = event.model or run.model
     if event.mode:
         run.mode = event.mode

--- a/dashboard/backend/app/services/run_lifecycle.py
+++ b/dashboard/backend/app/services/run_lifecycle.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models import Notification, Run, RunControl
+from app.models import CoordinatorTask, Notification, Run, RunControl
 from app.schemas import WebhookRunEvent
 from app.services.event_bus import publish as event_bus_publish
 from app.services.log_parser import parse_employee_report
@@ -186,7 +186,6 @@ async def handle_finished(
     # marked 'orphaned' so /api/runs/active-employees does not resurrect
     # them as phantom employees after the parent run has finalised.
     # See issue #345 / spec 2026-05-11-run-lifecycle-overhaul-design.md.
-    from app.models import CoordinatorTask
     await db.execute(
         update(CoordinatorTask)
         .where(

--- a/dashboard/backend/tests/test_run_lifecycle.py
+++ b/dashboard/backend/tests/test_run_lifecycle.py
@@ -45,3 +45,47 @@ async def test_handle_finished_persists_vision_bootstrap_fields(setup_db):
         proposals = json.loads(run.vision_bootstrap_proposals)
         assert len(proposals) == 3
         assert proposals[0]["number"] == 101
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_orphans_running_coordinator_tasks(setup_db):
+    """When a Run finalises, any of its coordinator_tasks left in 'running' or
+    'claimed' must be cascaded to 'orphaned'. Fixes the zombie-task bug
+    (issue #345) where /api/runs/active-employees surfaces stale rows."""
+    from app.models import CoordinatorTask, Run
+    from datetime import datetime, timezone
+    from sqlalchemy import select
+
+    run_id = "run-orphan-test-1"
+    async with async_session() as db:
+        db.add(Run(run_id=run_id, status="running",
+                   started_at=datetime.now(timezone.utc)))
+        db.add(CoordinatorTask(id="t-zombie-run", run_id=run_id,
+                               project_repo="x/y", title="zombie run task",
+                               status="running",
+                               started_at=datetime.now(timezone.utc)))
+        db.add(CoordinatorTask(id="t-zombie-claim", run_id=run_id,
+                               project_repo="x/y", title="zombie claim task",
+                               status="claimed",
+                               started_at=datetime.now(timezone.utc)))
+        db.add(CoordinatorTask(id="t-other-run", run_id="run-other",
+                               project_repo="x/y", title="other run task",
+                               status="running",
+                               started_at=datetime.now(timezone.utc)))
+        await db.commit()
+
+    event = WebhookRunEvent(event="finished", run_id=run_id, status="success")
+    async with async_session() as db:
+        await handle_finished(db, event, project_id=None,
+                              run=(await db.execute(
+                                  select(Run).where(Run.run_id == run_id)
+                              )).scalar_one())
+        await db.commit()
+
+    async with async_session() as db:
+        rows = (await db.execute(select(CoordinatorTask))).scalars().all()
+        by_id = {r.id: r for r in rows}
+        assert by_id["t-zombie-run"].status == "orphaned"
+        assert by_id["t-zombie-claim"].status == "orphaned"
+        assert by_id["t-zombie-claim"].claimed_at is None
+        assert by_id["t-other-run"].status == "running"

--- a/dashboard/backend/tests/test_run_lifecycle.py
+++ b/dashboard/backend/tests/test_run_lifecycle.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 
 from app.database import Base, async_session, engine
-from app.services.run_lifecycle import handle_finished
+from app.models import CoordinatorTask, Run
 from app.schemas import WebhookRunEvent
+from app.services.run_lifecycle import handle_finished
 
 
 @pytest_asyncio.fixture
@@ -52,10 +55,6 @@ async def test_handle_finished_orphans_running_coordinator_tasks(setup_db):
     """When a Run finalises, any of its coordinator_tasks left in 'running' or
     'claimed' must be cascaded to 'orphaned'. Fixes the zombie-task bug
     (issue #345) where /api/runs/active-employees surfaces stale rows."""
-    from app.models import CoordinatorTask, Run
-    from datetime import datetime, timezone
-    from sqlalchemy import select
-
     run_id = "run-orphan-test-1"
     async with async_session() as db:
         db.add(Run(run_id=run_id, status="running",

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -16,7 +16,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.database import Base, async_session, engine
 from app.main import app
-from app.models import Project, Run
+from app.models import CoordinatorTask, Project, Run
 
 
 @pytest_asyncio.fixture
@@ -522,3 +522,26 @@ async def test_telemetry_summary_verdicts_7d(client):
     assert resp.status_code == 200, resp.text
     v = resp.json()["verdicts_7d"]
     assert v == {"ok": 3, "pr": 1, "x": 1}
+
+
+@pytest.mark.asyncio
+async def test_active_employees_skips_synthesis_when_parent_terminal(client):
+    """When a Run is terminal (completed/failed/interrupted) the
+    active-employees fallback must NOT synthesize phantom employees from
+    its leftover coordinator_tasks. Fixes issue #345."""
+    run_id = "run-terminal-1"
+    async with async_session() as db:
+        db.add(Run(run_id=run_id, status="completed",
+                   started_at=datetime.now(timezone.utc),
+                   finished_at=datetime.now(timezone.utc)))
+        db.add(CoordinatorTask(id="t-stale", run_id=run_id,
+                               project_repo="x/y", title="stale task",
+                               status="running",
+                               started_at=datetime.now(timezone.utc)))
+        await db.commit()
+
+    resp = await client.get("/api/runs/active-employees")
+    assert resp.status_code == 200
+    employees = resp.json()
+    assert all(e["run_id"] != run_id for e in employees), \
+        f"phantom employee returned for terminal run: {employees}"

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -23,7 +23,7 @@ export type RunStatus = 'started' | 'employee_done' | 'reviewing' | 'finished' |
 export type Verdict = 'APPROVE' | 'PR' | 'REJECT';
 export type QueueState = 'pending' | 'assigned' | 'claimed' | 'planning' | 'in_progress' | 'review' | 'verifying' | 'approved' | 'rejected' | 'escalated' | 'paused' | 'failed' | 'cancelled' | 'completed';
 export type PlanStatus = 'draft' | 'approved' | 'implementing' | 'completed' | 'rejected';
-export type CoordinatorTaskStatus = 'pending' | 'ready' | 'running' | 'completed' | 'blocked' | 'failed';
+export type CoordinatorTaskStatus = 'pending' | 'ready' | 'running' | 'completed' | 'blocked' | 'failed' | 'orphaned';
 export type BackpressureLevel = 'GREEN' | 'YELLOW' | 'RED' | 'BLACK';
 
 // --- Projects ---


### PR DESCRIPTION
Fixes #345. Two new tests, both green. See spec at docs/superpowers/specs/2026-05-11-run-lifecycle-overhaul-design.md.