### PR TITLE
feat(runs): optimistic placeholder on Trigger Run

### DIFF
--- a/agent/launcher.py
+++ b/agent/launcher.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 import httpx
 from fastapi import FastAPI, Header, HTTPException
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
@@ -146,21 +147,18 @@ def stop(x_launcher_token: str | None = Header(default=None)) -> dict:
     return {"status": "stopping", "pid": pid}
 
 
-@app.post("/run")
-def trigger(x_launcher_token: str | None = Header(default=None)) -> dict:
-    """Spawn run-manager.sh detached. Returns once the process is forked.
+class RunHint(BaseModel):
+    hint_run_id: str | None = None
 
-    Before spawning, fetch a fresh GitHub App installation token from the
-    dashboard and export it as GH_TOKEN in the subprocess env. Lets the
-    `gh` CLI (and any tools that read GH_TOKEN) act as the App's
-    installation. If the dashboard isn't reachable or GitHub isn't
-    configured, the run still proceeds — the agent will fall back to
-    whatever auth gh already has (e.g. host bind mount on systemd).
+
+def _spawn_run_manager(hint_run_id: str | None = None) -> dict:
+    """Fork run-manager.sh detached and return immediately.
+
+    ``hint_run_id`` is propagated to the subprocess as
+    ``STATION_RUN_ID_OVERRIDE`` so the bash script adopts the pre-allocated
+    run_id from the dashboard instead of generating its own.
     """
     global _current
-
-    if LAUNCHER_TOKEN and x_launcher_token != LAUNCHER_TOKEN:
-        raise HTTPException(status_code=401, detail="invalid or missing launcher token")
 
     if _current is not None and _current.poll() is None:
         raise HTTPException(
@@ -195,6 +193,12 @@ def trigger(x_launcher_token: str | None = Header(default=None)) -> dict:
     # longer.
     env.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", "1800000")
 
+    # Propagate the pre-allocated run_id hint so run-manager.sh adopts it
+    # via STATION_RUN_ID_OVERRIDE, converging on the placeholder row the
+    # dashboard already inserted.
+    if hint_run_id:
+        env["STATION_RUN_ID_OVERRIDE"] = hint_run_id
+
     LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_path = LOG_DIR / "launcher.out"
     log_fh = log_path.open("ab")
@@ -208,9 +212,36 @@ def trigger(x_launcher_token: str | None = Header(default=None)) -> dict:
         cwd=WORKDIR,
         env=env,
     )
-    logger.info("Spawned run-manager.sh pid=%s, logging to %s, app_auth=%s",
-                _current.pid, log_path, "yes" if gh_token else "no")
+    logger.info("Spawned run-manager.sh pid=%s, logging to %s, app_auth=%s, hint_run_id=%s",
+                _current.pid, log_path, "yes" if gh_token else "no",
+                hint_run_id or "none")
     return {"status": "triggered", "pid": _current.pid, "log": str(log_path)}
+
+
+@app.post("/run")
+def trigger(
+    body: RunHint | None = None,
+    x_launcher_token: str | None = Header(default=None),
+) -> dict:
+    """Spawn run-manager.sh detached. Returns once the process is forked.
+
+    Accepts an optional JSON body ``{"hint_run_id": "run-..."}`` which is
+    propagated to run-manager.sh as ``STATION_RUN_ID_OVERRIDE`` so the
+    script adopts the pre-allocated run_id from the dashboard's placeholder
+    row instead of generating its own timestamp-based id.
+
+    Before spawning, fetch a fresh GitHub App installation token from the
+    dashboard and export it as GH_TOKEN in the subprocess env. Lets the
+    `gh` CLI (and any tools that read GH_TOKEN) act as the App's
+    installation. If the dashboard isn't reachable or GitHub isn't
+    configured, the run still proceeds — the agent will fall back to
+    whatever auth gh already has (e.g. host bind mount on systemd).
+    """
+    if LAUNCHER_TOKEN and x_launcher_token != LAUNCHER_TOKEN:
+        raise HTTPException(status_code=401, detail="invalid or missing launcher token")
+
+    hint = body.hint_run_id if body else None
+    return _spawn_run_manager(hint_run_id=hint)
 
 
 _current_analyst: subprocess.Popen | None = None

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -24,7 +24,12 @@ resolve_prompt() {
         echo "$default_prompt"
     fi
 }
-RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+if [ -n "${STATION_RUN_ID_OVERRIDE:-}" ]; then
+    _override="${STATION_RUN_ID_OVERRIDE#run-}"
+    RUN_ID="$_override"
+else
+    RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+fi
 _RUN_COMPLETE_SENT=0  # Flag: set to 1 once run_complete webhook has been sent
 LOG_DIR=""
 DIGEST_DIR=""

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -630,47 +630,63 @@ async def rescan_logs(db: AsyncSession = Depends(get_db)):
 
 
 @router.post("/trigger")
-async def trigger_run():
-    """Trigger the agent service immediately.
+async def trigger_run(db: AsyncSession = Depends(get_db)):
+    """Trigger an agent run immediately and surface a pending placeholder.
 
-    Delegates to :mod:`app.services.service_control` which branches on
-    ``STATION_DEPLOY_MODE`` between ``sudo systemctl start`` (systemd
-    deployments) and ``POST /run`` on the agent launcher (compose).
+    Insertion order matters: the Run row must be committed and the
+    run_start SSE event must be published BEFORE the launcher is asked
+    to spawn run-manager.sh, so a fast dashboard sees the placeholder
+    before the bash takes seconds to enumerate projects.
     """
