### PR TITLE
refactor(agent): verdict_execution module (#363, step 1)

### DIFF
--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -1,0 +1,349 @@
+"""Execute manager verdicts via gh/git subprocess calls.
+
+The manager review writes verdicts JSON like:
+
+    {"verdicts": [
+        {"project": "owner/repo",
+         "issue_number": 123,
+         "verdict": "APPROVE" | "PR" | "REJECT" | "SKIP",
+         "branch": "autonomous/issue-123",
+         "base_branch": "main",
+         "reasoning": "Manager's prose explanation",
+         "mode": "full"},
+        ...
+    ]}
+
+The bash currently walks this list and executes each verdict inline
+via ``gh pr create`` / ``git push`` / ``gh issue comment`` / label edits
+(see ``agent/scripts/run-manager.sh`` lines ~2050–2500).
+
+This module provides the **Python primitives** for those operations so
+the bash deletion in a follow-up session has a stable target. Today it
+is invokable but not yet wired — the bash continues to execute verdicts
+directly. See :func:`execute` for the dispatcher signature.
+
+What's intentionally NOT in this module:
+
+- Analyze-mode handling, integration-branch merging, queue state
+  updates, intelligence-loop outcome recording. Those live in
+  ``run-manager.sh`` and stay there until the broader bash phase port
+  lands (deferred follow-up).
+- Conflict resolution. Continues to invoke the separate
+  ``agent.conflict_resolver`` subprocess; this module does not duplicate
+  that logic.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from agent.gh_client import gh_run
+
+logger = logging.getLogger(__name__)
+
+VerdictKind = Literal["APPROVE", "PR", "REJECT", "SKIP"]
+
+
+@dataclass
+class Verdict:
+    """Parsed verdict from the manager's verdicts JSON. Mirrors the
+    field names the bash reads at run-manager.sh:2027 onward.
+    """
+
+    project: str
+    issue_number: int | None
+    verdict: VerdictKind
+    branch: str
+    base_branch: str = "main"
+    reasoning: str = ""
+    mode: str = "full"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Verdict":
+        return cls(
+            project=str(data.get("project") or ""),
+            issue_number=_optional_int(data.get("issue_number")),
+            verdict=str(data.get("verdict") or "REJECT"),  # type: ignore[arg-type]
+            branch=str(data.get("branch") or ""),
+            base_branch=str(data.get("base_branch") or "main"),
+            reasoning=str(data.get("reasoning") or ""),
+            mode=str(data.get("mode") or "full"),
+        )
+
+
+def _optional_int(value: Any) -> int | None:
+    if value in (None, "", "null", "None"):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass
+class ExecutionResult:
+    """Outcome of executing one verdict. The dispatcher returns one of
+    these per verdict so the caller can fold them into a run summary
+    or surface failures in a webhook payload.
+    """
+
+    verdict: VerdictKind
+    project: str
+    issue_number: int | None
+    success: bool
+    pr_url: str | None = None
+    error: str | None = None
+    actions: list[str] = field(default_factory=list)
+
+    def with_action(self, action: str) -> "ExecutionResult":
+        self.actions.append(action)
+        return self
+
+
+def _build_pr_body(verdict: Verdict, *, run_id: str | None = None) -> str:
+    body = verdict.reasoning or "(no reasoning supplied)"
+    if verdict.issue_number is not None:
+        # Use the close-keywords plural form so multi-issue PRs work too;
+        # GitHub also accepts the singular for a one-issue PR.
+        body += f"\n\nCloses #{verdict.issue_number}"
+    if run_id:
+        body += f"\n\n---\nAutonomous run: {run_id}"
+    return body
+
+
+def execute_approve(
+    verdict: Verdict,
+    *,
+    workspace: Path,
+    run_id: str | None = None,
+    env: dict[str, str] | None = None,
+) -> ExecutionResult:
+    """Push the branch, open a PR, comment on the issue.
+
+    Does NOT auto-merge, does NOT close the issue — those decisions live
+    in the bash path that consumes this module (deferred follow-up).
+    """
+    result = ExecutionResult(
+        verdict="APPROVE",
+        project=verdict.project,
+        issue_number=verdict.issue_number,
+        success=False,
+    )
+
+    # 1. git push origin <branch>
+    push = subprocess.run(
+        ["git", "push", "-u", "origin", verdict.branch],
+        cwd=str(workspace), capture_output=True, text=True, env=env,
+    )
+    if push.returncode != 0:
+        result.error = f"git push failed: {push.stderr.strip()[:200]}"
+        return result
+    result.with_action("git push")
+
+    # 2. gh pr create
+    pr = gh_run(
+        [
+            "pr", "create",
+            "--repo", verdict.project,
+            "--head", verdict.branch,
+            "--base", verdict.base_branch,
+            "--title", _pr_title(verdict),
+            "--body", _build_pr_body(verdict, run_id=run_id),
+        ],
+        env=env,
+    )
+    if not pr.ok:
+        result.error = f"gh pr create failed: {pr.stderr.strip()[:200]}"
+        return result
+    result.pr_url = pr.stdout.strip()
+    result.with_action(f"gh pr create → {result.pr_url}")
+
+    # 3. issue comment (best-effort; do not fail the verdict on this)
+    if verdict.issue_number is not None:
+        _post_issue_comment(verdict, body_prefix="## Manager verdict: APPROVED",
+                            run_id=run_id, env=env, into=result)
+    result.success = True
+    return result
+
+
+def execute_pr(
+    verdict: Verdict,
+    *,
+    workspace: Path,
+    run_id: str | None = None,
+    env: dict[str, str] | None = None,
+    draft: bool = True,
+) -> ExecutionResult:
+    """Open a draft PR (or marked-ready) for manual review. Same path as
+    APPROVE but with ``--draft`` and a different issue comment.
+    """
+    result = ExecutionResult(
+        verdict="PR",
+        project=verdict.project,
+        issue_number=verdict.issue_number,
+        success=False,
+    )
+
+    push = subprocess.run(
+        ["git", "push", "-u", "origin", verdict.branch],
+        cwd=str(workspace), capture_output=True, text=True, env=env,
+    )
+    if push.returncode != 0:
+        result.error = f"git push failed: {push.stderr.strip()[:200]}"
+        return result
+    result.with_action("git push")
+
+    pr_args = [
+        "pr", "create",
+        "--repo", verdict.project,
+        "--head", verdict.branch,
+        "--base", verdict.base_branch,
+        "--title", _pr_title(verdict),
+        "--body", _build_pr_body(verdict, run_id=run_id),
+    ]
+    if draft:
+        pr_args.append("--draft")
+    pr = gh_run(pr_args, env=env)
+    if not pr.ok:
+        result.error = f"gh pr create failed: {pr.stderr.strip()[:200]}"
+        return result
+    result.pr_url = pr.stdout.strip()
+    result.with_action(f"gh pr create{' --draft' if draft else ''} → {result.pr_url}")
+
+    if verdict.issue_number is not None:
+        _post_issue_comment(
+            verdict,
+            body_prefix="## Manager verdict: PR opened for human review",
+            run_id=run_id, env=env, into=result,
+        )
+    result.success = True
+    return result
+
+
+def execute_reject(
+    verdict: Verdict,
+    *,
+    workspace: Path | None = None,  # noqa: ARG001 — unused, kept for caller symmetry
+    run_id: str | None = None,
+    env: dict[str, str] | None = None,
+) -> ExecutionResult:
+    """Comment on the issue and apply the reject label. No branch
+    operations — the feature branch stays local for the operator to
+    inspect / rerun.
+    """
+    result = ExecutionResult(
+        verdict="REJECT",
+        project=verdict.project,
+        issue_number=verdict.issue_number,
+        success=True,  # rejecting is "successful execution of the reject"
+    )
+    if verdict.issue_number is None:
+        result.with_action("skip (no issue_number)")
+        return result
+
+    _post_issue_comment(
+        verdict, body_prefix="🤖 **Manager verdict: REJECTED**",
+        run_id=run_id, env=env, into=result,
+    )
+    # Remove in-progress and add a needs-help label so the human knows.
+    for label in ("autonomous-agent/in-progress", "autonomous-agent/done"):
+        gh_run(
+            [
+                "issue", "edit", str(verdict.issue_number),
+                "--repo", verdict.project,
+                "--remove-label", label,
+            ],
+            env=env,
+        )
+        result.with_action(f"remove-label {label}")
+    return result
+
+
+def execute_skip(
+    verdict: Verdict,
+    *,
+    workspace: Path | None = None,  # noqa: ARG001 — kept for symmetry
+    run_id: str | None = None,
+    env: dict[str, str] | None = None,
+) -> ExecutionResult:
+    """SKIP is observably similar to REJECT but with a kinder message
+    (the manager chose not to act this cycle, not that the work was bad).
+    """
+    result = ExecutionResult(
+        verdict="SKIP",
+        project=verdict.project,
+        issue_number=verdict.issue_number,
+        success=True,
+    )
+    if verdict.issue_number is None:
+        result.with_action("skip (no issue_number)")
+        return result
+
+    _post_issue_comment(
+        verdict, body_prefix="🤖 **Manager verdict: SKIPPED this cycle**",
+        run_id=run_id, env=env, into=result,
+    )
+    return result
+
+
+_EXECUTORS = {
+    "APPROVE": execute_approve,
+    "PR": execute_pr,
+    "REJECT": execute_reject,
+    "SKIP": execute_skip,
+}
+
+
+def execute(verdict: Verdict, **kwargs) -> ExecutionResult:
+    """Dispatch to the right execute_* helper based on ``verdict.verdict``.
+
+    Unknown verdicts are coerced to REJECT (the bash's safe default) so
+    a malformed manager output doesn't push code on accident.
+    """
+    fn = _EXECUTORS.get(verdict.verdict, execute_reject)
+    return fn(verdict, **kwargs)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _pr_title(verdict: Verdict) -> str:
+    if verdict.issue_number is not None:
+        return f"autonomous: resolve #{verdict.issue_number}"
+    return f"autonomous: {verdict.branch}"
+
+
+def _post_issue_comment(
+    verdict: Verdict,
+    *,
+    body_prefix: str,
+    run_id: str | None,
+    env: dict[str, str] | None,
+    into: ExecutionResult,
+) -> None:
+    body = body_prefix
+    if verdict.reasoning:
+        body += f" — {verdict.reasoning}"
+    if run_id:
+        body += f"\n\nRun: {run_id}"
+    if verdict.issue_number is None:
+        return
+    result = gh_run(
+        [
+            "issue", "comment", str(verdict.issue_number),
+            "--repo", verdict.project,
+            "--body", body,
+        ],
+        env=env,
+    )
+    if result.ok:
+        into.with_action(f"gh issue comment #{verdict.issue_number}")
+    else:
+        logger.warning(
+            "verdict_execution: gh issue comment failed for %s#%s: %s",
+            verdict.project, verdict.issue_number, result.stderr.strip()[:200],
+        )

--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -249,7 +249,10 @@ def execute_reject(
         verdict, body_prefix="🤖 **Manager verdict: REJECTED**",
         run_id=run_id, env=env, into=result,
     )
-    # Remove in-progress and add a needs-help label so the human knows.
+    # Clear the in-progress / done labels so the issue surfaces in the
+    # next pick_issue pass as eligible work. Mirrors the bash REJECT
+    # path at run-manager.sh:2196-2197. No new label is added — the
+    # comment alone signals the rejection to humans.
     for label in ("autonomous-agent/in-progress", "autonomous-agent/done"):
         gh_run(
             [

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -1,0 +1,274 @@
+"""Tests for agent.verdict_execution (#363).
+
+These tests pin the per-decision argv shape so reviewers can diff
+against the bash invocations in agent/scripts/run-manager.sh
+(~lines 2200–2500). Drift here means the Python module would push
+code, label issues, or comment in subtly different ways from the
+bash it replaces.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+def _verdict(verdict_kind: str = "APPROVE", **overrides):
+    from agent.verdict_execution import Verdict
+
+    fields = dict(
+        project="owner/repo",
+        issue_number=42,
+        verdict=verdict_kind,
+        branch="autonomous/issue-42",
+        base_branch="main",
+        reasoning="Looks good",
+        mode="full",
+    )
+    fields.update(overrides)
+    return Verdict(**fields)
+
+
+def _ok_gh_result(stdout: str = ""):
+    from agent.gh_client import GhResult
+
+    return GhResult(cmd=["gh"], returncode=0, stdout=stdout, stderr="")
+
+
+def _fail_gh_result(stderr: str = "boom"):
+    from agent.gh_client import GhResult
+
+    return GhResult(cmd=["gh"], returncode=1, stdout="", stderr=stderr)
+
+
+def _ok_subprocess():
+    cp = MagicMock()
+    cp.returncode = 0
+    cp.stdout = ""
+    cp.stderr = ""
+    return cp
+
+
+def _fail_subprocess(stderr: str = "permission denied"):
+    cp = MagicMock()
+    cp.returncode = 1
+    cp.stdout = ""
+    cp.stderr = stderr
+    return cp
+
+
+# ── APPROVE ────────────────────────────────────────────────────────────
+
+
+def test_approve_pushes_branch_then_creates_pr_then_comments(tmp_path):
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/100"
+
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_ok_subprocess()) as mock_sp, \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [_ok_gh_result(stdout=pr_url),
+                               _ok_gh_result(stdout="")]
+        result = execute(_verdict("APPROVE"), workspace=tmp_path, run_id="run-1")
+
+    assert result.success
+    assert result.pr_url == pr_url
+    # Git push as the first subprocess call
+    push_args = mock_sp.call_args_list[0].args[0]
+    assert push_args[:2] == ["git", "push"]
+    assert "autonomous/issue-42" in push_args
+    # gh pr create as the first gh call
+    pr_args = mock_gh.call_args_list[0].args[0]
+    assert pr_args[:2] == ["pr", "create"]
+    assert pr_args[pr_args.index("--repo") + 1] == "owner/repo"
+    assert pr_args[pr_args.index("--head") + 1] == "autonomous/issue-42"
+    assert pr_args[pr_args.index("--base") + 1] == "main"
+    # gh issue comment second
+    comment_args = mock_gh.call_args_list[1].args[0]
+    assert comment_args[:2] == ["issue", "comment"]
+    assert "42" in comment_args
+
+
+def test_approve_records_failure_when_git_push_fails(tmp_path):
+    from agent.verdict_execution import execute
+
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_fail_subprocess("rejected")), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        result = execute(_verdict("APPROVE"), workspace=tmp_path)
+
+    assert not result.success
+    assert "git push failed" in (result.error or "")
+    # gh MUST NOT have been called — push failure aborts the verdict
+    mock_gh.assert_not_called()
+
+
+def test_approve_records_failure_when_pr_create_fails(tmp_path):
+    from agent.verdict_execution import execute
+
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_ok_subprocess()), \
+         patch("agent.verdict_execution.gh_run",
+               side_effect=[_fail_gh_result("a PR already exists")]):
+        result = execute(_verdict("APPROVE"), workspace=tmp_path)
+
+    assert not result.success
+    assert "gh pr create failed" in (result.error or "")
+    assert "PR already exists" in (result.error or "")
+
+
+def test_approve_body_includes_closes_keyword_when_issue_present(tmp_path):
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/100"
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_ok_subprocess()), \
+         patch("agent.verdict_execution.gh_run",
+               side_effect=[_ok_gh_result(stdout=pr_url),
+                            _ok_gh_result()]) as mock_gh:
+        execute(_verdict("APPROVE"), workspace=tmp_path, run_id="run-1")
+
+    pr_args = mock_gh.call_args_list[0].args[0]
+    body = pr_args[pr_args.index("--body") + 1]
+    assert "Closes #42" in body
+    assert "Run" not in body  # Run line goes in issue comment, not PR body
+    assert "Autonomous run: run-1" in body
+
+
+# ── PR (draft) ─────────────────────────────────────────────────────────
+
+
+def test_pr_verdict_passes_draft_flag_by_default(tmp_path):
+    from agent.verdict_execution import execute
+
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_ok_subprocess()), \
+         patch("agent.verdict_execution.gh_run",
+               side_effect=[_ok_gh_result(stdout="url"),
+                            _ok_gh_result()]) as mock_gh:
+        execute(_verdict("PR"), workspace=tmp_path)
+
+    pr_args = mock_gh.call_args_list[0].args[0]
+    assert "--draft" in pr_args
+
+
+def test_pr_verdict_caller_can_disable_draft(tmp_path):
+    from agent.verdict_execution import execute
+
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_ok_subprocess()), \
+         patch("agent.verdict_execution.gh_run",
+               side_effect=[_ok_gh_result(stdout="url"),
+                            _ok_gh_result()]) as mock_gh:
+        execute(_verdict("PR"), workspace=tmp_path, draft=False)
+
+    pr_args = mock_gh.call_args_list[0].args[0]
+    assert "--draft" not in pr_args
+
+
+# ── REJECT ─────────────────────────────────────────────────────────────
+
+
+def test_reject_comments_and_removes_labels_without_touching_git(tmp_path):
+    from agent.verdict_execution import execute
+
+    with patch("agent.verdict_execution.subprocess.run") as mock_sp, \
+         patch("agent.verdict_execution.gh_run",
+               return_value=_ok_gh_result()) as mock_gh:
+        result = execute(_verdict("REJECT"), workspace=tmp_path)
+
+    assert result.success
+    # git push MUST NOT happen on REJECT
+    mock_sp.assert_not_called()
+    # Exactly: 1 issue comment + 2 label removals
+    invocations = [c.args[0][:3] for c in mock_gh.call_args_list]
+    assert ["issue", "comment", "42"] in invocations
+    label_edits = [c for c in mock_gh.call_args_list
+                   if c.args[0][:2] == ["issue", "edit"]]
+    assert len(label_edits) == 2
+    removed_labels = {
+        c.args[0][c.args[0].index("--remove-label") + 1]
+        for c in label_edits
+    }
+    assert removed_labels == {
+        "autonomous-agent/in-progress",
+        "autonomous-agent/done",
+    }
+
+
+def test_reject_with_no_issue_number_is_a_clean_noop(tmp_path):
+    from agent.verdict_execution import execute
+
+    with patch("agent.verdict_execution.subprocess.run") as mock_sp, \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        result = execute(_verdict("REJECT", issue_number=None),
+                         workspace=tmp_path)
+    assert result.success
+    mock_sp.assert_not_called()
+    mock_gh.assert_not_called()
+    assert "skip" in " ".join(result.actions).lower()
+
+
+# ── SKIP ───────────────────────────────────────────────────────────────
+
+
+def test_skip_comments_and_does_not_modify_anything_else(tmp_path):
+    from agent.verdict_execution import execute
+
+    with patch("agent.verdict_execution.subprocess.run") as mock_sp, \
+         patch("agent.verdict_execution.gh_run",
+               return_value=_ok_gh_result()) as mock_gh:
+        result = execute(_verdict("SKIP"), workspace=tmp_path)
+
+    assert result.success
+    mock_sp.assert_not_called()
+    # Exactly one gh call: the issue comment. No label edits, no push.
+    assert len(mock_gh.call_args_list) == 1
+    assert mock_gh.call_args_list[0].args[0][:2] == ["issue", "comment"]
+
+
+# ── dispatcher safety ─────────────────────────────────────────────────
+
+
+def test_unknown_verdict_kind_falls_back_to_reject(tmp_path):
+    """If the manager produces a verdict string we don't recognise, the
+    dispatcher MUST default to REJECT so we never push code on accident.
+    """
+    from agent.verdict_execution import execute
+
+    with patch("agent.verdict_execution.subprocess.run") as mock_sp, \
+         patch("agent.verdict_execution.gh_run",
+               return_value=_ok_gh_result()) as mock_gh:
+        # type: ignore[arg-type] — deliberately wrong verdict kind
+        result = execute(_verdict("UNKNOWN_KIND"), workspace=tmp_path)  # type: ignore[arg-type]
+
+    # No git push under any circumstance for an unrecognised verdict.
+    mock_sp.assert_not_called()
+    # We executed REJECT — issue comment + 2 label removals
+    invocations = {tuple(c.args[0][:2]) for c in mock_gh.call_args_list}
+    assert ("issue", "comment") in invocations
+    assert ("issue", "edit") in invocations
+
+
+def test_verdict_from_dict_handles_string_and_null_issue_number():
+    from agent.verdict_execution import Verdict
+
+    # JSON-ish input with stringy issue_number
+    v = Verdict.from_dict({
+        "project": "x/y",
+        "issue_number": "17",
+        "verdict": "APPROVE",
+        "branch": "feat/foo",
+    })
+    assert v.issue_number == 17
+
+    # null / "None" / empty are all None
+    for sentinel in (None, "null", "None", ""):
+        v = Verdict.from_dict({
+            "project": "x/y",
+            "issue_number": sentinel,
+            "verdict": "REJECT",
+            "branch": "feat/foo",
+        })
+        assert v.issue_number is None, f"sentinel {sentinel!r} should map to None"

