### PR TITLE
fix(launcher): set STATION_AGENT_LAUNCHER_URL in agent container + default to localhost

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1226,6 +1226,34 @@ def post_webhook(config: dict, event: str, data: dict | None = None) -> None:
     except Exception:
         pass  # Best-effort
 
+    # Also ping the launcher's /webhook-tick so its zombie reaper sees
+    # the orchestrator's activity. The PR #364 wrapper only pinged from
+    # the bash-side webhook_event helper, but most Agent Teams runtime
+    # traffic flows through this Python path; without this ping the
+    # launcher reaped active runs after 120s of "bash silence" (see
+    # run-20260512T122255Z post-mortem).
+    _ping_launcher_best_effort()
+
+
+def _ping_launcher_best_effort() -> None:
+    """Bump the launcher's heartbeat clock so its _zombie_reaper sees
+    that the Python orchestrator is making forward progress. Mirrors
+    agent.webhook_emitter._ping_launcher. Silent on all errors.
+
+    Defaults to ``http://localhost:8421`` because the orchestrator
+    runs inside the agent container and the launcher listens there.
+    The env var is the override (e.g. for tests that run the
+    orchestrator outside the container).
+    """
+    base = os.environ.get("STATION_AGENT_LAUNCHER_URL") or "http://localhost:8421"
+    token = os.environ.get("STATION_LAUNCHER_TOKEN", "")
+    headers = {"X-Launcher-Token": token} if token else {}
+    try:
+        with httpx.Client(timeout=1.0) as client:
+            client.post(f"{base.rstrip('/')}/webhook-tick", headers=headers)
+    except Exception:
+        pass
+
 
 def _usage_val(usage, key: str, default=0):
     """Safely get a usage field whether usage is a dict or object."""