-    result = await service_control.start_agent_service()
+    from datetime import datetime, timezone
+    from app.models import Run
+
+    # Generate a stable run_id we hand to the launcher; run-manager.sh
+    # adopts it via STATION_RUN_ID_OVERRIDE so its own webhook_event
+    # "run_start" upgrades this same row instead of inserting a duplicate.
+    run_id = f"run-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+
+    placeholder = Run(
+        run_id=run_id,
+        status="pending",
+        started_at=datetime.now(timezone.utc),
+    )
+    db.add(placeholder)
+    await db.commit()
+
+    await publish({
+        "type": "run_start",
+        "run_id": run_id,
+        "status": "pending",
+    })
+
+    result = await service_control.start_agent_service(hint_run_id=run_id)
     if not result.get("success"):
-        # Compose path may set status_code to a launcher 4xx (e.g. 409
-        # "already running") or 502 (unreachable); systemd path returns
-        # generic 500. Preserve the upstream status so the UI can show a
-        # precise message.
+        placeholder.status = "failed"
+        placeholder.finished_at = datetime.now(timezone.utc)
+        await db.commit()
+        error_detail = (
+            result.get("error")
+            or result.get("stderr")
+            or result.get("detail")
+            or result.get("raw")
+            or "trigger failed"
+        )
+        await publish({"type": "run_complete", "run_id": run_id,
+                       "status": "failed",
+                       "error": error_detail})
         status = result.get("status_code") or 500
         if status < 400:
             status = 500
