### PR TITLE
feat(mission-control): explicit idle state when no active run

### DIFF
--- a/dashboard/frontend/src/components/mission/IdlePanel.svelte
+++ b/dashboard/frontend/src/components/mission/IdlePanel.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import { triggerRun } from '../../lib/api';
+  import { addToast } from '../../lib/toast.svelte';
+  import { navigate } from '../../lib/router.svelte';
+  import { timeAgo } from '../../lib/format';
+  import type { Run } from '../../lib/types';
+
+  let { lastRun }: { lastRun: Run | null } = $props();
+
+  let triggering = $state(false);
+
+  async function handleTrigger() {
+    if (triggering) return;
+    triggering = true;
+    try {
+      const res = await triggerRun();
+      addToast('success', `Triggered run ${res.run_id ?? ''}`);
+    } catch (e: any) {
+      addToast('error', e.message ?? 'Trigger failed');
+    } finally {
+      triggering = false;
+    }
+  }
+
+  function viewLast() {
+    if (lastRun) navigate(`/runs/${lastRun.run_id}`);
+  }
+</script>
+
+<section class="idle-panel" data-testid="mission-idle-panel">
+  <div class="idle-head">
+    <h2>● Agent is idle</h2>
+    <button type="button"
+            class="trigger-btn primary"
+            onclick={handleTrigger}
+            disabled={triggering}
+            data-testid="idle-trigger-btn">
+      {triggering ? 'Triggering…' : 'Trigger Run'}
+    </button>
+  </div>
+
+  {#if lastRun}
+    <div class="last-run">
+      <div class="row">
+        <span class="lbl">Last run</span>
+        <a href={`/runs/${lastRun.run_id}`} onclick={(e) => { e.preventDefault(); viewLast(); }}>
+          {lastRun.run_id}
+        </a>
+      </div>
+      <div class="row">
+        <span class="lbl">Status</span>
+        <span class="val">{lastRun.status}{lastRun.verdict ? ` · ${lastRun.verdict}` : ''}</span>
+      </div>
+      {#if lastRun.finished_at}
+        <div class="row">
+          <span class="lbl">Finished</span>
+          <span class="val">{timeAgo(lastRun.finished_at)}</span>
+        </div>
+      {/if}
+    </div>
+  {:else}
+    <p class="desc">No runs yet. Click <b>Trigger Run</b> to start the agent.</p>
+  {/if}
+</section>
+
+<style>
+  .idle-panel {
+    border: 1px dashed var(--graphite);
+    background: var(--paper-2);
+    padding: 32px;
+    border-radius: 8px;
+    margin: 24px 0;
+    color: var(--ink);
+  }
+  .idle-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 16px;
+  }
+  .idle-head h2 {
+    margin: 0;
+    color: var(--ash);
+    font-size: 1.1rem;
+    font-weight: 500;
+  }
+  .trigger-btn {
+    padding: 8px 24px;
+    background: var(--data);
+    color: var(--paper);
+    border: 0;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.95rem;
+  }
+  .trigger-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+  .last-run .row { display: flex; gap: 12px; margin: 4px 0; }
+  .last-run .lbl { color: var(--graphite); min-width: 90px; }
+  .last-run a { color: var(--data); text-decoration: none; }
+  .desc { color: var(--graphite); margin: 8px 0 0; }
+</style>

--- a/dashboard/frontend/src/lib/api.ts
+++ b/dashboard/frontend/src/lib/api.ts
@@ -206,7 +206,7 @@ export const getRunDiff = (runId: string) =>
   request<DiffResult>(`/api/runs/${runId}/diff`);
 
 export const triggerRun = () =>
-  requestWithToast<{ status: string; detail: string }>('/api/runs/trigger', { method: 'POST' });
+  requestWithToast<{ status: string; detail: string; run_id?: string }>('/api/runs/trigger', { method: 'POST' });
 
 export const rescanRuns = () =>
   requestWithToast<{ status: string; imported: number }>('/api/runs/rescan', { method: 'POST' });

--- a/dashboard/frontend/src/pages/MissionControl.svelte
+++ b/dashboard/frontend/src/pages/MissionControl.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { agentPresence, type ConversationEntry } from '../lib/agent-presence.svelte';
   import IdlePanel from '../components/mission/IdlePanel.svelte';
-  import { runs as runsStore } from '../lib/data-store.svelte';
+  import { runs as runsStore, refreshRuns, initStoreSSE } from '../lib/data-store.svelte';
   import {
     messageRun,
     triggerRun,
@@ -35,6 +35,14 @@
   let runPaused = $derived(!!agentPresence.pausedRuns[currentRunId]);
   let globalPause = $derived(agentPresence.globalPause);
   let pendingDecisions = $derived(agentPresence.pendingDecisionCount);
+
+  // Wire up SSE-driven cache invalidation (idempotent) and seed the
+  // initial runs list so the IdlePanel can show last-run summary
+  // immediately on mount. See PR #354 review.
+  $effect(() => {
+    initStoreSSE();
+    refreshRuns();
+  });
 
   // Issue #266 — surface the plan-review gate so operators can see when a
   // plan_only run is waiting on the manager (or has been approved/rejected).
@@ -388,7 +396,6 @@
         <span>Aut <b>{autonomyLabel(currentRun.mode)}</b></span>
       {:else}
         <span><span class="dot idle"></span><b>idle</b></span>
-        <button type="button" class="trigger-btn" onclick={handleTrigger}>Trigger Run</button>
       {/if}
       {#if pendingDecisions > 0}
         <span class="br">·</span>

--- a/dashboard/frontend/src/pages/MissionControl.svelte
+++ b/dashboard/frontend/src/pages/MissionControl.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { agentPresence, type ConversationEntry } from '../lib/agent-presence.svelte';
+  import IdlePanel from '../components/mission/IdlePanel.svelte';
+  import { runs as runsStore } from '../lib/data-store.svelte';
   import {
     messageRun,
     triggerRun,
@@ -28,6 +30,8 @@
     agentPresence.activeRuns.find((r) => r.run_id === currentRunId) ?? null,
   );
   let isLive = $derived(agentPresence.activeRuns.length > 0);
+  let isIdle = $derived(agentPresence.activeRuns.length === 0);
+  let lastRun = $derived(runsStore.length > 0 ? runsStore[0] : null);
   let runPaused = $derived(!!agentPresence.pausedRuns[currentRunId]);
   let globalPause = $derived(agentPresence.globalPause);
   let pendingDecisions = $derived(agentPresence.pendingDecisionCount);
@@ -393,6 +397,10 @@
     </div>
   </div>
 
+  {#if isIdle}
+    <IdlePanel {lastRun} />
+  {:else}
+
   <!-- Intervention bar ──────────────────────────────────────── -->
   <div class="intervene">
     <span class="label">Intervene</span>
@@ -606,6 +614,8 @@
       </section>
     </aside>
   </div>
+
+  {/if}
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

- Adds `IdlePanel.svelte` — shown when `agentPresence.activeRuns.length === 0`, displaying last-run summary (status, verdict, finished_at via `timeAgo`) and a prominent Trigger Run button
- Wires `isIdle` derived state into `MissionControl.svelte`; the intervene bar, banner, and console grid are only rendered in the active (`{:else}`) branch
- Fixes the `run_id?` omission in the `triggerRun()` TS return type (backend has always returned it)

Pairs with PR #353 (optimistic placeholder): clicking Trigger Run immediately inserts a `pending` run into `activeRuns`, so the idle panel disappears without any visible flicker.

Fixes #347.

## Test plan
- [ ] With no active runs, Mission Control shows the idle panel with "Agent is idle" heading
- [ ] Last run details (run_id, status, verdict, finished_at) render correctly when runs exist
- [ ] Clicking "Trigger Run" in the panel shows a success toast and the panel disappears (replaced by active run chrome) once the placeholder is picked up
- [ ] With an active run, the panel is absent and the normal intervene bar/console render
- [ ] `svelte-check --threshold error` reports only the 3 pre-existing errors (VisionTab + format.test.ts duplicates), no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)