### PR TITLE
fix(orchestrator): unblock long Agent Teams sessions (stdin, work-complete gate, stream break)

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1478,6 +1478,39 @@ def handle_stream_event(
             )
             return
 
+        # Even when the session matches, this may be an intermediate
+        # ResultMessage from the lead — e.g. when the lead delegates work
+        # via the Agent tool, the SDK emits a turn-complete ResultMessage
+        # for the lead well before any actual work is done. The outer loop
+        # already uses _is_work_complete() to distinguish; mirror that
+        # check here so orchestrator_complete only fires once, when the
+        # lead signals actual completion. Without this gate the dashboard
+        # marks the run terminal on the first ResultMessage and the
+        # ongoing lead/teammate work runs orphaned. Surfaced after the
+        # _user_prompt_stream stdin fix (PR #381) removed the
+        # incidental "one-result-per-query" rate-limit that had been
+        # masking this. See run-20260512T205423Z.
+        result_text = getattr(message, "result", "")
+        if not _is_work_complete(result_text):
+            # Still flush accumulated tokens so progress_update is current,
+            # but do NOT emit orchestrator_complete — the lead is mid-flight.
+            if state:
+                post_webhook(config, "progress_update", {
+                    "run_id": f"run-{run_id}",
+                    "tokens_input": state.tokens_in,
+                    "tokens_output": state.tokens_out,
+                    "tokens_total": state.tokens_in + state.tokens_out,
+                    "turns": state.turns,
+                })
+            logger.info(
+                "Skipping orchestrator_complete emit — main-session ResultMessage "
+                "but result_text does not signal work completion (turns=%s, "
+                "result_preview=%r)",
+                getattr(message, "num_turns", "?"),
+                (result_text or "")[:120],
+            )
+            return
+
         # Final flush of accumulated tokens
         if state:
             post_webhook(config, "progress_update", {
@@ -1493,7 +1526,6 @@ def handle_stream_event(
             "duration_ms": getattr(message, "duration_ms", 0),
             "num_turns": getattr(message, "num_turns", 0),
         })
-        result_text = getattr(message, "result", "")
         if result_text:
             logger.info("Orchestrator result:\n%s", result_text[:2000])
 

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -82,18 +82,53 @@ async def _user_prompt_stream(text: str):
     """Wrap a string prompt as the AsyncIterable form the SDK requires when
     ``can_use_tool`` or ``hooks`` are supplied.
 
-    Yields one user message then ends. The SDK is designed for this shape
-    and handles stdin lifetime itself via ``_first_result_event`` and the
-    ``CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`` env var (in ms; 60s default).
-    Long Agent Teams sessions need that timeout bumped; see
-    :mod:`agent.launcher` where it's set on the orchestrator subprocess.
+    **Generator must NOT return for the lifetime of the SDK session.**
+
+    The SDK's :py:meth:`Query.stream_input` (`claude_agent_sdk/_internal/query.py`)
+    is structured as::
+
+        async for message in stream:
+            await self.transport.write(...)
+        await self.wait_for_result_and_end_input()  # closes stdin
+
+    The moment this generator returns, ``stream_input`` exits its
+    ``async for`` and immediately calls ``wait_for_result_and_end_input``,
+    which closes stdin as soon as the **first** ``ResultMessage`` arrives
+    (which for an Agent Teams session is seconds in — the lead agent's
+    first turn). Every subsequent PreToolUse / PostToolUse hook callback
+    the CLI tries to make to the Python side then raises
+    ``Error("Stream closed")`` at ``cli.js:7552 sendRequest`` — the
+    audit_hook stops recording for the rest of the run.
+
+    ``CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`` (set to 1800000 ms by
+    :mod:`agent.launcher`) only sets the *maximum* wait for the first
+    result event before closing stdin anyway — it does not delay the
+    close once the event fires. For a one-shot ``query()`` call this is
+    correct; for our long-running Agent Teams sessions it cripples the
+    audit log.
+
+    Fix: yield the single user message, then suspend forever on an
+    event that never fires. The SDK's ``stream_input`` blocks in the
+    ``async for``, never reaches ``wait_for_result_and_end_input``, and
+    stdin stays open. When the orchestrator's outer ``query()`` iterator
+    completes, ``InternalClient.process_query`` calls ``query.close()``
+    in its ``finally`` block; the task group cancels this generator,
+    which raises ``anyio.get_cancelled_exc_class()`` and propagates up
+    cleanly.
     """
+    import anyio  # local import — anyio is already a transitive dep via the SDK
+
     yield {
         "type": "user",
         "session_id": "",
         "message": {"role": "user", "content": text},
         "parent_tool_use_id": None,
     }
+    # Suspend for the lifetime of the SDK session. Cancellation arrives
+    # via the SDK's task group when query.close() runs in its finally
+    # block, which raises an anyio cancelled exception — the desired
+    # teardown path.
+    await anyio.Event().wait()
 
 
 SKIP_LABELS = frozenset({

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -2079,11 +2079,25 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
                             logger.info("Stop requested; breaking SDK stream")
                             break
 
-                        # Check result for completion
+                        # Check result for completion. When matched, also
+                        # break out of the inner ``async for`` — before
+                        # PR #381 the SDK naturally closed stdin after the
+                        # first ResultMessage and the stream ended for us,
+                        # but now stdin stays open and the stream never
+                        # terminates on its own. Without this break the
+                        # orchestrator process sits in the inner loop
+                        # forever after the lead said "done", the bash
+                        # parent never observes our exit, and the
+                        # launcher's zombie reaper eventually SIGTERMs
+                        # us ~2 min later. See run-20260512T213225Z.
                         if isinstance(message, ResultMessage):
                             result_text = getattr(message, "result", "")
                             if _is_work_complete(result_text):
                                 work_complete = True
+                                logger.info(
+                                    "Work-complete signal received; breaking SDK stream"
+                                )
+                                break
 
                     if control_flags["stop"]:
                         raise OrchestratorStopRequested()

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -116,19 +116,25 @@ async def _user_prompt_stream(text: str):
     which raises ``anyio.get_cancelled_exc_class()`` and propagates up
     cleanly.
     """
-    import anyio  # local import — anyio is already a transitive dep via the SDK
-
     yield {
         "type": "user",
         "session_id": "",
         "message": {"role": "user", "content": text},
         "parent_tool_use_id": None,
     }
-    # Suspend for the lifetime of the SDK session. Cancellation arrives
-    # via the SDK's task group when query.close() runs in its finally
-    # block, which raises an anyio cancelled exception — the desired
-    # teardown path.
-    await anyio.Event().wait()
+    # Suspend up to one hour. asyncio.sleep handles both cancellation
+    # paths the SDK uses:
+    #   - CancelledError when the SDK task group cancels us during
+    #     query.close() (propagates up cleanly)
+    #   - GeneratorExit when the consumer calls aclose() on the iterator
+    #     (Python's generator machinery handles this transparently)
+    # The earlier anyio.Event().wait() pattern left the orchestrator
+    # process lingering after teardown — see run-20260513T044331Z.
+    # asyncio.sleep with a hard cap avoids both that and the failure
+    # mode where, if cleanup signaling somehow doesn't reach us, the
+    # generator still returns within the cap and stdin is allowed to
+    # close.
+    await asyncio.sleep(3600)
 
 
 SKIP_LABELS = frozenset({
@@ -2451,6 +2457,54 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _force_exit_with_cleanup(exit_code: int) -> None:
+    """Terminate any lingering child claude/bundled-CLI subprocesses, then
+    os._exit. Used after orchestrate() returns because the SDK's transport
+    teardown does not reliably reap its bundled CLI subprocess: production
+    has seen the bundled CLI process keep running, firing failed hooks
+    against a closed stdin, long after the Python orchestrator is "done"
+    — flooding the bash log stream and effectively leaking until SIGKILL.
+
+    Going through ``os._exit`` instead of ``sys.exit`` skips Python's
+    atexit + finalizer machinery (which has nothing useful to do at this
+    point — webhooks have already fired) and immediately closes all
+    inherited file descriptors. The kernel then reparents and reaps any
+    children to init.
+    """
+    import signal as _signal_mod
+
+    # Find any direct children of this PID (orchestrator subprocess).
+    # /proc walk is portable enough for our container target (Linux) and
+    # avoids a `psutil` dependency just for cleanup.
+    try:
+        my_pid = os.getpid()
+        for entry in os.listdir("/proc"):
+            if not entry.isdigit():
+                continue
+            try:
+                with open(f"/proc/{entry}/status") as f:
+                    parent = None
+                    for line in f:
+                        if line.startswith("PPid:"):
+                            parent = int(line.split()[1])
+                            break
+                if parent != my_pid:
+                    continue
+                # It's our child; politely SIGTERM. The kernel will
+                # reap it once we os._exit and init takes over.
+                os.kill(int(entry), _signal_mod.SIGTERM)
+            except (OSError, ValueError, FileNotFoundError):
+                continue
+    except Exception:  # noqa: BLE001 — best-effort
+        logger.debug("cleanup: failed to enumerate /proc", exc_info=True)
+    # Bypass the asyncio.run finalizer + SDK transport close path that
+    # has been observed to hang. Webhooks already fired; nothing else
+    # depends on a clean Python shutdown here.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(exit_code)
+
+
 def main() -> None:
     logging.basicConfig(
         level=logging.INFO,
@@ -2472,7 +2526,7 @@ def main() -> None:
     # Existing Agent Teams orchestration path — unchanged.
     config = load_config(args.config)
     exit_code = asyncio.run(orchestrate(config, args.run_id, args.workspaces_dir))
-    sys.exit(exit_code)
+    _force_exit_with_cleanup(exit_code)
 
 
 if __name__ == "__main__":

--- a/dashboard/backend/tests/test_force_exit_cleanup.py
+++ b/dashboard/backend/tests/test_force_exit_cleanup.py
@@ -1,0 +1,137 @@
+"""Tests for agent.station_orchestrator._force_exit_with_cleanup.
+
+After orchestrate() returns, the SDK's transport teardown does not
+reliably reap its bundled CLI subprocess — production has seen the
+bundled CLI keep running, firing failed PreToolUse/PostToolUse hook
+callbacks against a closed stdin, flooding the bash log stream long
+after the Python orchestrator was "done". See run-20260513T044331Z.
+
+main() now calls _force_exit_with_cleanup which:
+1. Enumerates this process's direct children via /proc walk
+2. SIGTERMs them so the kernel reaps them on our exit
+3. Calls os._exit (bypasses asyncio.run / SDK teardown that has been
+   observed to hang)
+
+These tests cover the SIGTERM enumeration and the failure-tolerant
+shape — they cannot easily cover os._exit itself without spawning a
+subprocess.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+from unittest.mock import patch
+
+
+def test_signals_only_direct_children(tmp_path):
+    """When called, the cleanup MUST signal only this process's
+    direct children — NOT grandchildren, NOT unrelated processes
+    that happen to have the same PPid in some other tree.
+    """
+    from agent.station_orchestrator import _force_exit_with_cleanup
+
+    my_pid = os.getpid()
+    # Fake /proc tree: pid 1000 is our child, pid 2000 is NOT.
+    proc_entries = ["1000", "2000", "1", "self"]
+
+    def _fake_open(path, *args, **kwargs):
+        # Only respond to status files we expect
+        if path == "/proc/1000/status":
+            from io import StringIO
+            return StringIO(f"Name: child\nState: S\nPPid: {my_pid}\n")
+        if path == "/proc/2000/status":
+            from io import StringIO
+            return StringIO("Name: unrelated\nState: S\nPPid: 1\n")
+        raise FileNotFoundError(path)
+
+    killed: list[int] = []
+
+    def _fake_kill(pid, sig):
+        assert sig == signal.SIGTERM, (
+            f"cleanup must use SIGTERM, not {sig!r} — graceful is essential "
+            f"because the bundled SDK CLI is a normal child process and "
+            f"we don't want to leave half-written files."
+        )
+        killed.append(pid)
+
+    def _fake_exit(code):
+        raise SystemExit(code)
+
+    with patch("agent.station_orchestrator.os.listdir", return_value=proc_entries), \
+         patch("builtins.open", side_effect=_fake_open), \
+         patch("agent.station_orchestrator.os.kill", side_effect=_fake_kill), \
+         patch("agent.station_orchestrator.os._exit", side_effect=_fake_exit):
+        try:
+            _force_exit_with_cleanup(0)
+        except SystemExit:
+            pass
+
+    assert killed == [1000], (
+        f"Cleanup signaled wrong PIDs. Expected only [1000] (our child); "
+        f"got {killed!r}. Either it picked up an unrelated process (PPid "
+        f"mismatch leaked) or skipped our actual child."
+    )
+
+
+def test_swallows_oserror_from_dead_processes(tmp_path):
+    """Children can die between /proc enumeration and os.kill. The
+    cleanup MUST swallow the resulting OSError so it can keep
+    signaling other children.
+    """
+    from agent.station_orchestrator import _force_exit_with_cleanup
+
+    my_pid = os.getpid()
+
+    def _fake_open(path, *args, **kwargs):
+        from io import StringIO
+        if path.startswith("/proc/") and path.endswith("/status"):
+            return StringIO(f"Name: child\nPPid: {my_pid}\n")
+        raise FileNotFoundError(path)
+
+    kill_attempts: list[int] = []
+
+    def _flaky_kill(pid, sig):
+        kill_attempts.append(pid)
+        if pid == 1000:
+            raise ProcessLookupError("No such process")
+        # pid 2000 succeeds
+
+    with patch("agent.station_orchestrator.os.listdir",
+               return_value=["1000", "2000"]), \
+         patch("builtins.open", side_effect=_fake_open), \
+         patch("agent.station_orchestrator.os.kill", side_effect=_flaky_kill), \
+         patch("agent.station_orchestrator.os._exit"):
+        _force_exit_with_cleanup(0)
+
+    assert kill_attempts == [1000, 2000], (
+        f"Cleanup gave up after the first failure. Got: {kill_attempts!r}. "
+        f"It must keep going so one dead child doesn't leave others "
+        f"unsignaled."
+    )
+
+
+def test_eventually_calls_os_exit_with_provided_code():
+    """The whole point is to bypass the asyncio.run teardown that has
+    been observed to hang. Cleanup MUST end in os._exit with the
+    correct exit code — not return normally (which would let asyncio.run
+    cleanup run).
+    """
+    from agent.station_orchestrator import _force_exit_with_cleanup
+
+    actual_exit_code: list[int] = []
+
+    def _record_exit(code):
+        actual_exit_code.append(code)
+        raise SystemExit(code)
+
+    with patch("agent.station_orchestrator.os.listdir", return_value=[]), \
+         patch("agent.station_orchestrator.os._exit", side_effect=_record_exit):
+        try:
+            _force_exit_with_cleanup(42)
+        except SystemExit:
+            pass
+
+    assert actual_exit_code == [42], (
+        f"_force_exit_with_cleanup did not call os._exit(42); got: {actual_exit_code!r}"
+    )

--- a/dashboard/backend/tests/test_orchestrator_complete_session_filter.py
+++ b/dashboard/backend/tests/test_orchestrator_complete_session_filter.py
@@ -17,7 +17,8 @@ REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT))
 
 
-def _make_result_msg(session_id: str, num_turns: int = 31, subtype: str = "error_max_turns"):
+def _make_result_msg(session_id: str, num_turns: int = 31, subtype: str = "error_max_turns",
+                     result: str = ""):
     """Build a stand-in for the SDK's ResultMessage that's identifiable
     via isinstance via the real class."""
     from claude_agent_sdk import ResultMessage
@@ -27,16 +28,22 @@ def _make_result_msg(session_id: str, num_turns: int = 31, subtype: str = "error
     m.subtype = subtype
     m.is_error = subtype.startswith("error")
     m.duration_ms = 100
-    m.result = ""
+    m.result = result
     return m
 
 
 def test_emits_orchestrator_complete_for_main_session():
     """When a ResultMessage's session_id matches the captured main
-    session, orchestrator_complete must fire."""
+    session AND its result text signals work completion,
+    orchestrator_complete must fire. (Both gates apply since the
+    work-completion gate was added — see run-20260512T205423Z post-mortem.)
+    """
     from agent.station_orchestrator import handle_stream_event, _StreamState
     state = _StreamState(main_session_id="lead-session-abc")
-    msg = _make_result_msg("lead-session-abc", num_turns=120, subtype="success")
+    msg = _make_result_msg(
+        "lead-session-abc", num_turns=120, subtype="success",
+        result="Final summary: all teammates completed; PRs opened.",
+    )
 
     with patch("agent.station_orchestrator.post_webhook") as mock_post:
         handle_stream_event(msg, config={}, run_id="r-1", state=state)

--- a/dashboard/backend/tests/test_orchestrator_complete_work_gate.py
+++ b/dashboard/backend/tests/test_orchestrator_complete_work_gate.py
@@ -1,0 +1,152 @@
+"""Tests for the orchestrator_complete work-completion gate (run-20260512T205423Z).
+
+After the _user_prompt_stream stdin fix (PR #381), the SDK keeps stdin
+open for the full lifetime of the lead session — so the lead can emit
+multiple ResultMessages during one query() call (e.g., turn-complete
+when delegation finishes, then later a real completion).
+
+handle_stream_event's session_id gate (added in #371) prevents
+teammate sub-session ResultMessages from firing orchestrator_complete,
+but it doesn't gate intermediate lead ResultMessages. Without an
+extra check, the FIRST lead ResultMessage — emitted seconds after
+delegation, while teammates are still running — marks the run
+terminal in the dashboard.
+
+These tests pin the contract: orchestrator_complete fires ONCE, on
+the ResultMessage whose result text passes _is_work_complete().
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+_MAIN_SESSION = "session-main-abc"
+_SUB_SESSION = "session-teammate-xyz"
+
+
+def _result_message(result_text: str, *, session_id: str = _MAIN_SESSION,
+                    num_turns: int = 1):
+    """Build a minimal ResultMessage-shaped object handle_stream_event accepts."""
+    from claude_agent_sdk.types import ResultMessage
+
+    # Construct via SimpleNamespace then promote isinstance via a real class
+    # would be cleaner, but handle_stream_event only uses isinstance() and
+    # attribute access; we use the real type so isinstance(ResultMessage)
+    # passes inside handle_stream_event.
+    msg = ResultMessage(
+        subtype="success",
+        duration_ms=1000,
+        duration_api_ms=500,
+        is_error=False,
+        num_turns=num_turns,
+        session_id=session_id,
+        total_cost_usd=0.0,
+        usage=None,
+        result=result_text,
+    )
+    return msg
+
+
+def _state():
+    """Build a _StreamState with main_session_id captured."""
+    from agent.station_orchestrator import _StreamState
+
+    s = _StreamState(last_webhook_time=0.0)
+    s.main_session_id = _MAIN_SESSION
+    s.tokens_in = 1000
+    s.tokens_out = 500
+    s.turns = 3
+    return s
+
+
+def _collect_emits(handler_fn, message):
+    """Drive handle_stream_event under a patched post_webhook and return
+    the list of (event_name, payload) emitted.
+    """
+    from agent.station_orchestrator import handle_stream_event
+    seen: list[tuple[str, dict]] = []
+    with patch("agent.station_orchestrator.post_webhook",
+               side_effect=lambda cfg, event, payload: seen.append((event, payload))):
+        handle_stream_event(message, config={}, run_id="testrun",
+                            log_file=None, state=_state())
+    return seen
+
+
+# ── The new gate ──────────────────────────────────────────────────────
+
+
+def test_intermediate_lead_result_does_not_emit_orchestrator_complete():
+    """A ResultMessage from the lead's main session with prose that doesn't
+    match _is_work_complete (no 'final summary', no 'issues_completed', no
+    'all teammates completed') MUST NOT emit orchestrator_complete. This
+    is the bug from run-20260512T205423Z: the lead's delegation-turn
+    ResultMessage fired orchestrator_complete at 21:05:29 while teammates
+    were still working until 21:17.
+    """
+    from agent.station_orchestrator import handle_stream_event
+
+    msg = _result_message(
+        "I've delegated the work to the team. They will report back.",
+    )
+    seen = _collect_emits(handle_stream_event, msg)
+
+    events = [e for e, _ in seen]
+    assert "orchestrator_complete" not in events, (
+        f"orchestrator_complete fired on intermediate ResultMessage — "
+        f"emitted: {events}"
+    )
+    # progress_update IS allowed (token totals get flushed) — that's a
+    # current-state event, not a lifecycle terminal.
+    assert "progress_update" in events
+
+
+def test_completion_lead_result_with_final_summary_emits_orchestrator_complete():
+    """The terminal ResultMessage (matching _is_work_complete) MUST fire
+    orchestrator_complete. Pins that the fix didn't over-correct.
+    """
+    msg = _result_message(
+        "Final summary: all three teammates pushed branches and the manager "
+        "reviewed each. PR verdicts opened for human review.",
+        num_turns=42,
+    )
+    seen = _collect_emits(None, msg)
+
+    events = [e for e, _ in seen]
+    assert "orchestrator_complete" in events, (
+        f"orchestrator_complete should fire on terminal ResultMessage — "
+        f"emitted: {events}"
+    )
+    # The payload should carry the actual turn count for telemetry.
+    complete_payload = next(p for e, p in seen if e == "orchestrator_complete")
+    assert complete_payload["num_turns"] == 42
+    assert complete_payload["is_error"] is False
+
+
+def test_completion_lead_result_with_structured_json_summary_emits():
+    """_is_work_complete also matches the structured JSON form
+    ('issues_completed' + 'issues_failed' keys). Cover it too.
+    """
+    msg = _result_message(
+        '```json\n{"issues_completed": [27], "issues_failed": []}\n```',
+    )
+    seen = _collect_emits(None, msg)
+    assert "orchestrator_complete" in [e for e, _ in seen]
+
+
+def test_subsession_result_message_still_filtered():
+    """The session_id gate from #371 must still apply: a ResultMessage with
+    a session_id that doesn't match the captured main session must be
+    skipped, regardless of result_text. Regression guard.
+    """
+    msg = _result_message(
+        "Final summary: I did some work.",
+        session_id=_SUB_SESSION,  # NOT the main session
+    )
+    seen = _collect_emits(None, msg)
+    events = [e for e, _ in seen]
+    # Neither orchestrator_complete nor progress_update should fire — the
+    # whole branch returns early when the session doesn't match.
+    assert "orchestrator_complete" not in events
+    assert "progress_update" not in events

--- a/dashboard/backend/tests/test_user_prompt_stream_lifetime.py
+++ b/dashboard/backend/tests/test_user_prompt_stream_lifetime.py
@@ -9,9 +9,11 @@ that crippled the audit_hook on long Agent Teams runs. See:
   ``wait_for_result_and_end_input`` the moment our generator returns,
   which closes stdin as soon as the first ResultMessage arrives (i.e.
   seconds into a 50-minute Agent Teams session).
-- Fix: keep the generator alive by ``await``ing an anyio Event that
-  never fires. ``stream_input``'s ``async for`` blocks forever, and
-  stdin only closes when ``query.close()`` cancels the task group.
+- Fix: keep the generator alive by ``await``ing an ``asyncio.sleep``
+  with a one-hour cap that bounds the worst case if cleanup fails.
+  ``stream_input``'s ``async for`` blocks while we sleep, and stdin
+  only closes when ``query.close()`` cancels the task group — or, in
+  the absolute-worst-case, when the one-hour cap is reached.
 """
 
 from __future__ import annotations
@@ -55,8 +57,8 @@ def test_generator_suspends_after_first_yield_does_not_return():
         await agen.__anext__()  # consume the user message
         # Now try to advance one more step. If the generator returned,
         # this raises StopAsyncIteration immediately. If it correctly
-        # suspends on anyio.Event().wait(), this hangs forever — so
-        # we wrap it in a tight timeout and assert the timeout fires.
+        # suspends on the asyncio.sleep cap, anext won't yield within
+        # the timeout — so we assert TimeoutError fires.
         try:
             await asyncio.wait_for(agen.__anext__(), timeout=0.5)
         except asyncio.TimeoutError:
@@ -77,9 +79,9 @@ def test_generator_suspends_after_first_yield_does_not_return():
 
 def test_generator_cancels_cleanly_when_consumer_aborts():
     """When the SDK's task group cancels the stream task (during
-    ``query.close()``), the suspended ``await anyio.Event().wait()``
-    must propagate the cancellation cleanly — no swallowed exceptions,
-    no leaked task. Models the real teardown path.
+    ``query.close()``), the suspended ``asyncio.sleep`` must propagate
+    the cancellation cleanly — no swallowed exceptions, no leaked task.
+    Models the real teardown path.
     """
     from agent.station_orchestrator import _user_prompt_stream
 
@@ -101,4 +103,35 @@ def test_generator_cancels_cleanly_when_consumer_aborts():
     outcome = asyncio.run(cancel_consumer())
     assert outcome == "cancelled", (
         f"Cancellation did not propagate: {outcome!r}"
+    )
+
+
+def test_generator_returns_cleanly_on_aclose_after_first_yield():
+    """The teardown path used by the SDK's task-group cancel is
+    ``agen.aclose()``, which throws GeneratorExit at the suspended
+    point. Our generator MUST catch + return, not propagate
+    GeneratorExit out (which would manifest as an
+    'unhandled exception during asyncio.run() shutdown' warning seen
+    in run-20260513T044331Z).
+    """
+    from agent.station_orchestrator import _user_prompt_stream
+
+    async def aclose_after_first_yield():
+        agen = _user_prompt_stream("hi")
+        await agen.__anext__()  # consume the user message
+        # Now close the generator while it's suspended. This is what
+        # the SDK runtime does when its task group cancels the
+        # stream task. Must return cleanly with no exception.
+        try:
+            await agen.aclose()
+        except Exception as exc:  # noqa: BLE001 — we WANT to flag any leak
+            return f"raised: {type(exc).__name__}: {exc}"
+        return "closed-cleanly"
+
+    outcome = asyncio.run(aclose_after_first_yield())
+    assert outcome == "closed-cleanly", (
+        f"aclose() did not close cleanly: {outcome}. "
+        f"This regression would surface in production as "
+        f"'asyncio: unhandled exception during asyncio.run() shutdown' "
+        f"and a lingering Python orchestrator process."
     )

--- a/dashboard/backend/tests/test_user_prompt_stream_lifetime.py
+++ b/dashboard/backend/tests/test_user_prompt_stream_lifetime.py
@@ -1,0 +1,104 @@
+"""Tests for agent.station_orchestrator._user_prompt_stream.
+
+This generator is the load-bearing fix for the SDK's stdin-close behaviour
+that crippled the audit_hook on long Agent Teams runs. See:
+
+- Failure mode: ``cli.js:7552 sendRequest`` raises ``Error("Stream closed")``
+  for every hook callback that fires after stdin is closed.
+- Root cause: the SDK's ``Query.stream_input`` calls
+  ``wait_for_result_and_end_input`` the moment our generator returns,
+  which closes stdin as soon as the first ResultMessage arrives (i.e.
+  seconds into a 50-minute Agent Teams session).
+- Fix: keep the generator alive by ``await``ing an anyio Event that
+  never fires. ``stream_input``'s ``async for`` blocks forever, and
+  stdin only closes when ``query.close()`` cancels the task group.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+def test_generator_yields_the_user_message_first():
+    """First yield MUST be the user-message dict the SDK control protocol
+    expects (type=user, message.role=user, etc.). Pinning the shape here
+    so a future refactor doesn't accidentally change the wire contract.
+    """
+    from agent.station_orchestrator import _user_prompt_stream
+
+    async def first():
+        agen = _user_prompt_stream("hello world")
+        return await agen.__anext__()
+
+    msg = asyncio.run(first())
+    assert msg["type"] == "user"
+    assert msg["message"]["role"] == "user"
+    assert msg["message"]["content"] == "hello world"
+    # session_id is set by the SDK on the wire; we send empty to defer.
+    assert msg["session_id"] == ""
+    assert msg["parent_tool_use_id"] is None
+
+
+def test_generator_suspends_after_first_yield_does_not_return():
+    """The whole point: after yielding the user message, the generator
+    MUST NOT return. If it did, the SDK would close stdin and every
+    subsequent hook callback would fail with 'Stream closed'.
+
+    Verified by trying to advance the generator past the first yield
+    under a tight timeout — anext() must time out, not raise
+    StopAsyncIteration.
+    """
+    from agent.station_orchestrator import _user_prompt_stream
+
+    async def advance_past_first_yield():
+        agen = _user_prompt_stream("hi")
+        await agen.__anext__()  # consume the user message
+        # Now try to advance one more step. If the generator returned,
+        # this raises StopAsyncIteration immediately. If it correctly
+        # suspends on anyio.Event().wait(), this hangs forever — so
+        # we wrap it in a tight timeout and assert the timeout fires.
+        try:
+            await asyncio.wait_for(agen.__anext__(), timeout=0.5)
+        except asyncio.TimeoutError:
+            return "suspended"
+        except StopAsyncIteration:
+            return "returned"
+        return "yielded-again"
+
+    outcome = asyncio.run(advance_past_first_yield())
+    assert outcome == "suspended", (
+        f"Generator returned/yielded after first message: {outcome!r}. "
+        f"This regresses the stdin-stays-open contract and the SDK will "
+        f"close stdin as soon as the first ResultMessage arrives, "
+        f"causing every PreToolUse/PostToolUse hook to fail with "
+        f"'Stream closed' for the rest of the Agent Teams run."
+    )
+
+
+def test_generator_cancels_cleanly_when_consumer_aborts():
+    """When the SDK's task group cancels the stream task (during
+    ``query.close()``), the suspended ``await anyio.Event().wait()``
+    must propagate the cancellation cleanly — no swallowed exceptions,
+    no leaked task. Models the real teardown path.
+    """
+    from agent.station_orchestrator import _user_prompt_stream
+
+    async def cancel_consumer():
+        agen = _user_prompt_stream("hi")
+        await agen.__anext__()
+
+        # asyncio CancelledError is the equivalent of anyio cancellation
+        # for this purpose — the generator's await must respect it.
+        task = asyncio.create_task(agen.__anext__())
+        await asyncio.sleep(0.1)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            return "cancelled"
+        return "completed-somehow"
+
+    outcome = asyncio.run(cancel_consumer())
+    assert outcome == "cancelled", (
+        f"Cancellation did not propagate: {outcome!r}"
+    )

--- a/dashboard/backend/tests/test_work_complete_breaks_stream.py
+++ b/dashboard/backend/tests/test_work_complete_breaks_stream.py
@@ -1,0 +1,69 @@
+"""Test that work_complete breaks the inner async-for stream loop.
+
+After PR #381 keeps stdin open for the SDK session, the inner
+``async for message in query(...)`` loop no longer naturally exits
+when the lead is done. Without an explicit ``break`` on the
+work-complete signal, the orchestrator process keeps consuming
+messages indefinitely and is eventually SIGTERM'd by the zombie
+reaper — long after the work was actually finished.
+
+Run-20260512T213225Z surfaced this: the orchestrator emitted
+``orchestrator_complete`` at 22:06:58 (correct), then kept running,
+filtering "stale background sleep" ResultMessages at 22:07:00 and
+22:07:10, then went silent. The launcher's _zombie_reaper SIGTERM'd
+the bash child at 22:09:19 — 2+ minutes after the work was done.
+The bash never reached its manager-review phase.
+
+This test pins the contract: when ``_is_work_complete(result_text)``
+returns True for a main-session ResultMessage, the orchestrator
+must break the inner async-for loop so the session exits.
+"""
+
+from __future__ import annotations
+
+import inspect
+from agent.station_orchestrator import orchestrate
+
+
+def test_inner_stream_loop_breaks_on_work_complete():
+    """The inner ``async for message in query(...)`` block must
+    contain a ``break`` statement following a ``work_complete = True``
+    assignment. Without it, the orchestrator hangs after the lead
+    is done.
+    """
+    src = inspect.getsource(orchestrate)
+    # Locate the work-complete check and confirm a break follows
+    # before the next outer-loop control flow.
+    idx = src.find("work_complete = True")
+    assert idx != -1, "work_complete = True assignment missing from orchestrate()"
+    # Take the 200 chars following the assignment — the break must
+    # appear there, NOT later (where it would only break the outer loop).
+    tail = src[idx:idx + 400]
+    assert "break" in tail, (
+        f"`break` statement missing after `work_complete = True`. "
+        f"Without it, the inner async-for in orchestrate() never exits "
+        f"once stdin stays open (post #381) and the orchestrator process "
+        f"hangs until the zombie reaper SIGTERMs the bash child. "
+        f"See run-20260512T213225Z. Snippet:\n{tail}"
+    )
+
+
+def test_outer_loop_still_breaks_on_work_complete():
+    """The outer ``for iteration in range(max_reentries)`` loop must
+    still break when ``work_complete`` is True — this is the original
+    flow control from before #381 and should be preserved as a
+    belt-and-suspenders.
+    """
+    src = inspect.getsource(orchestrate)
+    # Find the outer-loop work_complete check
+    outer_check = "if work_complete:"
+    assert outer_check in src, (
+        "outer-loop `if work_complete:` block missing from orchestrate()"
+    )
+    # The lines after that check must include `break`
+    idx = src.find(outer_check)
+    tail = src[idx:idx + 200]
+    assert "break" in tail, (
+        f"outer-loop `break` after `if work_complete:` is missing — "
+        f"belt-and-suspenders flow control regressed. Snippet:\n{tail}"
+    )


### PR DESCRIPTION
## Summary

Closes a four-part cascade of bugs that crippled long Agent Teams sessions. Each commit fixes a distinct issue surfaced by the previous one's fix. End-to-end production verification completed on `run-20260513T151408Z` (28 min, three PRs cleanly opened).

## The bugs, in causal order

### 1. `_user_prompt_stream` returned early → SDK closed stdin → hooks failed for the rest of the session (commit `1a3e45b`)

In `claude_agent_sdk` 0.1.50, `Query.stream_input` calls `wait_for_result_and_end_input()` the moment our generator returns. That function closes stdin as soon as the **first** `ResultMessage` arrives — a few seconds into the lead's first turn. Every subsequent PreToolUse / PostToolUse hook callback then raises `Error("Stream closed")` at `cli.js:7552 sendRequest`.

`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT=1800000` set in `agent.launcher` only caps the *maximum* wait; once the first result arrives, the close fires regardless. Env override was effectively a no-op.

**Fix:** after yielding the user message, suspend with `asyncio.sleep(3600)` (1-hour cap). The SDK's `async for` blocks on the generator, `wait_for_result_and_end_input` is never called, stdin stays open.

### 2. Intermediate `ResultMessage`s fired `orchestrator_complete` prematurely (commit `11d78de`)

With stdin staying open (fix #1), the lead emits multiple `ResultMessage`s in a single `query()` call (turn-complete boundaries, not work-complete). `handle_stream_event`'s session-id gate from #371 filters out teammate sub-sessions but not intermediate lead results. The first one fired `orchestrator_complete` — dashboard marked the run terminal while teammates were still running.

**Fix:** in the main-session-matched branch, also check `_is_work_complete(result_text)`. If false, flush `progress_update` and return without emitting `orchestrator_complete`.

### 3. Inner `async for` loop never broke on work-complete (commit `432feac`)

Before fix #1, the SDK closed stdin after the first ResultMessage and the inner async-for naturally exited. The outer `for iteration in range(max_reentries)` loop would then check `work_complete` and break. With stdin staying open, the inner loop never exits on its own. The orchestrator process hung after the lead said "done", and the launcher's `_zombie_reaper` SIGTERM'd the bash child ~2 minutes later. The bash never reached its manager-review phase.

**Fix:** when `_is_work_complete(result_text)` matches, set `work_complete = True` AND `break` out of the inner async-for. The outer-loop check is preserved as belt-and-suspenders.

### 4. Bundled SDK CLI subprocess wasn't reaped → hook-error flood corrupted bash log stream (commit `aaf5a9d`)

After the inner break (fix #3), the SDK's task-group teardown sometimes doesn't reap its bundled CLI subprocess. That subprocess keeps running, firing failed hook callbacks against a closed stdin, generating noise that follows the bash into its manager-review phase. Also surfaces as `ERROR asyncio: unhandled exception during asyncio.run() shutdown`.

**Fix:** new `_force_exit_with_cleanup(exit_code)`:
- Walks `/proc`, finds direct children of this process
- SIGTERMs them
- Calls `os._exit` (bypasses asyncio.run's finalizer)

`main()`'s non-driver path now ends in this helper instead of `sys.exit`.

## Test coverage

29 tests, all passing:

| Test file | New tests |
|---|---|
| `test_user_prompt_stream_lifetime.py` | yields correct shape; suspends after first yield; cancels cleanly; aclose returns cleanly |
| `test_orchestrator_complete_work_gate.py` | intermediate result skipped; terminal result fires; structured-JSON form fires; sub-session still filtered |
| `test_work_complete_breaks_stream.py` | inner-loop break exists; outer-loop break preserved |
| `test_force_exit_cleanup.py` | signals only direct children; swallows OSError; ends in os._exit(code) |
| `test_orchestrator_complete_session_filter.py` | (updated) existing test uses completion-signalling result |

## Production verification — run-20260513T151408Z

| Metric | Before fixes (run-...193836Z, ...213225Z, ...044331Z) | After all fixes (run-...151408Z) |
|---|---|---|
| Run status | `completed` but ~no work / `failed` mid-review | **`completed`** with verdict |
| Duration | 45-50 min (truncated) | **28 min (clean)** |
| Log size | thousands of lines of noise | **418 lines** |
| `Error in hook callback` | 424+ per run | **0** |
| `error: Stream closed` | 1000s | **0** |
| `forwarding SIGTERM` | 1 (reaper had to step in) | **0** |
| `_zombie_reaper` warnings | several | **0** |
| Lingering processes after run | yes | **0** |
| PRs created | 0 (run failed mid-manager-review) | **3 (issues #27, #28 — backend / frontend / qa)** |

Full handoff chain confirmed in production:
```
15:33:54  Work-complete signal received; breaking SDK stream
15:33:54  Agent Teams orchestration completed for laboef1900/next-itsm
15:34:05  [OK] Agent Teams orchestration completed successfully  ← bash
15:34:07  MANAGER: Reviewing employee work
15:41:56  Manager review tokens: 24,191
15:41:56  EXECUTING VERDICTS
15:41:57  Verdict: PR | Issue: #27 | Branch: feat/issues-27-28-backend-...
15:42:16  Run 20260513T151408Z complete
```

**11 seconds** from Python signal to bash handoff (was 2-minute SIGTERM gap).

## Remaining items (not in this PR)

- 1 cosmetic `ERROR asyncio: unhandled exception during asyncio.run() shutdown` still appears in the log. Functionally swallowed by `_force_exit_with_cleanup`; would be cleaner to fix but doesn't block.
- `tokens_total=0` on the run row — bash's run_complete didn't carry token totals from the manager-review path. Different scope.
- Per `claude_agent_sdk` docs, `ClaudeSDKClient` is the recommended API for long-running stateful sessions. Migration would eliminate every fix in this PR. Worth doing as a separate effort; this PR is the minimal patch that unblocks the immediate audit-log + completion-timing issues.

## Refs

- Bug surfaces: run-20260512T193836Z (initial), run-20260512T213225Z (premature completion), run-20260513T044331Z (lingering process)
- Verification: run-20260513T151408Z

Targets `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)