### PR TITLE
fix(launcher): hold reference to zombie reaper task; lifespan migration

### DIFF
--- a/agent/launcher.py
+++ b/agent/launcher.py
@@ -22,6 +22,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
 
@@ -66,7 +68,38 @@ def _fetch_gh_token() -> str | None:
 # This launcher keeps process state in module globals (``_current``), so it
 # only works correctly under a single uvicorn worker. The Dockerfile launches
 # without --workers; do not change that without reworking state to be shared.
-app = FastAPI(title="claude-agent-station launcher")
+# Module-level reference to the zombie reaper task. Without this,
+# asyncio.create_task()'s return value would be the ONLY strong
+# reference; Python's GC can collect a task with no strong refs,
+# silently stopping the background loop. See #372.
+_reaper_task: asyncio.Task | None = None
+
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    """Start/stop the background zombie reaper. Replaces the deprecated
+    ``@app.on_event("startup")`` hook (which had a documented bug where
+    fire-and-forget tasks could be GC'd; we hold an explicit reference
+    here as well as a belt-and-suspenders measure)."""
+    global _reaper_task
+    _reaper_task = asyncio.create_task(_zombie_reaper())
+    logger.info(
+        "Zombie reaper started (interval=%ds, timeout=%ds)",
+        ZOMBIE_CHECK_INTERVAL_SECONDS, ZOMBIE_TIMEOUT_SECONDS,
+    )
+    try:
+        yield
+    finally:
+        if _reaper_task and not _reaper_task.done():
+            _reaper_task.cancel()
+            try:
+                await _reaper_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        _reaper_task = None
+
+
+app = FastAPI(title="claude-agent-station launcher", lifespan=_lifespan)
 _current: subprocess.Popen | None = None
 
 # Last time we observed a webhook event for the active subprocess. Used by
@@ -234,11 +267,6 @@ async def _zombie_reaper() -> None:
             _reap_once()
         except Exception:
             logger.exception("_zombie_reaper: unexpected error")
-
-
-@app.on_event("startup")
-async def _start_reaper() -> None:
-    asyncio.create_task(_zombie_reaper())
 
 
 class RunHint(BaseModel):

--- a/dashboard/backend/tests/test_launcher_zombie_reaper.py
+++ b/dashboard/backend/tests/test_launcher_zombie_reaper.py
@@ -86,3 +86,71 @@ def test_reaper_skips_recent_heartbeat(launcher_module):
     fake_proc.terminate.assert_not_called()
     # Still tracked — not cleared
     assert launcher_module._current is fake_proc
+
+
+def test_reaper_task_started_and_referenced_under_lifespan(launcher_module):
+    """The lifespan handler must start the reaper AND hold a module-level
+    reference so Python's GC doesn't collect the task. Without the
+    reference, the background task is silently lost — exactly the bug
+    that left run-20260512T124731Z hung for 2+ hours with no reap.
+    See #372."""
+    from fastapi.testclient import TestClient
+
+    # Entering the TestClient context manager runs the lifespan startup.
+    assert launcher_module._reaper_task is None  # before startup
+    with TestClient(launcher_module.app) as client:
+        # Inside the context, the reaper task must be present and live.
+        assert launcher_module._reaper_task is not None, \
+            "lifespan did not start the reaper task"
+        assert not launcher_module._reaper_task.done(), \
+            "reaper task ended immediately — likely an exception in _zombie_reaper"
+        # Sanity-check the launcher is responsive
+        resp = client.get("/status")
+        assert resp.status_code == 200
+    # After lifespan teardown, the reference is cleared.
+    assert launcher_module._reaper_task is None, \
+        "lifespan did not clear the task reference on shutdown"
+
+
+@pytest.mark.asyncio
+async def test_reaper_task_actually_fires_under_lifespan(launcher_module, monkeypatch):
+    """End-to-end: start the lifespan, seed a stale heartbeat, wait one
+    check interval, assert the reaper terminated the subprocess. This
+    locks in the regression — pre-fix, the task was GC'd before its
+    first tick fired in production."""
+    import asyncio
+    # Short interval/timeout so the test doesn't have to wait minutes
+    monkeypatch.setattr(launcher_module, "ZOMBIE_CHECK_INTERVAL_SECONDS", 1)
+    monkeypatch.setattr(launcher_module, "ZOMBIE_TIMEOUT_SECONDS", 1)
+
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None  # alive
+    fake_proc.pid = 9999
+    fake_proc.wait.return_value = 0
+
+    async with _launcher_lifespan(launcher_module.app, launcher_module):
+        # Seed a stale subprocess
+        launcher_module._current = fake_proc
+        launcher_module._last_webhook_at = datetime.now(timezone.utc) - timedelta(seconds=10)
+        # Wait long enough for at least one reap tick
+        await asyncio.sleep(2.5)
+        # Reaper should have terminated and cleared state
+        assert fake_proc.terminate.called, "reaper never fired"
+        assert launcher_module._current is None
+
+
+from contextlib import asynccontextmanager
+
+
+@asynccontextmanager
+async def _launcher_lifespan(app, launcher_module):
+    """Async helper to drive the lifespan context outside of a TestClient.
+    TestClient is sync; we want async control here so we can `await
+    asyncio.sleep` between events."""
+    # Manually call the lifespan's startup
+    cm = app.router.lifespan_context(app)
+    await cm.__aenter__()
+    try:
+        yield
+    finally:
+        await cm.__aexit__(None, None, None)


### PR DESCRIPTION
Fixes #372. The reaper task was being silently GC'd because PR #364 dropped the `asyncio.create_task()` return value. Diagnosed during run-20260512T124731Z which hung 2+ hours unmolested. 2 new tests; one drives the full lifespan and asserts the reaper actually fires.