-        # Detail precedence: structured error fields first, then any
-        # JSON ``detail`` from the launcher response, then ``raw`` for
-        # plain-text 4xx bodies (the launcher's HTTPException emits JSON
-        # but tests and some clients exercise the text path), then a
-        # generic fallback.
-        raise HTTPException(
-            status_code=status,
-            detail=(
-                result.get("error")
-                or result.get("stderr")
-                or result.get("detail")
-                or result.get("raw")
-                or "Failed to trigger run"
-            ),
-        )
-    # Choose the success message based on the actual deploy mode rather
-    # than sniffing for ``pid`` in the result. The previous heuristic would
-    # silently flip to the launcher message if a future systemd
-    # implementation surfaced MainPID.
+        raise HTTPException(status_code=status, detail=error_detail)
+
     is_compose = service_control.deploy_mode() == "compose"
     detail = result.get("detail") or (
         "agent launcher accepted run" if is_compose else "claude-agent.service started"
     )
     return {
         "status": "triggered",
+        "run_id": run_id,
         "detail": detail,
         **{k: v for k, v in result.items() if k not in {"success", "status_code"}},
     }

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -638,9 +638,6 @@ async def trigger_run(db: AsyncSession = Depends(get_db)):
     to spawn run-manager.sh, so a fast dashboard sees the placeholder
     before the bash takes seconds to enumerate projects.
     """
-    from datetime import datetime, timezone
-    from app.models import Run
-
     # Generate a stable run_id we hand to the launcher; run-manager.sh
     # adopts it via STATION_RUN_ID_OVERRIDE so its own webhook_event
     # "run_start" upgrades this same row instead of inserting a duplicate.
@@ -656,8 +653,10 @@ async def trigger_run(db: AsyncSession = Depends(get_db)):
 
     await publish({
         "type": "run_start",
-        "run_id": run_id,
-        "status": "pending",
+        "data": {
+            "run_id": run_id,
+            "status": "pending",
+        },
     })
 
     result = await service_control.start_agent_service(hint_run_id=run_id)
@@ -672,9 +671,14 @@ async def trigger_run(db: AsyncSession = Depends(get_db)):
             or result.get("raw")
             or "trigger failed"
         )
-        await publish({"type": "run_complete", "run_id": run_id,
-                       "status": "failed",
-                       "error": error_detail})
+        await publish({
+            "type": "run_complete",
+            "data": {
+                "run_id": run_id,
+                "status": "failed",
+                "error": error_detail,
+            },
+        })
         status = result.get("status_code") or 500
         if status < 400:
             status = 500

--- a/dashboard/backend/app/services/service_control.py
+++ b/dashboard/backend/app/services/service_control.py
@@ -65,7 +65,8 @@ def _launcher_headers() -> dict[str, str]:
     return headers
 
 
-async def _launcher_call(method: str, path: str) -> dict:
+async def _launcher_call(method: str, path: str,
+                         json_body: dict | None = None) -> dict:
     """Call the agent launcher and shape the response like systemctl()."""
     base = _launcher_base_url()
     if not base:
@@ -73,7 +74,9 @@ async def _launcher_call(method: str, path: str) -> dict:
     url = f"{base.rstrip('/')}{path}"
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
-            resp = await client.request(method, url, headers=_launcher_headers())
+            resp = await client.request(method, url,
+                                        headers=_launcher_headers(),
+                                        json=json_body)
     except httpx.HTTPError as exc:
         # 502 Bad Gateway is the right HTTP status for "upstream
         # unreachable"; trigger_run preserves status_code so the dashboard
@@ -96,10 +99,17 @@ async def _launcher_call(method: str, path: str) -> dict:
     }
 
 
-async def start_agent_service() -> dict:
-    """Start the agent (systemctl start, or POST /run on the launcher)."""
+async def start_agent_service(hint_run_id: str | None = None) -> dict:
+    """Start the agent (systemctl start, or POST /run on the launcher).
+
+    ``hint_run_id`` lets the dashboard pre-allocate a run_id so the
+    in-flight run row created on /api/runs/trigger and the bash-emitted
+    run_start webhook converge on the same id. The launcher passes this
+    to run-manager.sh as ``STATION_RUN_ID_OVERRIDE``.
+    """
     if _mode() == "compose":
-        return await _launcher_call("POST", "/run")
+        body = {"hint_run_id": hint_run_id} if hint_run_id else None
+        return await _launcher_call("POST", "/run", json_body=body)
     return await systemctl("start", DEFAULT_AGENT_UNIT)
 
 

--- a/dashboard/backend/app/services/stale_run_reaper.py
+++ b/dashboard/backend/app/services/stale_run_reaper.py
@@ -145,10 +145,14 @@ async def _reap_pending_placeholders(db: AsyncSession) -> int:
             r.run_id,
             r.started_at,
         )
-        await event_bus_publish({"type": "run_complete",
-                                 "run_id": r.run_id,
-                                 "status": "failed",
-                                 "error": "pending placeholder expired"})
+        await event_bus_publish({
+            "type": "run_complete",
+            "data": {
+                "run_id": r.run_id,
+                "status": "failed",
+                "error": "pending placeholder expired",
+            },
+        })
     return len(pending_rows)
 
 

--- a/dashboard/backend/app/services/stale_run_reaper.py
+++ b/dashboard/backend/app/services/stale_run_reaper.py
@@ -42,6 +42,12 @@ UNKNOWN_RUN_REAP_AGE_MINUTES = 30
 # issue #348.
 ACTIVE_HEARTBEAT_TIMEOUT_SECONDS = 120
 
+# Pending placeholder rows that never advanced to 'running' within this
+# window — the bash never picked up the hint, or the launcher accepted
+# the call but failed before run_start — are reaped as failed.
+# See issue #346.
+PENDING_REAP_AGE_SECONDS = 90
+
 # Statuses we consider "still active" — rows in any of these states whose
 # orchestrator is dead are candidates for reaping.  ``unknown`` is included
 # only when the row is older than ``UNKNOWN_RUN_REAP_AGE_MINUTES``.
@@ -111,6 +117,41 @@ async def _reap_by_heartbeat(db: AsyncSession) -> int:
     return len(stale)
 
 
+async def _reap_pending_placeholders(db: AsyncSession) -> int:
+    """Reap ``pending`` placeholder rows that never advanced to ``running``
+    within :data:`PENDING_REAP_AGE_SECONDS`.
+
+    Runs unconditionally — pending rows are stale regardless of whether the
+    service is active, because the bash may have adopted a different run_id
+    or failed silently after the launcher accepted the POST.
+
+    Returns the number of rows reaped. Does not commit; caller is responsible.
+    """
+    cutoff_pending = datetime.now(timezone.utc) - timedelta(
+        seconds=PENDING_REAP_AGE_SECONDS
+    )
+    pending_result = await db.execute(
+        select(Run).where(
+            Run.status == "pending",
+            Run.started_at < cutoff_pending,
+        )
+    )
+    pending_rows = pending_result.scalars().all()
+    for r in pending_rows:
+        r.status = "failed"
+        r.finished_at = datetime.now(timezone.utc)
+        logger.info(
+            "Reaped expired pending placeholder %s (started %s)",
+            r.run_id,
+            r.started_at,
+        )
+        await event_bus_publish({"type": "run_complete",
+                                 "run_id": r.run_id,
+                                 "status": "failed",
+                                 "error": "pending placeholder expired"})
+    return len(pending_rows)
+
+
 async def reap_stale_runs(db: AsyncSession) -> int:
     """Mark orphaned 'running' runs as 'interrupted' if the agent service is dead.
 
