### PR TITLE
hotfix(emitter): correct PYTHONPATH in run-manager.sh webhook wrapper

### DIFF
--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -332,7 +332,7 @@ PYEOF
     [ -z "${STATION_WEBHOOK_URL:-}" ] && [ -n "$_cfg_url" ] && export STATION_WEBHOOK_URL="$_cfg_url"
     [ -z "${STATION_WEBHOOK_SECRET:-}" ] && [ -n "$_cfg_secret" ] && export STATION_WEBHOOK_SECRET="$_cfg_secret"
 
-    PYTHONPATH="$SCRIPT_DIR/.." \
+    PYTHONPATH="$SCRIPT_DIR/../.." \
         python3 -m agent.webhook_emitter "$event" \
             --run-id "run-$RUN_ID" \
             --json "$payload" 2>&1 | while IFS= read -r line; do

--- a/dashboard/backend/tests/test_run_manager_helpers.py
+++ b/dashboard/backend/tests/test_run_manager_helpers.py
@@ -59,6 +59,9 @@ def _resolve_run_mode(workspace: str, project_index: int, *, config_mode: str) -
     cmd = (
         f"export STATION_CONFIG='{cfg}'; "
         f"source '{RUN_MANAGER}' 2>/dev/null || true; "
+        # Mark run_complete as already sent so the EXIT trap does not fire the
+        # webhook emitter and pollute stdout with HTTP log lines.
+        f"_RUN_COMPLETE_SENT=1; "
         f"resolve_run_mode '{workspace}' {project_index}"
     )
     out = subprocess.run(

--- a/dashboard/backend/tests/test_webhook_emitter.py
+++ b/dashboard/backend/tests/test_webhook_emitter.py
@@ -88,3 +88,69 @@ def test_emit_omits_token_header_when_secret_unset():
         emit("run_start", run_id="run-h2", payload={})
         headers = mock_post.call_args.kwargs["headers"]
         assert "X-Webhook-Token" not in headers
+
+
+def test_module_importable_from_repo_root_via_pythonpath():
+    """Regression test for the run-manager.sh PYTHONPATH hotfix (issue #349).
+
+    PR #352 introduced webhook_event() with PYTHONPATH=$SCRIPT_DIR/.. which
+    resolves to agent/. Python needs the PARENT of agent/ (the repo root) to
+    resolve `import agent`. On systemd deployments the cwd is the workspaces
+    dir (not the repo root), so the import fails silently inside `|| true`,
+    dropping every bash-emitted webhook event.
+
+    This test simulates the corrected bash wrapper: PYTHONPATH=$SCRIPT_DIR/../..
+    (two levels up from agent/scripts/), cwd=/tmp, and asserts the module is
+    importable.
+    """
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    # SCRIPT_DIR is agent/scripts; two levels up reaches the repo root
+    script_dir = Path(__file__).resolve().parents[3] / "agent" / "scripts"
+    pythonpath = str((script_dir / ".." / "..").resolve())
+
+    env = {**os.environ, "PYTHONPATH": pythonpath}
+    result = subprocess.run(
+        [sys.executable, "-c", "import agent.webhook_emitter; print('ok')"],
+        cwd="/tmp",  # NOT the repo root — simulates systemd deployment cwd
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"agent.webhook_emitter not importable from cwd=/tmp with "
+        f"PYTHONPATH={pythonpath}; stderr: {result.stderr}"
+    )
+    assert "ok" in result.stdout
+
+
+def test_old_pythonpath_fails_from_arbitrary_cwd():
+    """Negative regression: the pre-fix PYTHONPATH ($SCRIPT_DIR/..) must NOT
+    allow `import agent` from an arbitrary cwd. This documents that the
+    one-level path was wrong and the fix is necessary."""
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    # Pre-fix: SCRIPT_DIR/.. resolves to agent/ itself, which doesn't contain
+    # an `agent` package to import.
+    script_dir = Path(__file__).resolve().parents[3] / "agent" / "scripts"
+    wrong_pythonpath = str((script_dir / "..").resolve())
+
+    env = {**os.environ, "PYTHONPATH": wrong_pythonpath}
+    result = subprocess.run(
+        [sys.executable, "-c", "import agent.webhook_emitter; print('ok')"],
+        cwd="/tmp",  # NOT the repo root
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    # With the wrong path and a non-repo cwd, the import must fail.
+    assert result.returncode != 0, (
+        "Expected import to fail with pre-fix PYTHONPATH but it succeeded; "
+        "the test environment may have agent/ on sys.path via other means."
+    )


### PR DESCRIPTION
## Summary

Hotfix for #352. Systemd-mode webhook emission was silently dropping every event because the PYTHONPATH the bash `webhook_event()` wrapper built was wrong by one level.

- **Root cause**: `PYTHONPATH="$SCRIPT_DIR/.."` resolves to `agent/` — Python needs the directory *containing* `agent/` (the repo root) to resolve `import agent`
- **Compose mode**: accidentally worked because the launcher cwd is `/app`, so `agent/` ended up on the cwd-based path
- **Systemd mode**: broken — cwd is `/home/claude-agent/workspaces`, so `python3 -m agent.webhook_emitter` fails with `ModuleNotFoundError` silently swallowed by `|| true`
- **Fix**: `$SCRIPT_DIR/..` → `$SCRIPT_DIR/../..` (matches the working pattern at lines ~2795 and ~3082 which use `agent_dir/..` after `agent_dir=$(cd $SCRIPT_DIR/.. && pwd)`)

**Secondary fix**: the 4 broken `test_run_manager_helpers.py` tests had a second issue: once the import worked, the EXIT trap's `webhook_event()` was emitting HTTP log lines to stdout (contaminating test assertions). Fixed by setting `_RUN_COMPLETE_SENT=1` after sourcing in the test helper so the trap no-ops.

## Changes

- `agent/scripts/run-manager.sh`: one-character fix `$SCRIPT_DIR/..` → `$SCRIPT_DIR/../..`
- `dashboard/backend/tests/test_run_manager_helpers.py`: set `_RUN_COMPLETE_SENT=1` after sourcing to suppress EXIT trap noise in stdout
- `dashboard/backend/tests/test_webhook_emitter.py`: two new regression tests — positive (correct path works from `/tmp`) and negative (pre-fix path fails from `/tmp`)

## Test plan

- [ ] `test_run_manager_helpers.py` — 4 previously failing tests now green (8/8 pass)
- [ ] `test_webhook_emitter.py` — 2 new regression tests + 6 existing = 8/8 pass
- [ ] `bash -n agent/scripts/run-manager.sh` — syntax check passes

Refs #349.

🤖 Generated with [Claude Code](https://claude.com/claude-code)