### PR TITLE
fix(orchestrator): gate orchestrator_complete on main-session ResultMessage

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -70,6 +70,11 @@ class _StreamState:
     turns: int = 0
     last_webhook_time: float = 0.0
     BATCH_INTERVAL: float = 15.0  # seconds between progress webhooks
+    # The lead orchestrator's session_id, captured from the first
+    # SystemMessage(subtype="init"). Used to filter ResultMessages so
+    # teammate sub-session results don't trigger a premature
+    # orchestrator_complete webhook. See #371.
+    main_session_id: str | None = None
 
 
 async def _user_prompt_stream(text: str):
@@ -1412,6 +1417,31 @@ def handle_stream_event(
         })
 
     elif isinstance(message, ResultMessage):
+        # ResultMessages from teammate sub-sessions (spawned via the
+        # Agent tool) propagate up through the lead's stream. Each one
+        # would otherwise trigger orchestrator_complete and mark the
+        # parent run terminal — exactly the bug that left
+        # run-20260512T124731Z stuck while the lead kept working. Gate
+        # the emission on session_id matching the captured main session.
+        # See #371.
+        msg_session_id = getattr(message, "session_id", None)
+        is_main_session = (
+            state is not None
+            and state.main_session_id is not None
+            and msg_session_id is not None
+            and msg_session_id == state.main_session_id
+        )
+        if not is_main_session:
+            logger.info(
+                "Skipping orchestrator_complete emit — ResultMessage is from "
+                "sub-session %s (main=%s, subtype=%s, turns=%s)",
+                msg_session_id,
+                state.main_session_id if state else None,
+                getattr(message, "subtype", "?"),
+                getattr(message, "num_turns", "?"),
+            )
+            return
+
         # Final flush of accumulated tokens
         if state:
             post_webhook(config, "progress_update", {
@@ -1949,6 +1979,15 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                         # Only send orchestrator_start webhook on the very first init
                         if isinstance(message, SystemMessage) and getattr(message, "subtype", "") == "init":
                             if not first_init_sent:
+                                # Lock in the lead orchestrator's session_id
+                                # so handle_stream_event can filter
+                                # teammate sub-session ResultMessages
+                                # below (and avoid the premature
+                                # orchestrator_complete emission that
+                                # marked run-20260512T124731Z completed
+                                # while it was still running). See #371.
+                                if sid and stream_state.main_session_id is None:
+                                    stream_state.main_session_id = sid
                                 post_webhook(config, "orchestrator_start", {
                                     "run_id": f"run-{run_id}",
                                     "mode": project_mode,

--- a/dashboard/backend/tests/test_orchestrator_complete_session_filter.py
+++ b/dashboard/backend/tests/test_orchestrator_complete_session_filter.py
@@ -1,0 +1,93 @@
+"""Tests for the session_id gate on orchestrator_complete emission.
+
+PR #371 fixes the bug where every SDK ResultMessage — including those
+from teammate sub-sessions spawned via the Agent tool — triggered an
+orchestrator_complete webhook. That marked the parent run terminal
+prematurely. See post-mortem of run-20260512T124731Z."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+
+def _make_result_msg(session_id: str, num_turns: int = 31, subtype: str = "error_max_turns"):
+    """Build a stand-in for the SDK's ResultMessage that's identifiable
+    via isinstance via the real class."""
+    from claude_agent_sdk import ResultMessage
+    m = MagicMock(spec=ResultMessage)
+    m.session_id = session_id
+    m.num_turns = num_turns
+    m.subtype = subtype
+    m.is_error = subtype.startswith("error")
+    m.duration_ms = 100
+    m.result = ""
+    return m
+
+
+def test_emits_orchestrator_complete_for_main_session():
+    """When a ResultMessage's session_id matches the captured main
+    session, orchestrator_complete must fire."""
+    from agent.station_orchestrator import handle_stream_event, _StreamState
+    state = _StreamState(main_session_id="lead-session-abc")
+    msg = _make_result_msg("lead-session-abc", num_turns=120, subtype="success")
+
+    with patch("agent.station_orchestrator.post_webhook") as mock_post:
+        handle_stream_event(msg, config={}, run_id="r-1", state=state)
+
+    events = [c.args[1] for c in mock_post.call_args_list]
+    assert "orchestrator_complete" in events, f"main-session result must emit, got: {events}"
+
+
+def test_skips_orchestrator_complete_for_teammate_session():
+    """A ResultMessage from a teammate sub-session (different session_id)
+    must NOT trigger orchestrator_complete. This is THE bug from
+    run-20260512T124731Z."""
+    from agent.station_orchestrator import handle_stream_event, _StreamState
+    state = _StreamState(main_session_id="lead-session-abc")
+    msg = _make_result_msg("qa-teammate-session-xyz", num_turns=31, subtype="error_max_turns")
+
+    with patch("agent.station_orchestrator.post_webhook") as mock_post:
+        handle_stream_event(msg, config={}, run_id="r-1", state=state)
+
+    events = [c.args[1] for c in mock_post.call_args_list]
+    assert "orchestrator_complete" not in events, \
+        f"teammate sub-session result must NOT emit, got: {events}"
+
+
+def test_skips_when_main_session_id_unknown():
+    """Defensive: if we never captured the main session_id (e.g. SDK
+    behavior changed and no init SystemMessage arrived), skip the emit
+    rather than fire on every ResultMessage. The orchestrator's
+    try/finally already handles graceful shutdown."""
+    from agent.station_orchestrator import handle_stream_event, _StreamState
+    state = _StreamState(main_session_id=None)
+    msg = _make_result_msg("some-session", num_turns=5)
+
+    with patch("agent.station_orchestrator.post_webhook") as mock_post:
+        handle_stream_event(msg, config={}, run_id="r-1", state=state)
+
+    events = [c.args[1] for c in mock_post.call_args_list]
+    assert "orchestrator_complete" not in events, \
+        f"missing main_session_id must skip emit, got: {events}"
+
+
+def test_skips_when_message_lacks_session_id():
+    """Some SDK message variants may not carry session_id. Skip emit
+    rather than fire on every untraceable ResultMessage."""
+    from agent.station_orchestrator import handle_stream_event, _StreamState
+    state = _StreamState(main_session_id="lead-session-abc")
+    msg = _make_result_msg("", num_turns=5)
+    msg.session_id = None  # explicitly null out
+
+    with patch("agent.station_orchestrator.post_webhook") as mock_post:
+        handle_stream_event(msg, config={}, run_id="r-1", state=state)
+
+    events = [c.args[1] for c in mock_post.call_args_list]
+    assert "orchestrator_complete" not in events


### PR DESCRIPTION
Fixes #371. Premature `orchestrator_complete` was being emitted on every SDK ResultMessage, including teammate sub-session results, marking the parent run terminal while the lead was still working. Captures the lead session_id from the first SystemMessage init and gates the emit on a match. 4 tests, including the exact regression from run-20260512T124731Z.