--- a/agent/webhook_emitter.py
+++ b/agent/webhook_emitter.py
@@ -44,10 +44,13 @@ LAUNCHER_URL_ENV = "STATION_AGENT_LAUNCHER_URL"
 def _ping_launcher(timeout: float = 1.0) -> None:
     """Best-effort heartbeat to the launcher's /webhook-tick. Silently
     swallows all errors — the launcher may not be reachable (the bash
-    might be running outside compose mode) and that's fine."""
-    base = os.environ.get(LAUNCHER_URL_ENV, "")
-    if not base:
-        return
+    might be running outside compose mode) and that's fine.
+
+    Defaults to ``http://localhost:8421`` because the emitter runs
+    inside the agent container alongside the launcher. The env var is
+    only the override (e.g. for tests).
+    """
+    base = os.environ.get(LAUNCHER_URL_ENV) or "http://localhost:8421"
     token = os.environ.get("STATION_LAUNCHER_TOKEN", "")
     headers: dict[str, str] = {}
     if token:

--- a/compose.yml
+++ b/compose.yml
@@ -105,6 +105,14 @@ services:
       # service by name on the compose network. Without this it falls back
       # to localhost, which inside the agent container is the agent itself.
       STATION_WEBHOOK_URL: http://dashboard:8420/api/webhook/run-event
+      # The orchestrator and webhook_emitter ping the launcher's
+      # /webhook-tick to bump _last_webhook_at so the zombie reaper sees
+      # live progress. Inside the agent container the launcher is at
+      # localhost — the dashboard's "agent" hostname is meaningless here.
+      # Without this var set, the heartbeat ping was silently skipped
+      # and the reaper killed every run > 120s (post-mortem of
+      # run-20260512T122255Z / run-20260512T123216Z).
+      STATION_AGENT_LAUNCHER_URL: http://localhost:8421
       # Shared secret authenticating dashboard → launcher calls. Both ends
       # read the same value from the environment / .env at the repo root.
       STATION_LAUNCHER_TOKEN: "${STATION_LAUNCHER_TOKEN:?STATION_LAUNCHER_TOKEN must be set (generate with: openssl rand -hex 32)}"

--- a/dashboard/backend/tests/test_orchestrator_launcher_ping.py
+++ b/dashboard/backend/tests/test_orchestrator_launcher_ping.py
@@ -1,0 +1,126 @@
+"""Tests for the launcher heartbeat ping fired by station_orchestrator
+.post_webhook. Bug: PR #364's launcher zombie reaper killed actively-
+working runs because its heartbeat signal was bumped only from the
+bash-side webhook_event wrapper, but Agent Teams runs emit nearly all
+their webhook traffic from the Python orchestrator path. See
+post-mortem of run-20260512T122255Z."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def test_post_webhook_pings_launcher_when_url_set(monkeypatch):
+    """Every post_webhook call must also bump the launcher's heartbeat
+    clock so its zombie reaper sees the orchestrator's progress."""
+    from agent import station_orchestrator as so
+
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://agent:8421")
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "test-token")
+
+    # Mock httpx.Client used both for the dashboard post and the
+    # launcher ping. Two separate `with` blocks construct two clients;
+    # both must receive a POST.
+    dashboard_call = None
+    launcher_call = None
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.calls = []
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            self.calls.append((url, kwargs))
+            FakeClient.last_calls.append((url, kwargs))
+    FakeClient.last_calls = []
+
+    with patch("agent.station_orchestrator.httpx.Client", FakeClient):
+        so.post_webhook(
+            {"dashboard": {"webhook_url": "http://dashboard:8420/api/webhook/run-event"}},
+            "narration",
+            {"run_id": "run-test"},
+        )
+
+    urls = [c[0] for c in FakeClient.last_calls]
+    assert any("/api/webhook/run-event" in u for u in urls), urls
+    assert any("/webhook-tick" in u for u in urls), urls
+
+    # Verify the token was passed on the launcher ping
+    for url, kwargs in FakeClient.last_calls:
+        if "/webhook-tick" in url:
+            assert kwargs.get("headers", {}).get("X-Launcher-Token") == "test-token"
+
+
+def test_post_webhook_pings_default_localhost_when_url_unset(monkeypatch):
+    """When STATION_AGENT_LAUNCHER_URL is unset, the ping must still
+    fire against the in-container default (http://localhost:8421).
+    The original 'skip' design hid a real bug: in the compose deployment
+    the env var was missing on the agent side, so every Agent Teams run
+    silently failed to ping the launcher and got reaped after 120s."""
+    from agent import station_orchestrator as so
+
+    monkeypatch.delenv("STATION_AGENT_LAUNCHER_URL", raising=False)
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            self.calls = []
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            self.calls.append(url)
+            FakeClient.last_calls.append(url)
+    FakeClient.last_calls = []
+
+    with patch("agent.station_orchestrator.httpx.Client", FakeClient):
+        so.post_webhook(
+            {"dashboard": {"webhook_url": "http://dashboard:8420/api/webhook/run-event"}},
+            "narration",
+            {"run_id": "run-test"},
+        )
+
+    ticks = [u for u in FakeClient.last_calls if "/webhook-tick" in u]
+    assert len(ticks) == 1, f"expected one /webhook-tick call, saw {FakeClient.last_calls}"
+    assert "localhost:8421" in ticks[0], f"expected localhost default, got: {ticks[0]}"
+
+
+def test_launcher_ping_swallows_errors(monkeypatch):
+    """A launcher that's down must not break the dashboard webhook —
+    the ping is best-effort by contract."""
+    from agent import station_orchestrator as so
+
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://broken-host:9999")
+
+    import httpx
+    class FlakyClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            # First call (dashboard webhook): success.
+            # Second call (launcher ping): raise.
+            if "/webhook-tick" in url:
+                raise httpx.ConnectError("simulated launcher down")
+            return MagicMock(status_code=200)
+
+    with patch("agent.station_orchestrator.httpx.Client", FlakyClient):
+        # Must not raise even though the launcher ping fails
+        so.post_webhook(
+            {"dashboard": {"webhook_url": "http://dashboard:8420/api/webhook/run-event"}},
+            "run_start",
+            {"run_id": "run-flaky"},
+        )

