### PR TITLE
fix(bash): manager_heartbeat keeps reapers off during long manager review (#376)

### DIFF
--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -1928,6 +1928,23 @@ Read the review package file first, then evaluate each project's work against th
         return 0
     fi
 
+    # Heartbeat: the bash does not parse the manager stream (it is streamed
+    # to a file). Without a side-channel ping, the launcher's _zombie_reaper
+    # (120s timeout) and the dashboard's stale_run_reaper kill an otherwise-
+    # healthy manager review around the 2-minute mark. See issue #376.
+    local _heartbeat_pid=""
+    (
+        # Subshell suppresses all output so it cannot pollute the function's
+        # captured-output return value (the verdicts_file path echoed below).
+        while sleep 30; do
+            webhook_event "manager_heartbeat" phase "manager_review" >/dev/null 2>&1 || true
+        done
+    ) >/dev/null 2>&1 &
+    _heartbeat_pid=$!
+    # Function-scoped RETURN trap fires on every return path (success,
+    # set -e crash, signal). No existing RETURN trap to clobber.
+    trap 'kill "$_heartbeat_pid" 2>/dev/null || true; trap - RETURN' RETURN
+
     local stream_file="$LOG_DIR/run-${RUN_ID}-manager.stream.jsonl"
     local stderr_file="$LOG_DIR/run-${RUN_ID}-manager.stderr.log"
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,7 +307,7 @@ review-criteria branching.
 
 ### Run-level run kinds
 
-- **Agent Teams flow** (the default for `full`/`analyze`/`plan`/`plan_only`) — lead decomposes eligible issues into tasks, spawns three teammates in isolated worktrees, manager reviews each implementation, verdicts issued (APPROVE/PR/REJECT for `full`; APPROVE_PLAN/REVISE_PLAN/REJECT_PLAN for `plan_only`).
+- **Agent Teams flow** (the default for `full`/`analyze`/`plan`/`plan_only`) — lead decomposes eligible issues into tasks, spawns three teammates in isolated worktrees, manager reviews each implementation, verdicts issued (APPROVE/PR/REJECT for `full`; APPROVE_PLAN/REVISE_PLAN/REJECT_PLAN for `plan_only`). The bash-driven manager-review phase emits a `manager_heartbeat` webhook every 30 s while `claude -p` runs so the launcher's `_zombie_reaper` and the dashboard's `stale_run_reaper` don't kill an otherwise-healthy review (see issue #376).
 - **`vision-bootstrap`** — single-shot run that dispatches `agent/vision_analyst.py` to propose new issues from `docs/vision.md`. Triggered automatically (orchestrator empty backlog, or vision commit with content-hash change) or manually from the Vision tab. Never spawns teammates, never opens PRs.
 - **`fix`** — single-issue repair mode for regressions and urgent bugs (legacy; not exposed in the project mode dropdown).
 - **`triage`** — issue classification and labeling without implementation (legacy).

--- a/docs/design/issue-376.md
+++ b/docs/design/issue-376.md
@@ -1,0 +1,74 @@
+# Design — Issue #376: Heartbeat coverage during bash manager review
+
+**Status**: design
+**Date**: 2026-05-12
+**Issue**: [#376](https://github.com/kenhaesler/claude-agent-station/issues/376)
+**Targets**: `dev`
+
+## Context
+
+After implementation phase ends, `agent/scripts/run-manager.sh::run_manager_review()` (around line 1871) spawns `claude -p --output-format stream-json` to evaluate employee work. Stdout is redirected to `run-<RUN_ID>-manager.stream.jsonl`; the bash itself does not parse turns and does not emit webhooks while the manager is thinking.
+
+The launcher's `_zombie_reaper` (`agent/launcher.py:217`) and the dashboard's `stale_run_reaper` both interpret a >120 s webhook silence as a hung run and kill it. Reproduced in `run-20260512T133721Z`: the manager was actively progressing (logs show per-turn manager output), but no `webhook-tick` calls reached the launcher, so SIGTERM/SIGKILL fired at 133 s of silence — even though the manager review was healthy and partway through real work.
+
+The implementation phase avoids this because `station_orchestrator.py` streams from the Agent SDK and emits a webhook per narration / progress event. The bash-driven manager review has no equivalent.
+
+## Goals
+
+- A long-running manager review phase (5–10 minutes is plausible on a multi-project run) does not get killed by either reaper.
+- Heartbeats only fire while the manager is actually running — no leaked background loops after `run_manager_review` returns.
+- The fix is local to bash; no Python or dashboard changes required.
+- The fix is small enough to land independently of the milestone-2 bash→Python migration. Once M2 lands, this hack disappears with the rest of `run_manager_review`.
+
+## Non-goals
+
+- Operator-visible manager progress in the dashboard. That is the issue's "option 2" — stream-parse the manager output and emit per-turn webhooks. Bigger change, deferred to a follow-up issue.
+- Bumping the reaper timeout. That masks the problem and weakens detection for genuinely-hung runs (the issue's "option 3", explicitly rejected).
+- Touching the implementation-phase webhook flow.
+
+## Approach
+
+**Option 1 from the issue** — background heartbeat shell loop, killed on `run_manager_review` exit.
+
+1. Before invoking `claude -p`, fork a subshell that emits `webhook_event manager_heartbeat` every 30 s. Capture the subshell's PID.
+2. Run the `claude -p | while read …` pipeline as today.
+3. After the pipeline exits, `kill` the heartbeat subshell. Use a `trap` so the heartbeat is killed even if `run_manager_review` returns early (error path) or the parent receives a signal.
+
+### Why 30 s
+
+- Reaper timeout is 120 s. 30 s gives 3 chances before timeout; one missed iteration is recoverable, two consecutive misses still doesn't trip the reaper.
+- Cheap — each iteration is one HTTP POST to `/webhook` + one to `/webhook-tick`. Both already exist; no new endpoints.
+
+### Why a new event type (`manager_heartbeat`)
+
+- Dashboards already filter event types. Reusing an existing event (e.g., `manager_review`) would either double-count or mislead the timeline view.
+- A new no-op event with `event_type="manager_heartbeat"` lands in the events log, is ignored by the timeline UI, and bumps `Run.last_event_at` plus the launcher's `_last_webhook_at` — exactly what the reapers care about.
+
+### Subprocess lifecycle
+
+The heartbeat subshell must die when:
+- `run_manager_review` returns normally (claude exited)
+- `run_manager_review` errors out before the kill
+- The parent bash receives SIGTERM/SIGKILL (e.g., from the existing reaper for genuinely-hung claude)
+
+`trap "kill $HEARTBEAT_PID 2>/dev/null || true" EXIT INT TERM` inside `run_manager_review` is the cleanest local trap. We must save and restore any outer EXIT trap if one exists — `run-manager.sh` already has an EXIT trap for finalization; we use a function-local trap pattern that doesn't clobber the global one.
+
+## Alternatives considered
+
+- **Issue option 2 (stream-parse manager output and emit per-turn webhooks).** Better operator UX (manager progress visible in the dashboard), but requires non-trivial bash JSON wrangling. The bash already does shallow parsing for log lines (line 1940–1965); extending it to emit a `manager_progress` webhook per turn is doable but invasive. Deferred: file a follow-up issue once #376 lands.
+- **Issue option 3 (bump `ZOMBIE_TIMEOUT_SECONDS` to 600 for the manager phase).** Two problems: (a) the launcher doesn't currently know which phase the bash is in, so we'd need new IPC; (b) masks the real observability gap — a manager that genuinely hangs after 30 s of silence should still be reaped, just on a per-event basis.
+- **Move the manager review into Python now.** Correct long-term direction, but it belongs in the milestone-2 work, not a same-day hotfix. Doing it here would inflate scope and likely regress.
+
+## Testing
+
+- **Unit (bash)**: a small bats/shell test that stubs `webhook_event` to a counter file, runs `run_manager_review` with `claude` replaced by `sleep 90`, and asserts the counter is ≥ 2 (two 30 s intervals).
+- **Integration**: a triggered run with a deliberately slow manager (e.g. via `--max-turns 50` on a large review package) completes without being reaped. Manual; checklist in PR.
+
+## Rollback
+
+Single commit on `run-manager.sh`. Revertable in one click; no schema, no API, no shared state.
+
+## Out of scope (follow-ups)
+
+1. Per-turn manager progress webhooks (issue option 2).
+2. Same fix for any other long bash-driven phases (assigner_start? planner_complete?). A quick audit of all `claude -p` invocations in `run-manager.sh` will confirm if other phases share the gap.

--- a/docs/spec/issue-376.md
+++ b/docs/spec/issue-376.md
@@ -1,0 +1,113 @@
+# Spec — Issue #376: Manager review heartbeat
+
+**Status**: spec
+**Design**: [`docs/design/issue-376.md`](../design/issue-376.md)
+**Issue**: [#376](https://github.com/kenhaesler/claude-agent-station/issues/376)
+**Targets**: `dev`
+
+## Acceptance (from issue)
+
+- [ ] A successful 3-teammate full-mode run with a 5+ minute manager review phase completes without being reaped.
+- [ ] Launcher's `_zombie_reaper` does NOT fire during manager review.
+- [ ] Dashboard's `stale_run_reaper` does NOT mark the run interrupted during manager review.
+- [ ] Test: simulate a long bash phase with no orchestrator webhooks and assert the run completes.
+
+## Files changed
+
+| Path | Action | Approx LOC |
+|---|---|---|
+| `agent/scripts/run-manager.sh` | edit (`run_manager_review` function, ~line 1871) | +25 |
+| `agent/scripts/tests/test_manager_heartbeat.bats` | new (or shell-based smoke) | +40 |
+
+No other files. No Python changes. No dashboard changes.
+
+## Implementation steps
+
+### 1. Add the heartbeat helper
+
+Inside `run_manager_review()` in `agent/scripts/run-manager.sh`, before the `cd "$WORKSPACES_DIR"` and `claude -p` invocation:
+
+```bash
+# Fork a background loop that pings the launcher every 30 s during the
+# manager review. The bash does NOT parse the manager's stdout (which is
+# streamed to a file), so without this the launcher's _zombie_reaper kills
+# the run after 120 s of webhook silence. See issue #376.
+(
+    # Detach from job control so the trap-driven kill below is reliable.
+    while sleep 30; do
+        webhook_event "manager_heartbeat" phase "manager_review" >/dev/null 2>&1 || true
+    done
+) &
+local _heartbeat_pid=$!
+# Kill the heartbeat on any exit from this function — normal return, error,
+# parent signal. Use a function-local trap that restores afterwards.
+trap 'kill '"$_heartbeat_pid"' 2>/dev/null || true' RETURN
+```
+
+The `RETURN` trap is bash 4+ and fires when the function returns by any path (return, error, last-statement). It does not collide with the global `EXIT` trap that handles run-level finalization.
+
+If the bash interpreter version on the target host does not support function-scoped `RETURN` traps, fall back to an explicit `kill "$_heartbeat_pid" 2>/dev/null || true` at every `return` path inside `run_manager_review` plus a `trap … EXIT` register-and-restore dance. Spec assumes bash ≥ 4.0 (Rocky Linux 9 default is 5.1).
+
+### 2. Confirm `manager_heartbeat` is treated as a benign event
+
+The webhook handler at `dashboard/backend/app/routers/webhook.py` already bumps `Run.last_event_at` for every event (per #348). No frontend change needed; the timeline view filters known event types and ignores unknown ones.
+
+Verify by reading the webhook router: confirm there is no `match`/`if` that throws on unknown `event_type`. If there is, add `manager_heartbeat` to the known set with no side effects beyond the heartbeat bump.
+
+### 3. Test
+
+`agent/scripts/tests/test_manager_heartbeat.sh` (new):
+
+```bash
+#!/usr/bin/env bash
+# Smoke test: run_manager_review's heartbeat fires at least twice during a
+# 90s simulated manager run.
+set -euo pipefail
+
+WEBHOOK_COUNTER=$(mktemp)
+echo 0 > "$WEBHOOK_COUNTER"
+
+# Stub webhook_event to a counter.
+webhook_event() {
+    if [ "$1" = "manager_heartbeat" ]; then
+        local n
+        n=$(cat "$WEBHOOK_COUNTER")
+        echo $((n+1)) > "$WEBHOOK_COUNTER"
+    fi
+}
+export -f webhook_event
+
+# Stub claude binary to sleep instead.
+fake_claude() { sleep 90; }
+export -f fake_claude
+
+# Source run-manager.sh in a mode that lets us call the function directly,
+# with the heartbeat patched in. (Implementation may need a tiny --test-mode
+# flag in run-manager.sh; if so, add it.)
+
+# Source library, invoke run_manager_review with stubs, then:
+count=$(cat "$WEBHOOK_COUNTER")
+[ "$count" -ge 2 ] || { echo "FAIL: heartbeat fired $count times, expected ≥ 2"; exit 1; }
+echo "PASS: heartbeat fired $count times"
+```
+
+If extracting `run_manager_review` for direct invocation proves too invasive, accept manual verification only and document the manual test plan in the PR body. The dashboard observation (no reaper fires during a real 5-min manager review) is the load-bearing test.
+
+### 4. Documentation
+
+Add a one-line note in `docs/architecture.md` under the run-manager phase description: "Manager review phase emits a `manager_heartbeat` webhook every 30 s while `claude -p` runs (#376) so the zombie reapers don't kill it."
+
+## Risks
+
+- **Trap clobbering.** If the global `EXIT` trap and the new `RETURN` trap interact badly, run cleanup could be skipped. Mitigation: `RETURN` is function-scoped; it cannot override `EXIT`. Read the existing EXIT trap registration once to confirm.
+- **Zombie heartbeat after SIGKILL.** If the parent bash gets SIGKILL'd (not SIGTERM), the trap won't fire and the subshell leaks. Mitigation: the subshell's parent-PID check on its `webhook_event` POST would catch this; alternatively, set the subshell's parent-death-signal via `prctl` (not portably available in bash). Accepted risk: SIGKILL leaks one subshell that exits when its next `webhook_event` HTTP call sees the launcher-side `/webhook-tick` return `stale=true` (or simply fails). Low impact; cleared on next run.
+- **30 s × N runs flood the webhook log.** Each event hits `runs.last_event_at` and the events table. 30 s cadence × 5 min = 10 events. Negligible.
+
+## Rollback
+
+Single commit, single file. `git revert <sha>` and re-deploy.
+
+## Out of scope
+
+- Per-turn manager progress webhooks (issue option 2). Filed as a follow-up.
+- Heartbeats for other bash phases. Audit during PR review whether any other `claude -p` call site has the same gap.


### PR DESCRIPTION
## Summary
- Adds a 30 s background `webhook_event manager_heartbeat` loop while `claude -p` runs in `run_manager_review`.
- Function-scoped `RETURN` trap kills the loop on every exit path (return, `set -e` crash, signal). Subshell output is suppressed so it cannot pollute the function's captured `verdicts_file` return value.
- New `manager_heartbeat` event flows through the dashboard's existing `handle_unknown` path — no whitelist update required; bumps `Run.last_event_at` like every other event.

Fixes #376. Targets `dev`.

## Why
The bash redirects the manager's stream-json output to a file and does no per-turn parsing. With no webhook traffic during the review, the launcher's `_zombie_reaper` (120 s) and the dashboard's `stale_run_reaper` both conclude the run is hung and kill it — even when the manager is healthily working through turns. Repro: `run-20260512T133721Z`.

## Documents in this PR
- `docs/design/issue-376.md` — design (option chosen, alternatives considered).
- `docs/spec/issue-376.md` — concrete files/tests/risks.
- `docs/architecture.md` — one-line update describing the heartbeat.
- `agent/scripts/run-manager.sh` — implementation.

## Test plan
- [ ] Trigger a real run with a multi-project review package; verify dashboard does not mark it `interrupted` during manager review.
- [ ] Tail launcher logs and confirm no `_zombie_reaper: subprocess pid=… alive but silent for …s` warning during manager phase.
- [ ] Verify `Run.last_event_at` advances every 30 s in the DB while the review runs.
- [ ] Confirm the heartbeat subshell is gone (no leaked sleep processes) after `run_manager_review` returns — `pgrep -P <run-manager pid>` after the function returns.
- [ ] Bash syntax check: `bash -n agent/scripts/run-manager.sh` (already green locally).

## Follow-ups (not in this PR)
- Option 2 from the issue (stream-parse manager output for per-turn webhooks) — file a separate issue.
- Audit other `claude -p` call sites in `run-manager.sh` for the same heartbeat gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)