### PR TITLE
refactor(agent): introduce RunDriver — try/finally lifecycle guarantee (5c plumbing)

### DIFF
--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -1,0 +1,48 @@
+"""Per-project iteration entry-point.
+
+This module currently delegates to the existing bash logic via
+subprocess. As the migration progresses (follow-up sub-PRs to #349),
+the per-project body will be ported here directly. The interface is
+stable across the migration so the RunDriver doesn't change.
+
+See spec/plan: 2026-05-11-run-lifecycle-overhaul.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def iterate_projects(run_id: str, config_path: str,
+                     workspaces_dir: str) -> int:
+    """Iterate over enabled projects and dispatch agent work.
+
+    Currently shells to ``run-manager.sh --internal-iterate`` which
+    contains the legacy bash body. Migration sub-PRs will replace this
+    with native Python iteration.
+
+    Returns exit code: 0 on success, non-zero on failure. Does not
+    raise — the caller (RunDriver) handles exceptions via try/finally
+    around its own webhook emission.
+    """
+    script_dir = Path(__file__).resolve().parent / "scripts"
+    runmgr = script_dir / "run-manager.sh"
+    if not runmgr.exists():
+        logger.error("project_loop: run-manager.sh not found at %s", runmgr)
+        return 127
+
+    env = os.environ.copy()
+    env["STATION_RUN_ID_OVERRIDE"] = run_id
+
+    logger.info("project_loop: shelling to %s --internal-iterate", runmgr)
+    result = subprocess.run(
+        [str(runmgr), "--internal-iterate"],
+        env=env,
+        cwd=workspaces_dir if Path(workspaces_dir).exists() else None,
+    )
+    return result.returncode

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -35,6 +35,10 @@ LOG_DIR=""
 DIGEST_DIR=""
 WORKSPACES_DIR="${STATION_WORKSPACES:-/home/claude-agent/workspaces}"
 DRY_RUN=false
+# --internal-iterate is set by agent/project_loop.py (issue #349 migration).
+# When true, run_start/run_complete lifecycle events are owned by RunDriver
+# (Python try/finally) and must NOT be emitted from bash to avoid duplication.
+INTERNAL_ITERATE=false
 
 # Token accumulation across all employees + manager
 _TOTAL_TOKENS_IN=0
@@ -514,8 +518,12 @@ trap 'queue_api POST "/api/queue/batch-pause" "{\"run_id\":\"run-$RUN_ID\"}" 2>/
 
 # EXIT trap: guarantee run_complete webhook fires on ALL exit paths
 # (normal exit, set -e crash, signals). Runs AFTER SIGTERM/SIGINT traps.
+# When --internal-iterate is set, RunDriver (Python) owns run_complete; skip.
 _send_run_complete_on_exit() {
     local exit_code=$?
+    if [ "$INTERNAL_ITERATE" = "true" ]; then
+        return
+    fi
     if [ "$_RUN_COMPLETE_SENT" -eq 0 ] && [ -n "${RUN_ID:-}" ]; then
         local status="error"
         [ $exit_code -eq 0 ] && status="completed"
@@ -2628,10 +2636,14 @@ for v in data.get('verdicts', []):
 main() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --config)        CONFIG_FILE="$2"; shift 2 ;;
-            --dry-run)       DRY_RUN=true; shift ;;
-            --list-projects) preflight; list_projects; exit 0 ;;
-            --help|-h)       usage ;;
+            --config)           CONFIG_FILE="$2"; shift 2 ;;
+            --dry-run)          DRY_RUN=true; shift ;;
+            --list-projects)    preflight; list_projects; exit 0 ;;
+            --help|-h)          usage ;;
+            # Private flag: used by agent/project_loop.py (issue #349 migration).
+            # Runs the project-iteration body without emitting run lifecycle
+            # events (run_start / run_complete are owned by RunDriver).
+            --internal-iterate) INTERNAL_ITERATE=true; shift ;;
             -*)              log_error "Unknown option: $1"; usage ;;
             *)               log_error "Unknown argument: $1"; usage ;;
         esac
@@ -2663,11 +2675,14 @@ main() {
     log_info "Concurrency: max_concurrent=$max_concurrent, max_per_project=$max_per_project, strategy=$budget_strategy"
 
     _RUN_START_EPOCH=$(date +%s)
-    webhook_event "run_start" \
-        project_count "$project_count" \
-        max_concurrent "$max_concurrent" \
-        concurrent_group_id "$CONCURRENT_GROUP_ID" \
-        log_file "$LOG_DIR/run-${RUN_ID}.log"
+    # When invoked with --internal-iterate, RunDriver (Python) owns run_start.
+    if [ "$INTERNAL_ITERATE" != "true" ]; then
+        webhook_event "run_start" \
+            project_count "$project_count" \
+            max_concurrent "$max_concurrent" \
+            concurrent_group_id "$CONCURRENT_GROUP_ID" \
+            log_file "$LOG_DIR/run-${RUN_ID}.log"
+    fi
 
     # ---- Count total employees to spawn (for budget calculation) ----
     local total_employees=0
@@ -2998,14 +3013,17 @@ print(json.dumps(result))
         notify "complete" "Run $RUN_ID finished (no work to review)"
         local _duration_ms_nr=0
         [ "$_RUN_START_EPOCH" -gt 0 ] && _duration_ms_nr=$(( ($(date +%s) - _RUN_START_EPOCH) * 1000 ))
-        webhook_event "run_complete" \
-            status "no_reports" \
-            tokens_input "$_TOTAL_TOKENS_IN" \
-            tokens_output "$_TOTAL_TOKENS_OUT" \
-            tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
-            turns "$_TOTAL_TURNS" \
-            duration_ms "$_duration_ms_nr"
-        _RUN_COMPLETE_SENT=1
+        # When --internal-iterate is set, RunDriver (Python) owns run_complete.
+        if [ "$INTERNAL_ITERATE" != "true" ]; then
+            webhook_event "run_complete" \
+                status "no_reports" \
+                tokens_input "$_TOTAL_TOKENS_IN" \
+                tokens_output "$_TOTAL_TOKENS_OUT" \
+                tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
+                turns "$_TOTAL_TURNS" \
+                duration_ms "$_duration_ms_nr"
+            _RUN_COMPLETE_SENT=1
+        fi
         exit 0
     fi
 
@@ -3014,14 +3032,17 @@ print(json.dumps(result))
         notify "rate_limit" "Rate limit reached before manager review in run $RUN_ID"
         local _duration_ms_rl=0
         [ "$_RUN_START_EPOCH" -gt 0 ] && _duration_ms_rl=$(( ($(date +%s) - _RUN_START_EPOCH) * 1000 ))
-        webhook_event "run_complete" \
-            status "rate_limited" \
-            tokens_input "$_TOTAL_TOKENS_IN" \
-            tokens_output "$_TOTAL_TOKENS_OUT" \
-            tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
-            turns "$_TOTAL_TURNS" \
-            duration_ms "$_duration_ms_rl"
-        _RUN_COMPLETE_SENT=1
+        # When --internal-iterate is set, RunDriver (Python) owns run_complete.
+        if [ "$INTERNAL_ITERATE" != "true" ]; then
+            webhook_event "run_complete" \
+                status "rate_limited" \
+                tokens_input "$_TOTAL_TOKENS_IN" \
+                tokens_output "$_TOTAL_TOKENS_OUT" \
+                tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
+                turns "$_TOTAL_TURNS" \
+                duration_ms "$_duration_ms_rl"
+            _RUN_COMPLETE_SENT=1
+        fi
         exit 0
     fi
 
@@ -3199,14 +3220,17 @@ print(json.dumps(result))
     notify "complete" "Run $RUN_ID finished successfully"
     local _duration_ms_ok=0
     [ "$_RUN_START_EPOCH" -gt 0 ] && _duration_ms_ok=$(( ($(date +%s) - _RUN_START_EPOCH) * 1000 ))
-    webhook_event "run_complete" \
-        status "success" \
-        tokens_input "$_TOTAL_TOKENS_IN" \
-        tokens_output "$_TOTAL_TOKENS_OUT" \
-        tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
-        turns "$_TOTAL_TURNS" \
-        duration_ms "$_duration_ms_ok"
-    _RUN_COMPLETE_SENT=1
+    # When --internal-iterate is set, RunDriver (Python) owns run_complete.
+    if [ "$INTERNAL_ITERATE" != "true" ]; then
+        webhook_event "run_complete" \
+            status "success" \
+            tokens_input "$_TOTAL_TOKENS_IN" \
+            tokens_output "$_TOTAL_TOKENS_OUT" \
+            tokens_total "$((_TOTAL_TOKENS_IN + _TOTAL_TOKENS_OUT))" \
+            turns "$_TOTAL_TURNS" \
+            duration_ms "$_duration_ms_ok"
+        _RUN_COMPLETE_SENT=1
+    fi
 }
 
 # Only run main when executed directly; allow `source` for helper testing.

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -56,6 +56,7 @@ from agent.run_control import (
     set_run_paused,
 )
 from agent.vision_analyst import _ensure_workspace
+from agent.webhook_emitter import emit
 
 logger = logging.getLogger(__name__)
 
@@ -2027,6 +2028,61 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
     return exit_code
 
 
+# ============================================================================
+# RunDriver — issue #349 sub-PR 5c
+# ============================================================================
+
+
+class RunDriver:
+    """Owns the full run lifecycle: emits run_start at entry, emits
+    run_complete at exit (always — via try/finally), delegating the
+    project iteration to agent.project_loop.
+
+    Replaces run-manager.sh's EXIT-trap webhook construct, which had
+    reliability holes (silent drops on interrupted bash). The Python
+    try/finally cannot be skipped short of SIGKILL.
+    """
+
+    def __init__(self, *, run_id: str, config_path: str,
+                 workspaces_dir: str) -> None:
+        self.run_id = run_id
+        self.config_path = config_path
+        self.workspaces_dir = workspaces_dir
+
+    def run(self) -> int:
+        """Execute the run. Returns process exit code.
+
+        Always emits run_start and run_complete. On uncaught exception
+        in iterate_projects, emits run_complete with status='error'
+        and returns 1; does not re-raise.
+        """
+        emit("run_start", run_id=self.run_id, payload={})
+
+        status = "completed"
+        exit_code = 0
+        error: str | None = None
+
+        try:
+            from agent.project_loop import iterate_projects
+            exit_code = iterate_projects(
+                self.run_id, self.config_path, self.workspaces_dir,
+            )
+            if exit_code != 0:
+                status = "failed"
+        except Exception as e:  # noqa: BLE001 — driver MUST NOT propagate
+            logger.exception("RunDriver: iterate_projects raised")
+            status = "error"
+            exit_code = 1
+            error = f"{type(e).__name__}: {e}"
+        finally:
+            payload: dict = {"status": status}
+            if error:
+                payload["error"] = error
+            emit("run_complete", run_id=self.run_id, payload=payload)
+
+        return exit_code
+
+
 # ── CLI Entry Point ────────────────────────────────────────────
 
 def parse_args() -> argparse.Namespace:
@@ -2034,6 +2090,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--config", required=True, help="Path to manager-config.json")
     parser.add_argument("--run-id", required=True, help="Unique run identifier")
     parser.add_argument("--workspaces-dir", required=True, help="Directory for project workspaces")
+    parser.add_argument(
+        "--driver",
+        action="store_true",
+        default=False,
+        help=(
+            "Run via RunDriver (issue #349 migration path): emits run_start/"
+            "run_complete via Python try/finally, delegates project iteration "
+            "to agent.project_loop (which currently shells to run-manager.sh "
+            "--internal-iterate). Use this flag during the bash→Python "
+            "migration; omit it for the existing Agent Teams orchestration path."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -2044,8 +2112,19 @@ def main() -> None:
     )
 
     args = parse_args()
-    config = load_config(args.config)
 
+    if args.driver:
+        # Migration path (issue #349): RunDriver owns run_start/run_complete;
+        # bash project iteration is called via agent.project_loop.
+        driver = RunDriver(
+            run_id=args.run_id,
+            config_path=args.config,
+            workspaces_dir=args.workspaces_dir,
+        )
+        sys.exit(driver.run())
+
+    # Existing Agent Teams orchestration path — unchanged.
+    config = load_config(args.config)
     exit_code = asyncio.run(orchestrate(config, args.run_id, args.workspaces_dir))
     sys.exit(exit_code)
 

--- a/dashboard/backend/tests/test_run_driver.py
+++ b/dashboard/backend/tests/test_run_driver.py
@@ -1,0 +1,57 @@
+"""Tests for agent.station_orchestrator.RunDriver (issue #349, sub-PR 5c)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch, MagicMock
+
+
+def test_run_driver_emits_run_start_then_run_complete_on_success():
+    """The driver MUST emit run_start at entry and run_complete at exit
+    via webhook_emitter, replacing the bash EXIT-trap construct."""
+    from agent.station_orchestrator import RunDriver
+    with patch("agent.station_orchestrator.emit") as mock_emit, \
+         patch("agent.project_loop.iterate_projects", return_value=0):
+        driver = RunDriver(run_id="run-driver-1",
+                           config_path="/tmp/cfg.json",
+                           workspaces_dir="/tmp/ws")
+        rc = driver.run()
+    assert rc == 0
+    events = [c.args[0] for c in mock_emit.call_args_list]
+    assert "run_start" in events
+    assert "run_complete" in events
+    # And the order is: start before complete
+    assert events.index("run_start") < events.index("run_complete")
+
+
+def test_run_driver_emits_run_complete_even_on_exception():
+    """Try/finally invariant: if iterate_projects raises, the driver
+    must STILL emit run_complete (with status=error) before propagating."""
+    from agent.station_orchestrator import RunDriver
+    with patch("agent.station_orchestrator.emit") as mock_emit, \
+         patch("agent.project_loop.iterate_projects",
+               side_effect=RuntimeError("boom")):
+        driver = RunDriver(run_id="run-driver-2",
+                           config_path="/tmp/cfg.json",
+                           workspaces_dir="/tmp/ws")
+        rc = driver.run()
+    # Driver should not propagate; returns non-zero
+    assert rc != 0
+    events = [c.args[0] for c in mock_emit.call_args_list]
+    assert "run_complete" in events
+    # The run_complete event should carry status=error
+    complete_call = next(c for c in mock_emit.call_args_list
+                         if c.args[0] == "run_complete")
+    assert complete_call.kwargs.get("payload", {}).get("status") == "error"
+
+
+def test_run_driver_emits_run_complete_with_completed_status_on_success():
+    from agent.station_orchestrator import RunDriver
+    with patch("agent.station_orchestrator.emit") as mock_emit, \
+         patch("agent.project_loop.iterate_projects", return_value=0):
+        driver = RunDriver(run_id="run-driver-3",
+                           config_path="/tmp/cfg.json",
+                           workspaces_dir="/tmp/ws")
+        driver.run()
+    complete_call = next(c for c in mock_emit.call_args_list
+                         if c.args[0] == "run_complete")
+    assert complete_call.kwargs.get("payload", {}).get("status") == "completed"


### PR DESCRIPTION
## Summary

- Adds `RunDriver` class to `agent/station_orchestrator.py`: owns `run_start`/`run_complete` emission via Python `try/finally`, replacing the bash `EXIT-trap` construct which had silent-drop reliability holes on interrupted runs.
- Adds `agent/project_loop.py`: stable interface that currently delegates to `run-manager.sh --internal-iterate`; follow-up sub-PRs will replace its body with native Python without touching `RunDriver`.
- Adds `--internal-iterate` flag to `run-manager.sh`: gates all bash-side `run_start`/`run_complete` emissions so the Python driver owns those events without duplication when called via `project_loop`.

## Scope

This is the **plumbing-only** slice of PR 5c. Explicitly deferred to follow-up sub-PRs:
- Issue picking migration
- Dispatch path migration
- Verdict execution migration
- Deletion of any existing bash blocks

## Tests

Three tests in `dashboard/backend/tests/test_run_driver.py` lock in the `try/finally` invariant:
- `run_start` emitted before `run_complete` on success
- `run_complete` emitted with `status=error` even when `iterate_projects` raises
- `run_complete` emitted with `status=completed` on clean exit

## `__main__` wiring

`RunDriver` is wired to a new `--driver` flag in `station_orchestrator.py`'s `main()`. Passing `--driver` selects the `RunDriver` path; omitting it retains the existing Agent Teams `orchestrate()` path unchanged.

Refs #349. See `docs/superpowers/specs/2026-05-11-run-lifecycle-overhaul-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)