### PR TITLE
fix(orchestrator): capture lead session_id from any first message

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1976,18 +1976,26 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                         if sid:
                             session_id = sid
 
+                        # Capture the lead's session_id from the first
+                        # message that has one, regardless of message type.
+                        # SDK's SystemMessage(init) doesn't always carry
+                        # session_id (verified empirically — only {type,
+                        # subtype} fields present); the assistant/result
+                        # message right after init does. Without this
+                        # broader capture, state.main_session_id stays
+                        # None and handle_stream_event's session filter
+                        # falls back to its defensive skip-all path. See
+                        # #371 + run-20260512T133721Z follow-up.
+                        if sid and stream_state.main_session_id is None:
+                            stream_state.main_session_id = sid
+                            logger.info(
+                                "Captured lead session_id=%s for run-%s",
+                                sid, run_id,
+                            )
+
                         # Only send orchestrator_start webhook on the very first init
                         if isinstance(message, SystemMessage) and getattr(message, "subtype", "") == "init":
                             if not first_init_sent:
-                                # Lock in the lead orchestrator's session_id
-                                # so handle_stream_event can filter
-                                # teammate sub-session ResultMessages
-                                # below (and avoid the premature
-                                # orchestrator_complete emission that
-                                # marked run-20260512T124731Z completed
-                                # while it was still running). See #371.
-                                if sid and stream_state.main_session_id is None:
-                                    stream_state.main_session_id = sid
                                 post_webhook(config, "orchestrator_start", {
                                     "run_id": f"run-{run_id}",
                                     "mode": project_mode,

--- a/dashboard/backend/tests/test_orchestrator_complete_session_filter.py
+++ b/dashboard/backend/tests/test_orchestrator_complete_session_filter.py
@@ -91,3 +91,16 @@ def test_skips_when_message_lacks_session_id():
 
     events = [c.args[1] for c in mock_post.call_args_list]
     assert "orchestrator_complete" not in events
+
+
+def test_stream_state_main_session_id_is_settable():
+    """Sanity: _StreamState.main_session_id is a plain attribute set
+    by the orchestrate() loop on the first message with a session_id
+    (any message type — the SDK's SystemMessage(init) does not always
+    carry session_id, so we capture broadly). See run-20260512T133721Z
+    follow-up where init had only {type, subtype}."""
+    from agent.station_orchestrator import _StreamState
+    state = _StreamState()
+    assert state.main_session_id is None
+    state.main_session_id = "captured-from-first-assistant-msg"
+    assert state.main_session_id == "captured-from-first-assistant-msg"


### PR DESCRIPTION
Follow-up to PR #374. The session-id capture was gated on `SystemMessage(init)`, but the SDK's init message doesn't carry session_id (verified in production stream of run-20260512T133721Z). The capture is now broader: first message with any session_id wins.

Refs #371.