--- a/dashboard/backend/tests/test_webhook_emitter.py
+++ b/dashboard/backend/tests/test_webhook_emitter.py
@@ -7,14 +7,27 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 
+def _dashboard_call(mock_post):
+    """Pick out the dashboard webhook call from the captured posts.
+    Since the emitter also pings the launcher's /webhook-tick (a
+    second POST), call_args alone now points to that ping, not the
+    dashboard. Use the call list and filter by URL substring."""
+    for call in mock_post.call_args_list:
+        url = call.args[0] if call.args else ""
+        if "/api/webhook/run-event" in url:
+            return call
+    raise AssertionError(f"no dashboard webhook call seen; saw: {[c.args for c in mock_post.call_args_list]}")
+
+
 def test_emit_run_start_posts_to_webhook():
     from agent.webhook_emitter import emit
     with patch("agent.webhook_emitter.httpx.post") as mock_post:
         mock_post.return_value = MagicMock(status_code=200, text="ok")
         emit("run_start", run_id="run-test-1", payload={"project": "x/y"})
         assert mock_post.called
-        url = mock_post.call_args.args[0]
-        body = mock_post.call_args.kwargs["json"]
+        call = _dashboard_call(mock_post)
+        url = call.args[0]
+        body = call.kwargs["json"]
         assert "/api/webhook/run-event" in url
         assert body["event"] == "run_start"
         assert body["run_id"] == "run-test-1"
@@ -49,13 +62,19 @@ def test_emit_does_not_raise_on_final_failure():
 
 
 def test_emit_does_not_retry_on_4xx():
-    """4xx is a client error; retrying won't help."""
+    """4xx is a client error; retrying won't help. (The emitter still
+    pings the launcher's /webhook-tick once at the end, hence two
+    total POSTs: one dashboard attempt + one launcher ping.)"""
     from agent.webhook_emitter import emit
-    with patch("agent.webhook_emitter.httpx.post",
-               side_effect=[MagicMock(status_code=400, text="bad")]) as mock_post:
+    with patch("agent.webhook_emitter.httpx.post") as mock_post:
+        # Dashboard 400 → no retry, no further dashboard calls.
+        # Launcher ping is a separate URL — fire-and-forget.
+        mock_post.return_value = MagicMock(status_code=400, text="bad")
         emit("run_complete", run_id="run-test-4",
              payload={"status": "completed"})
-        assert mock_post.call_count == 1
+    dashboard_calls = [c for c in mock_post.call_args_list
+                       if "/api/webhook/run-event" in (c.args[0] if c.args else "")]
+    assert len(dashboard_calls) == 1, "expected exactly one dashboard attempt"
 
 
 def test_emit_uses_x_webhook_token_header():
@@ -68,7 +87,7 @@ def test_emit_uses_x_webhook_token_header():
          patch("agent.webhook_emitter.httpx.post") as mock_post:
         mock_post.return_value = MagicMock(status_code=200, text="ok")
         emit("run_start", run_id="run-h1", payload={})
-        headers = mock_post.call_args.kwargs["headers"]
+        headers = _dashboard_call(mock_post).kwargs["headers"]
         assert "X-Webhook-Token" in headers
         assert headers["X-Webhook-Token"] == "s3cr3t"
         # The wrong name must NOT be present
@@ -86,7 +105,7 @@ def test_emit_omits_token_header_when_secret_unset():
         os.environ.pop("STATION_WEBHOOK_SECRET", None)
         mock_post.return_value = MagicMock(status_code=200, text="ok")
         emit("run_start", run_id="run-h2", payload={})
-        headers = mock_post.call_args.kwargs["headers"]
+        headers = _dashboard_call(mock_post).kwargs["headers"]
         assert "X-Webhook-Token" not in headers
 
 


### PR DESCRIPTION
Follow-up to PR #369. The launcher-ping code added there was correct in shape but never fired: `STATION_AGENT_LAUNCHER_URL` was only set on the dashboard container, not on the agent. The orchestrator running inside the agent container saw `UNSET` and silently skipped every ping.

## Fixes

1. **compose.yml** sets `STATION_AGENT_LAUNCHER_URL: http://localhost:8421` on the agent service — the launcher is reachable at localhost from inside the agent container.
2. **`_ping_launcher` defaults** to `http://localhost:8421` in both `agent/station_orchestrator.py::_ping_launcher_best_effort` and `agent/webhook_emitter.py::_ping_launcher` when the env var is unset. Defensive — covers systemd/dev contexts.
3. **Tests updated** to match the new default (was previously expecting a silent skip when unset; now expects the localhost ping).