--- a/docs/spec/issue-363.md
+++ b/docs/spec/issue-363.md
@@ -1,0 +1,170 @@
+# Spec — Issue #363: Port verdict execution path to Python
+
+**Status**: spec
+**Design**: [`docs/design/milestone-2.md`](../design/milestone-2.md)
+**Issue**: [#363](https://github.com/kenhaesler/claude-agent-station/issues/363)
+**Targets**: `dev`
+**Depends on**: #361 (may land before or after #362)
+
+## Acceptance (from issue)
+
+- [ ] Verdicts (APPROVE / PR / REJECT) for a triggered run produce the same `gh`/`git` state as the bash path.
+- [ ] Conflict resolution still works (current bash conflict resolver is a separate subprocess; keep that interface).
+- [ ] Bash verdict blocks deleted from `run-manager.sh`.
+
+## Files changed
+
+| Path | Action | Approx LOC |
+|---|---|---|
+| `agent/verdict_execution.py` | new | ~+250 |
+| `agent/gh_client.py` | extend or create (shared with #362) | small |
+| `agent/project_loop.py` | call verdict_execution after manager review | ~+30 |
+| `agent/scripts/run-manager.sh` | delete verdict blocks (~lines 2100–2500) | ~−400 |
+| `tests/test_verdict_execution.py` | new | ~+200 |
+| `docs/architecture.md` | update | small |
+
+## Acceptance breakdown
+
+Each bash verdict path has a Python equivalent that yields **identical observable side effects** (gh API state, git refs, issue comments, labels). Specifically:
+
+| Verdict | Bash actions | Python equivalent |
+|---|---|---|
+| APPROVE | `git push origin <branch>`; `gh pr create … --base main`; merge if auto-merge; `gh issue comment` summary; close issue | `execute_approve(verdict, branch, base_branch)` — same |
+| PR (draft) | `git push`; `gh pr create --draft`; `gh issue comment` with PR URL | `execute_pr(verdict, branch, base_branch, draft=True)` |
+| REJECT | `gh issue comment` with rejection reason; `gh issue edit --add-label <reject_label>` | `execute_reject(verdict, reason)` |
+| SKIP | `gh issue comment` with skip reason | `execute_skip(verdict, reason)` |
+
+## Implementation steps
+
+### 1. `agent/verdict_execution.py`
+
+```python
+"""Execute manager verdicts via gh/git subprocess calls.
+
+Verdict shape (matches what the manager writes to the verdicts JSON):
+{
+    "project": "owner/repo",
+    "issue_number": 123,
+    "decision": "APPROVE" | "PR" | "REJECT" | "SKIP",
+    "branch": "autonomous/issue-123",
+    "base_branch": "dev",
+    "summary": "Manager's prose verdict",
+    "reason": "If REJECT/SKIP, the reason"
+}
+"""
+
+from dataclasses import dataclass
+from agent.gh_client import gh_run, gh_json, GhError
+
+@dataclass
+class ExecutionResult:
+    decision: str
+    project: str
+    issue_number: int
+    success: bool
+    pr_url: str | None = None
+    error: str | None = None
+
+def execute_approve(verdict: Verdict, *, dry_run: bool = False) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(...success=True)
+    # git push origin <branch>
+    push = subprocess.run(["git", "push", "origin", verdict.branch], cwd=workspace, ...)
+    if push.returncode != 0:
+        return ExecutionResult(success=False, error=f"git push failed: {push.stderr}")
+    # gh pr create
+    pr = gh_run(["pr", "create",
+                 "--repo", verdict.project,
+                 "--head", verdict.branch,
+                 "--base", verdict.base_branch,
+                 "--title", verdict.title,
+                 "--body", verdict.body])
+    if pr.returncode != 0:
+        return ExecutionResult(success=False, error=...)
+    pr_url = pr.stdout.strip()
+    # gh issue comment
+    gh_run(["issue", "comment", str(verdict.issue_number),
+            "--repo", verdict.project, "--body", verdict.summary])
+    return ExecutionResult(success=True, pr_url=pr_url, ...)
+
+def execute_pr(...): ...
+def execute_reject(...): ...
+def execute_skip(...): ...
+
+def execute(verdict: Verdict, **kwargs) -> ExecutionResult:
+    """Dispatcher — picks the right execute_* per verdict.decision."""
+    return {
+        "APPROVE": execute_approve,
+        "PR": execute_pr,
+        "REJECT": execute_reject,
+        "SKIP": execute_skip,
+    }[verdict.decision](verdict, **kwargs)
+```
+
+### 2. Conflict resolution preservation
+
+The current `agent/conflict_resolver/` runs as a separate subprocess. Before pushing on APPROVE/PR, the bash invokes the conflict resolver if the branch isn't fast-forward-able with `base_branch`. Replicate:
+
+```python
+# In execute_approve / execute_pr, before git push:
+if _needs_rebase(verdict.branch, verdict.base_branch):
+    rc = subprocess.run([sys.executable, "-m", "agent.conflict_resolver",
+                         "--branch", verdict.branch,
+                         "--base", verdict.base_branch],
+                        capture_output=True, text=True)
+    if rc.returncode != 0:
+        return ExecutionResult(success=False, error=f"conflict_resolver: {rc.stderr}")
+```
+
+Keep the subprocess interface — do not refactor conflict resolver in this PR.
+
+### 3. Caller integration
+
+In `agent/project_loop.py` (after #362):
+
+```python
+def iterate_projects(...):
+    ...
+    # After manager review writes verdicts to disk:
+    verdicts = _load_verdicts(verdicts_path)
+    for v in verdicts:
+        result = verdict_execution.execute(v)
+        webhook_emitter.emit("verdict_execute", run_id=run_id, payload={...})
+```
+
+If #362 hasn't landed yet, `project_loop.py` still shims to bash, but the verdict block in bash now invokes `python3 -m agent.verdict_execution` per verdict instead of running the gh/git calls directly. That intermediate stage is fine — it cleanly retires the bash without depending on #362.
+
+### 4. Delete bash
+
+Remove the verdict execution blocks from `run-manager.sh`. After deletion:
+- If #362 has merged: `run-manager.sh` should be near-empty. Delete it if safe.
+- If #362 hasn't merged: keep the bash file but with the verdict blocks excised and the dispatcher replaced with `python3 -m agent.verdict_execution`.
+
+### 5. Tests
+
+- `test_verdict_execution.py`:
+  - Mock `subprocess.run` for `git push`, `gh pr create`, `gh issue comment`, `gh issue edit`.
+  - Per-decision cases: APPROVE happy path, APPROVE with push failure, PR draft happy path, REJECT, SKIP.
+  - Conflict resolver branch: subprocess returns non-zero → ExecutionResult.success=False with error wired through.
+  - Assert exact argv for each subprocess call (golden-file style) against `tests/fixtures/verdict_argv_<decision>.json`.
+
+### 6. Documentation
+
+`docs/architecture.md`: replace the bash verdict description with the Python module call. List the file paths and the public functions.
+
+## Risks
+
+- **`gh pr create --body` shell quoting.** Multi-line verdict prose with backticks and quotes can corrupt the gh command when bash builds it as a string; Python avoids this naturally via argv lists. Watch for any bash workaround (e.g., writing the body to a temp file and using `--body-file`) — replicate the safe form.
+- **Conflict resolver re-entry.** If the resolver itself runs gh/git operations and races against our pre-push gate, results can diverge. Mitigation: pin the resolver invocation to the same workspace as our git push and verify with an integration test.
+- **Token scopes.** `gh pr create` needs PR-write scope; `gh issue edit --add-label` needs labels scope. Bash relies on the ambient `GH_TOKEN`; Python should pass the same env. Don't introduce a different auth path.
+- **Comment double-posting.** If a verdict execution fails mid-flow (push succeeds, gh pr create fails, retry succeeds), we may double-post the issue comment. Mitigation: include an idempotency marker in the comment body and check `gh issue view` before posting (or accept best-effort — the bash had the same risk).
+
+## Rollback
+
+Revert PR. `verdict_execution.py` becomes dead; bash verdict blocks come back. Clean.
+
+## Out of scope
+
+- Refactoring `agent/conflict_resolver/`.
+- Issue picking / dispatch port (#362).
+- Removing `run-manager.sh` entirely (incidental if #362 has already landed).


### PR DESCRIPTION
## Summary
- **Step 1 of 2 for verdict execution.** Ships the Python module; bash deletion deferred.
- New `agent/verdict_execution.py`: `Verdict` / `ExecutionResult` dataclasses + `execute_approve` / `execute_pr` / `execute_reject` / `execute_skip` + safe `execute()` dispatcher (unknown verdicts → REJECT, never pushes code).
- New `agent/gh_client.py`: shared with PR #379 (#362). Whichever PR lands first wins; the second's add is a no-op merge.

Refs #363. Targets `dev`.

## What landed
- `agent/verdict_execution.py` (new) — 349 LOC.
- `agent/gh_client.py` (new, shared with #362).
- `dashboard/backend/tests/test_verdict_execution.py` (11 tests).
- `docs/design/milestone-2.md`, `docs/spec/issue-363.md` from earlier commits.

## What's not in this PR (deferred to follow-up sessions)
- Bash verdict block deletion (`run-manager.sh` lines ~2050-2500). Requires also porting analyze-mode handling, integration-branch merging, queue state updates, and intelligence-loop outcome recording out of bash. Multi-session work.
- In-process invocation. Today the bash continues to execute verdicts directly via inline `gh`/`git` calls; this module is callable but not yet wired into the live flow.

## Test results
- `test_verdict_execution.py` (11 tests) — passing.

## Acceptance criteria
- [x] APPROVE/PR/REJECT path equivalent gh/git operations exist in Python — covered by per-decision argv tests.
- [x] Conflict resolution preserves the subprocess interface — by omission; this module doesn't touch it.
- [ ] Bash verdict blocks deleted — deferred.

## Notable safety property
The dispatcher falls back to REJECT on an unrecognised verdict kind (`test_unknown_verdict_kind_falls_back_to_reject`). A malformed manager output cannot push code by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)