@@ -121,13 +162,17 @@ async def reap_stale_runs(db: AsyncSession) -> int:
     # existing service-inactive sweep below catches the dead-launcher case.
     heartbeat_reaped = await _reap_by_heartbeat(db)
 
+    # Pending placeholder reap runs unconditionally — the placeholder row
+    # may expire regardless of whether the service later starts or not.
+    pending_reaped = await _reap_pending_placeholders(db)
+
     # Check if the agent service is actually running
     svc = await get_agent_status()
     if svc.get("service_active"):
-        # Launcher reports a run alive — heartbeat may still have reaped
-        # rows whose orchestrator died silently. Commit and return.
+        # Launcher reports a run alive — heartbeat and pending sweeps may
+        # still have reaped rows. Commit and return.
         await db.commit()
-        return heartbeat_reaped
+        return heartbeat_reaped + pending_reaped
 
     # pgrep is a useful tie-breaker for manual orchestrator invocations
     # outside the systemd unit (developer testing on the host). It's
@@ -136,7 +181,7 @@ async def reap_stale_runs(db: AsyncSession) -> int:
     # latency to every reaper tick. Skip it in compose.
     if deploy_mode() == "systemd" and _is_orchestrator_process_alive():
         await db.commit()
-        return heartbeat_reaped  # Orchestrator process is alive — nothing more to reap
+        return heartbeat_reaped + pending_reaped  # Orchestrator process is alive — nothing more to reap
 
     # Service is inactive — find any runs still marked as 'running' /
     # 'reviewing', or stuck in 'unknown' for too long.  ``unknown`` rows are
@@ -166,10 +211,6 @@ async def reap_stale_runs(db: AsyncSession) -> int:
         )
     )
     stale_runs = result.scalars().all()
-
-    if not stale_runs:
-        await db.commit()
-        return heartbeat_reaped
 
     for run in stale_runs:
         old_status = run.status
@@ -242,4 +283,4 @@ async def reap_stale_runs(db: AsyncSession) -> int:
             _bypass_filter=True,
         )
 
-    return heartbeat_reaped + len(stale_runs)
+    return heartbeat_reaped + pending_reaped + len(stale_runs)

--- a/dashboard/backend/tests/test_run_control.py
+++ b/dashboard/backend/tests/test_run_control.py
@@ -316,3 +316,30 @@ async def test_expire_orphan_controls_is_idempotent(client, live_run):
 
     assert len(first) == 1
     assert second == []  # nothing left to expire
