### PR TITLE
hotfix(runs): apply log_file zero-on-missing to /full endpoint too

### DIFF
--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -446,6 +446,10 @@ async def get_run_full_context(run_id: str, db: AsyncSession = Depends(get_db)):
     run = result.scalar_one_or_none()
     if not run:
         raise HTTPException(status_code=404, detail="Run not found")
+    # Same defensive zero of log_file as GET /{id} — historical rows
+    # advertised a phantom per-run path. See PR #365.
+    if run.log_file and not os.path.isfile(run.log_file):
+        run.log_file = None
 
     # 2. Fetch coordinator tasks for this run
     tasks_result = await db.execute(

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -250,6 +250,30 @@ async def test_get_run_preserves_log_file_when_present(client, tmp_path):
     assert resp.json()["log_file"] == str(real_log)
 
 
+@pytest.mark.asyncio
+async def test_get_run_full_zeros_log_file_when_missing(client):
+    """The /full endpoint that RunDetail.svelte actually uses must
+    apply the same zero-on-missing fix as GET /{id}."""
+    from datetime import datetime, timezone
+    from app.models import Run
+
+    async with async_session() as db:
+        db.add(Run(
+            run_id="run-phantom-log-full",
+            status="completed",
+            started_at=datetime.now(timezone.utc),
+            log_file="/var/log/claude-agent/does-not-exist-2.log",
+        ))
+        await db.commit()
+
+    resp = await client.get("/api/runs/run-phantom-log-full/full")
+    assert resp.status_code == 200
+    body = resp.json()
+    # The /full endpoint nests the run under a 'run' key
+    run_data = body.get("run", body)
+    assert run_data["log_file"] is None
+
+
 # --- ADR-0001 autonomy fields ---
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to #365. RunDetail.svelte uses `GET /api/runs/{id}/full` not `GET /api/runs/{id}`, so the previous fix didn't reach the actual call path. Same defensive filter applied. +1 test.