### PR TITLE
fix(launcher): bump heartbeat from Python orchestrator too

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1226,6 +1226,30 @@ def post_webhook(config: dict, event: str, data: dict | None = None) -> None:
     except Exception:
         pass  # Best-effort
 
+    # Also ping the launcher's /webhook-tick so its zombie reaper sees
+    # the orchestrator's activity. The PR #364 wrapper only pinged from
+    # the bash-side webhook_event helper, but most Agent Teams runtime
+    # traffic flows through this Python path; without this ping the
+    # launcher reaped active runs after 120s of "bash silence" (see
+    # run-20260512T122255Z post-mortem).
+    _ping_launcher_best_effort()
+
+
+def _ping_launcher_best_effort() -> None:
+    """Bump the launcher's heartbeat clock so its _zombie_reaper sees
+    that the Python orchestrator is making forward progress. Mirrors
+    agent.webhook_emitter._ping_launcher. Silent on all errors."""
+    base = os.environ.get("STATION_AGENT_LAUNCHER_URL", "")
+    if not base:
+        return
+    token = os.environ.get("STATION_LAUNCHER_TOKEN", "")
+    headers = {"X-Launcher-Token": token} if token else {}
+    try:
+        with httpx.Client(timeout=1.0) as client:
+            client.post(f"{base.rstrip('/')}/webhook-tick", headers=headers)
+    except Exception:
+        pass
+
 
 def _usage_val(usage, key: str, default=0):
     """Safely get a usage field whether usage is a dict or object."""

--- a/dashboard/backend/tests/test_orchestrator_launcher_ping.py
+++ b/dashboard/backend/tests/test_orchestrator_launcher_ping.py
@@ -1,0 +1,122 @@
+"""Tests for the launcher heartbeat ping fired by station_orchestrator
+.post_webhook. Bug: PR #364's launcher zombie reaper killed actively-
+working runs because its heartbeat signal was bumped only from the
+bash-side webhook_event wrapper, but Agent Teams runs emit nearly all
+their webhook traffic from the Python orchestrator path. See
+post-mortem of run-20260512T122255Z."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def test_post_webhook_pings_launcher_when_url_set(monkeypatch):
+    """Every post_webhook call must also bump the launcher's heartbeat
+    clock so its zombie reaper sees the orchestrator's progress."""
+    from agent import station_orchestrator as so
+
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://agent:8421")
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "test-token")
+
+    # Mock httpx.Client used both for the dashboard post and the
+    # launcher ping. Two separate `with` blocks construct two clients;
+    # both must receive a POST.
+    dashboard_call = None
+    launcher_call = None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.calls = []
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            FakeClient.last_calls.append((url, kwargs))
+    FakeClient.last_calls = []
+
+    with patch("agent.station_orchestrator.httpx.Client", FakeClient):
+        so.post_webhook(
+            {"dashboard": {"webhook_url": "http://dashboard:8420/api/webhook/run-event"}},
+            "narration",
+            {"run_id": "run-test"},
+        )
+
+    urls = [c[0] for c in FakeClient.last_calls]
+    assert any("/api/webhook/run-event" in u for u in urls), urls
+    assert any("/webhook-tick" in u for u in urls), urls
+
+    # Verify the token was passed on the launcher ping
+    for url, kwargs in FakeClient.last_calls:
+        if "/webhook-tick" in url:
+            assert kwargs.get("headers", {}).get("X-Launcher-Token") == "test-token"
+
+
+def test_post_webhook_skips_launcher_ping_when_url_unset(monkeypatch):
+    """When STATION_AGENT_LAUNCHER_URL is unset (systemd deployment),
+    the launcher ping path must be silently skipped."""
+    from agent import station_orchestrator as so
+
+    monkeypatch.delenv("STATION_AGENT_LAUNCHER_URL", raising=False)
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.calls = []
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            self.calls.append(url)
+            FakeClient.last_calls.append(url)
+    FakeClient.last_calls = []
+
+    with patch("agent.station_orchestrator.httpx.Client", FakeClient):
+        so.post_webhook(
+            {"dashboard": {"webhook_url": "http://dashboard:8420/api/webhook/run-event"}},
+            "narration",
+            {"run_id": "run-test"},
+        )
+
+    assert not any("/webhook-tick" in u for u in FakeClient.last_calls), \
+        f"unexpected webhook-tick call: {FakeClient.last_calls}"
+
+
+def test_launcher_ping_swallows_errors(monkeypatch):
+    """A launcher that's down must not break the dashboard webhook —
+    the ping is best-effort by contract."""
+    from agent import station_orchestrator as so
+
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://broken-host:9999")
+
+    import httpx
+    class FlakyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            # First call (dashboard webhook): success.
+            # Second call (launcher ping): raise.
+            if "/webhook-tick" in url:
+                raise httpx.ConnectError("simulated launcher down")
+            return MagicMock(status_code=200)
+
+    with patch("agent.station_orchestrator.httpx.Client", FlakyClient):
+        # Must not raise even though the launcher ping fails
+        so.post_webhook(
+            {"dashboard": {"webhook_url": "http://dashboard:8420/api/webhook/run-event"}},
+            "run_start",
+            {"run_id": "run-flaky"},
+        )


### PR DESCRIPTION
Post-mortem of run-20260512T122255Z: PR #364's launcher zombie reaper killed an actively-working full-mode run after 136s. The bash was idle (just waiting on its Python subprocess) so `_last_webhook_at` never advanced. The Python orchestrator was actively making webhook calls but those went directly to the dashboard, bypassing the bash wrapper that pings the launcher.

Fix: `station_orchestrator.post_webhook` also pings the launcher's `/webhook-tick` (best-effort). 3 new tests.