+
+
+@pytest.mark.asyncio
+async def test_trigger_run_inserts_pending_placeholder(client):
+    """POST /api/runs/trigger must insert a Run(status='pending') BEFORE
+    the launcher returns, so the dashboard shows feedback immediately
+    (issue #346). The launcher call is mocked so the placeholder is the
+    only side-effect we observe."""
+    from unittest.mock import patch, AsyncMock
+    from app.models import Run
+    from sqlalchemy import select
+
+    with patch("app.routers.runs.service_control.start_agent_service",
+               new_callable=AsyncMock,
+               return_value={"success": True, "detail": "accepted",
+                             "status_code": 200}):
+        resp = await client.post("/api/runs/trigger")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("run_id", "").startswith("run-")
+
+    async with async_session() as db:
+        rows = (await db.execute(
+            select(Run).where(Run.run_id == body["run_id"])
+        )).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].status == "pending"

--- a/dashboard/backend/tests/test_stale_run_reaper.py
+++ b/dashboard/backend/tests/test_stale_run_reaper.py
@@ -56,6 +56,39 @@ async def test_reap_stale_heartbeat(setup_db):
 
 
 @pytest.mark.asyncio
+async def test_reap_expired_pending_placeholder(setup_db):
+    """A pending placeholder older than PENDING_REAP_AGE_SECONDS gets
+    marked failed (issue #346 safety net)."""
+    from datetime import datetime, timedelta, timezone
+    from app.models import Run
+    from app.services.stale_run_reaper import (
+        reap_stale_runs, PENDING_REAP_AGE_SECONDS,
+    )
+    from sqlalchemy import select
+    from unittest.mock import patch, AsyncMock
+
+    too_old = datetime.now(timezone.utc) - timedelta(
+        seconds=PENDING_REAP_AGE_SECONDS + 30
+    )
+    async with async_session() as db:
+        db.add(Run(run_id="run-stale-pending", status="pending",
+                   started_at=too_old))
+        await db.commit()
+
+    with patch("app.services.stale_run_reaper.get_agent_status",
+               new_callable=AsyncMock,
+               return_value={"service_active": False}):
+        async with async_session() as db:
+            reaped = await reap_stale_runs(db)
+    assert reaped >= 1
+    async with async_session() as db:
+        row = (await db.execute(
+            select(Run).where(Run.run_id == "run-stale-pending")
+        )).scalar_one()
+        assert row.status == "failed"
+
+
+@pytest.mark.asyncio
 async def test_reap_stale_heartbeat_runs_when_launcher_alive(setup_db):
     """The whole point of the heartbeat reap: it must run EVEN when the
     launcher reports an active service, because that's the case where


### PR DESCRIPTION
## Summary

- `POST /api/runs/trigger` now allocates a `run_id` server-side, inserts a `Run(status='pending')` row, and publishes `run_start` to event_bus **before** calling the launcher — closing the 5–30s blank-UI window (issue #346).
- The launcher accepts an optional `{"hint_run_id": "..."}` body and passes it to `run-manager.sh` as `STATION_RUN_ID_OVERRIDE`; the bash script adopts the pre-allocated id so its `run_start` webhook upgrades the existing placeholder row rather than inserting a duplicate.
- `service_control._launcher_call` now accepts an optional `json_body` parameter.
- A new `_reap_pending_placeholders` helper in `stale_run_reaper.py` (threshold: 90s) sweeps placeholders that never advanced to `running` — safety net for launcher or bash failures.

## Test plan

- [x] `test_trigger_run_inserts_pending_placeholder` — new TDD test: HTTP 200, `run_id` starts with `run-`, DB row `status='pending'`
- [x] `test_reap_expired_pending_placeholder` — new TDD test: pending row older than 90s gets marked `failed`
- [x] All existing `test_trigger_run.py` tests pass (including `test_trigger_propagates_launcher_4xx`)
- [x] All existing `test_stale_run_reaper.py` tests pass
- [x] Full suite: 1078 passed, 5 pre-existing failures (unrelated to this PR)

Fixes #346. See `docs/superpowers/specs/2026-05-11-run-lifecycle-overhaul-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)