### PR TITLE
feat(integration): route autonomous PRs through the integration branch

### DIFF
--- a/agent/scripts/integration-branch.sh
+++ b/agent/scripts/integration-branch.sh
@@ -143,7 +143,9 @@ merge_to_dev() {
 
     cd "$workspace" || { log_error "Workspace $workspace not found"; return 1; }
 
-    # Ensure the integration branch exists before attempting merge
+    # Ensure the integration branch exists before attempting merge. The
+    # source is the project's underlying base (typically main) so a fresh
+    # dev branch starts in sync.
     ensure_dev_branch "$project" "$base_branch" || {
         log_error "Cannot ensure dev branch for $project"
         return 1
@@ -165,49 +167,53 @@ merge_to_dev() {
     fi
     log_ok "Pushed feature branch $branch"
 
-    # Checkout dev and pull latest
-    git checkout "$dev_branch" 2>/dev/null || {
-        log_error "Cannot checkout $dev_branch"
-        return 1
-    }
-    git pull origin "$dev_branch" 2>/dev/null || true
+    # Open a PR feature → dev so the merge is observable in GitHub history
+    # and any branch protection on the integration branch is honored.
+    local close_line=""
+    if declare -F format_close_keywords >/dev/null 2>&1; then
+        close_line=$(format_close_keywords "$issue_number" "" 2>/dev/null || echo "")
+    fi
+    local pr_title
+    pr_title=$(git -C "$workspace" log -1 --format=%s "$branch" 2>/dev/null || echo "autonomous merge")
+    local pr_url
+    pr_url=$(gh pr create --repo "$project" --base "$dev_branch" --head "$branch" \
+        --title "autonomous: $pr_title" \
+        --body "Approved by autonomous manager. Merging into integration branch \`$dev_branch\`.
 
-    # Attempt the merge
-    local merge_commit_sha=""
-    if git merge "$branch" --no-edit 2>/dev/null; then
-        merge_commit_sha=$(git rev-parse HEAD 2>/dev/null || echo "")
-        log_ok "Merged $branch into $dev_branch"
+**Manager reasoning**: $reasoning${close_line:+
 
-        git push origin "$dev_branch" 2>/dev/null || {
-            log_error "Failed to push $dev_branch after merge"
-            return 1
-        }
-        log_ok "Pushed $dev_branch"
-    else
-        # Merge conflict — abort, create a PR for manual resolution instead
-        git merge --abort 2>/dev/null || true
-        log_warn "Merge conflict: $branch into $dev_branch — creating PR for manual resolution"
-
-        gh pr create --repo "$project" --base "$dev_branch" --head "$branch" \
-            --title "autonomous: merge #${issue_number} to dev (conflict)" \
-            --body "## Merge Conflict
-
-Feature branch \`$branch\` could not be cleanly merged into \`$dev_branch\`.
-
-**Issue**: #${issue_number}
-**Reasoning**: ${reasoning}
-
-Please resolve conflicts manually.
+$close_line}
 
 ---
-Autonomous run: $RUN_ID" 2>/dev/null || log_warn "PR creation failed for conflict resolution"
+Autonomous run: $RUN_ID" 2>&1) || true
+
+    if [ -z "$pr_url" ] || ! echo "$pr_url" | grep -q "http"; then
+        log_error "Failed to create PR for $branch → $dev_branch: $pr_url"
+        return 1
+    fi
+    log_ok "PR created: $pr_url"
+
+    # Merge the PR into the integration branch
+    local merge_commit_sha=""
+    if gh pr merge "$pr_url" --merge --delete-branch 2>&1 | while IFS= read -r line; do log_info "  $line"; done; then
+        log_ok "Merged PR $pr_url into $dev_branch"
+        git fetch origin "$dev_branch" 2>/dev/null || true
+        merge_commit_sha=$(git rev-parse "origin/$dev_branch" 2>/dev/null || echo "")
+    else
+        log_warn "PR merge failed for $pr_url — leaving open for manual resolution"
 
         # Label the issue so it's visible in the dashboard
         if [ -n "$issue_number" ] && [ "$issue_number" != "None" ] && [ "$issue_number" != "null" ]; then
             gh issue edit "$issue_number" --repo "$project" --add-label "autonomous-agent/conflict" 2>/dev/null || true
+            gh issue comment "$issue_number" --repo "$project" --body "## Merge Conflict
+
+PR $pr_url could not be auto-merged into \`$dev_branch\`. Please resolve conflicts manually.
+
+---
+Autonomous run: $RUN_ID" 2>/dev/null || true
         fi
 
-        webhook_event "dev_merged" "\"project\":\"$project\",\"branch\":\"$branch\",\"issue_number\":\"$issue_number\",\"status\":\"conflict\"" >&2
+        webhook_event "dev_merged" "\"project\":\"$project\",\"branch\":\"$branch\",\"issue_number\":\"$issue_number\",\"status\":\"conflict\",\"pr_url\":\"$pr_url\"" >&2
         return 0
     fi
 
@@ -219,7 +225,7 @@ Autonomous run: $RUN_ID" 2>/dev/null || log_warn "PR creation failed for conflic
 
         gh issue comment "$issue_number" --repo "$project" --body "## Merged to Integration Branch
 
-Branch \`$branch\` merged into \`$dev_branch\`.
+PR $pr_url merged \`$branch\` into \`$dev_branch\`.
 Will be promoted to \`$base_branch\` after validation.
 
 **Manager reasoning**: $reasoning

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -2066,6 +2066,20 @@ print(json.dumps(v))
         base_branch=$(echo "$verdict_json" | python3 -c "import json,sys; print(json.load(sys.stdin).get('base_branch','main'))")
         verdict_mode=$(echo "$verdict_json" | python3 -c "import json,sys; print(json.load(sys.stdin).get('mode',''))" 2>/dev/null || echo "")
 
+        # When the integration branch is enabled, every autonomous PR
+        # targets the dev branch instead of the project's underlying base
+        # (typically main). The dev → main hop is handled by the
+        # promotion flow below, so verdict.base_branch stays as the
+        # promote-to target and pr_base_branch carries the actual PR target.
+        local pr_base_branch="$base_branch"
+        if integration_enabled; then
+            local _dev
+            _dev=$(get_dev_branch)
+            if [ -n "$_dev" ]; then
+                pr_base_branch="$_dev"
+            fi
+        fi
+
         local name
         name=$(repo_name "$project")
         local workspace="$WORKSPACES_DIR/$name"
@@ -2245,13 +2259,13 @@ Run: $RUN_ID" 2>/dev/null || true
             fi
 
             # Return to base branch and continue to next verdict
-            git checkout "$base_branch" 2>/dev/null || true
+            git checkout "$pr_base_branch" 2>/dev/null || git checkout "$base_branch" 2>/dev/null || true
             continue
         fi
 
         case "$verdict" in
             APPROVE)
-                log_info "APPROVE: Processing verdict (base: $base_branch)"
+                log_info "APPROVE: Processing verdict (pr_base: $pr_base_branch, promote_to: $base_branch)"
 
                 if integration_enabled; then
                     # Integration branch mode: merge to dev, don't close issue
@@ -2308,8 +2322,8 @@ Run: $RUN_ID" 2>/dev/null || true
                                 log_info "Auto-draft PR (autonomy=auto, rate limit OK)"
                                 local pr_url close_line
                                 close_line=$(format_close_keywords "$issue_number" "$issue_numbers_json")
-                                rebase_against_base "$workspace" "$branch" "$base_branch" "$project" "" "$RUN_ID" "pre_pr" || true
-                                pr_url=$(gh pr create --repo "$project" --base "$base_branch" --head "$branch" \
+                                rebase_against_base "$workspace" "$branch" "$pr_base_branch" "$project" "" "$RUN_ID" "pre_pr" || true
+                                pr_url=$(gh pr create --repo "$project" --base "$pr_base_branch" --head "$branch" \
                                     --draft \
                                     --title "autonomous (draft): $(git log -1 --format=%s)" \
                                     --body "Draft PR auto-opened under \`autonomy=auto\`.
@@ -2340,8 +2354,8 @@ Rate limit: max 1 auto-draft PR per project per hour. Regenerated at $(date -u +
                             # Create PR and merge via GitHub API (works with protected branches)
                             local pr_url close_line
                             close_line=$(format_close_keywords "$issue_number" "$issue_numbers_json")
-                            rebase_against_base "$workspace" "$branch" "$base_branch" "$project" "" "$RUN_ID" "pre_pr" || true
-                            pr_url=$(gh pr create --repo "$project" --base "$base_branch" --head "$branch" \
+                            rebase_against_base "$workspace" "$branch" "$pr_base_branch" "$project" "" "$RUN_ID" "pre_pr" || true
+                            pr_url=$(gh pr create --repo "$project" --base "$pr_base_branch" --head "$branch" \
                                 --title "autonomous: $(git log -1 --format=%s)" \
                                 --body "Approved by autonomous manager.
 
@@ -2364,14 +2378,14 @@ $close_line}" 2>&1) || true
                                     # shellcheck source=lib/conflict-helpers.sh
                                     source "$_script_dir/lib/conflict-helpers.sh"
                                     set +e
-                                    rebase_against_base "$workspace" "$branch" "$base_branch" "$project" "$pr_num_for_resolve" "$RUN_ID" "at_merge"
+                                    rebase_against_base "$workspace" "$branch" "$pr_base_branch" "$project" "$pr_num_for_resolve" "$RUN_ID" "at_merge"
                                     local resolve_rc=$?
                                     set -e
                                     if [ "$resolve_rc" = "0" ]; then
                                         log_info "Resolution succeeded; retrying merge"
                                         if gh pr merge "$pr_url" --merge --delete-branch 2>&1 | while IFS= read -r line; do log_info "  $line"; done; then
                                             push_merge_ok=true
-                                            log_ok "PR merged to $base_branch (after at-merge resolution)"
+                                            log_ok "PR merged to $pr_base_branch (after at-merge resolution)"
                                         else
                                             log_error "PR merge still failed after resolution — left open: $pr_url"
                                             post_resolution_outcome 1 "$project" "$pr_num_for_resolve" "$branch"
@@ -2436,13 +2450,13 @@ Autonomous run: $RUN_ID" 2>/dev/null || log_warn "Failed to comment on issue #$i
                 ;;
 
             PR)
-                log_info "PR: Pushing branch and creating PR for human review (base: $base_branch)"
-                rebase_against_base "$workspace" "$branch" "$base_branch" "$project" "" "$RUN_ID" "pre_pr" || true
+                log_info "PR: Pushing branch and creating PR for human review (base: $pr_base_branch)"
+                rebase_against_base "$workspace" "$branch" "$pr_base_branch" "$project" "" "$RUN_ID" "pre_pr" || true
                 if git push origin "$branch" 2>/dev/null; then
                     log_ok "Pushed $branch"
                     local close_line
                     close_line=$(format_close_keywords "$issue_number" "$issue_numbers_json")
-                    gh pr create --repo "$project" --base "$base_branch" \
+                    gh pr create --repo "$project" --base "$pr_base_branch" \
                         --title "autonomous: $(git log -1 --format=%s)" \
                         --body "## Needs Human Review
 
@@ -2533,7 +2547,7 @@ Run: $RUN_ID" 2>/dev/null || true
                 else
                     # Max retries exhausted — clean up
                     log_info "REJECT: Max retries ($max_retries) exhausted. Resetting workspace."
-                    git checkout "$base_branch" 2>/dev/null || true
+                    git checkout "$pr_base_branch" 2>/dev/null || git checkout "$base_branch" 2>/dev/null || true
                     git branch -D "$branch" 2>/dev/null || true
                     rm -f "$workspace/.claude-manager-feedback.json"
                     log_ok "Rejected changes cleaned up (retries exhausted)"
@@ -2576,7 +2590,7 @@ Run: $RUN_ID" 2>/dev/null || true
         esac
 
         # Always return to base branch
-        git checkout "$base_branch" 2>/dev/null || true
+        git checkout "$pr_base_branch" 2>/dev/null || git checkout "$base_branch" 2>/dev/null || true
     done
 
     # Post-verdict: validate integration branch if we had approvals


### PR DESCRIPTION
## Summary

- With `integration.enabled=true`, every autonomous PR (APPROVE auto-merged and PR-verdict draft) now targets the integration branch instead of `main`.
- `merge_to_dev` now opens a real PR (`feature → dev`) and merges it via `gh pr merge --merge --delete-branch`, replacing the previous local `git merge && git push`. The merge becomes observable in GitHub PR history and respects branch protection on the integration branch.
- `execute_verdicts` introduces `pr_base_branch` (= dev when integration enabled, else `verdict.base_branch`). All `gh pr create --base`, `rebase_against_base`, and post-verdict `git checkout` calls use it. `\$base_branch` is preserved as the promote-to target so `ensure_dev_branch` can still bootstrap the dev branch from main and the dev→main promotion PR keeps targeting main.
- Conflict path: on `gh pr merge` failure the PR stays open and the issue gets `autonomous-agent/conflict` (was: abort merge + open a separate "conflict PR").

## Test plan

- [ ] Trigger an APPROVE run on a project with `integration.enabled=true` and confirm a PR is opened against the dev branch and merged (`gh pr list --state merged --base claude-agent-station`).
- [ ] Force a conflict (e.g. concurrent commit on dev) and confirm the PR stays open with the `autonomous-agent/conflict` label.
- [ ] Trigger a PR-verdict run and confirm the draft/review PR targets the dev branch, not main.
- [ ] Confirm the post-validation dev→main promotion PR still targets `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)