### PR TITLE
fix(manager): forbid source re-fetch via gh api to stop max_turns exhaustion

### DIFF
--- a/agent/prompts/manager.md
+++ b/agent/prompts/manager.md
@@ -22,7 +22,7 @@ You are a manager agent responsible for reviewing work done by employee agents a
 </context>
 
 <tool-budget>
-You have ~30 turns total. Use them to **write the verdict file**, not to re-read source.
+Your turn budget for this review is provided in your user prompt (along with a soft "start drafting by turn N" deadline). Use the budget to **write the verdict file**, not to re-read source.
 
 **The review package already contains the full diffs and employee reports.** Trust it. Do not:
 
@@ -35,7 +35,7 @@ Allowed `gh api` / `gh` usage (sparingly):
 - `gh pr view <n>` once if a verdict needs context about an existing PR.
 - `gh api repos/.../issues/<n>/comments` once if you suspect missed requirements live in comments.
 
-If you find yourself on turn 15+ without a verdict drafted, stop investigating and write the verdict from what you have. A REJECT-with-reasoning is far better than no verdicts file at all.
+If you reach the soft deadline (or halfway through your budget) without verdicts drafted, stop investigating and write the verdicts file from what you have. Choose the verdict that best fits the evidence you have — APPROVE/PR/REJECT/SKIP all carry reasoning, and any of them is better than no output. **Do not bias toward REJECT just because you're short on time** — if the work looks complete from the diff you've already read, APPROVE is the honest call.
 </tool-budget>
 
 <mode-detection>

--- a/agent/prompts/manager.md
+++ b/agent/prompts/manager.md
@@ -18,7 +18,25 @@ You are a manager agent responsible for reviewing work done by employee agents a
 - `GH_TOKEN` and `GITHUB_REPO` env vars are available for `gh` CLI commands.
 - The verdict file path is provided in your user prompt.
 - Keep your review focused and efficient.
+- **You have a hard turn budget.** Running out of turns means no verdicts file is written and the entire run's work is wasted — no merges, no PRs, no issue updates. Spend turns on producing the verdict, not on exhaustive verification.
 </context>
+
+<tool-budget>
+You have ~30 turns total. Use them to **write the verdict file**, not to re-read source.
+
+**The review package already contains the full diffs and employee reports.** Trust it. Do not:
+
+- Use `gh api repos/.../contents/<file>?ref=<branch>` to fetch source files — every diff you need is in the review package.
+- Use `Read` on workspace paths to inspect code — same reason.
+- Re-fetch the same file from multiple branches to compare — read the diff sections.
+
+Allowed `gh api` / `gh` usage (sparingly):
+- `gh issue view <n>` once per issue to verify acceptance criteria you can't see in the package.
+- `gh pr view <n>` once if a verdict needs context about an existing PR.
+- `gh api repos/.../issues/<n>/comments` once if you suspect missed requirements live in comments.
+
+If you find yourself on turn 15+ without a verdict drafted, stop investigating and write the verdict from what you have. A REJECT-with-reasoning is far better than no verdicts file at all.
+</tool-budget>
 
 <mode-detection>
 Before reviewing each project, detect the mode:
@@ -249,6 +267,8 @@ Write your verdicts to the file path provided in your prompt:
 - Reject analyze-mode work for missing code changes, branches, or diffs
 - Reject for minor style differences — only reject for bugs or missing functionality
 - Hardcode `main` as the base branch — always use what the employee reports
+- Use `gh api repos/.../contents/...` to fetch source — the review package has all the diffs you need, and burning turns this way will exhaust your budget before you write the verdict file
+- Exit without writing the verdicts file — even a partial REJECT-with-reasoning is better than no output at all
 </never>
 
 <always>

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -1929,9 +1929,15 @@ run_manager_review() {
     # No --allowedTools: full VM access, prompt-enforced guardrails
 
     # Reference the review package file instead of inlining it (avoids ARG_MAX crash on large diffs)
+    # The turn budget is injected so the system prompt's tool-budget rules
+    # can stay generic and stay in sync with limits.max_manager_turns.
+    local _half_budget=$(( max_turns / 2 ))
+    [ "$_half_budget" -lt 5 ] && _half_budget=5
     local manager_prompt="Review the employee work package at: $review_package
 
 Write your verdicts to: $verdicts_file
+
+Your hard turn budget for this review is $max_turns. Treat turn $_half_budget as your soft deadline to start drafting the verdicts file — see the <tool-budget> section of your system prompt for how to spend the budget.
 
 Read the review package file first, then evaluate each project's work against the criteria in your system prompt. Be strict on completeness — never approve partial implementations."
 


### PR DESCRIPTION
## Summary

Run \`20260513T172335Z\` exhausted the manager's 30-turn budget at turn 31 by calling \`gh api repos/.../contents/<file>?ref=<branch>\` to re-fetch source on every teammate branch — even though every diff was already in the review package. No \`verdicts.json\` got written, so \`execute_verdicts\` skipped everything; 17 commits across 3 branches were left unmerged.

Root cause: the prompt told the manager what it could review on, but never told it not to re-fetch what it already had.

This adds:
- A \`<tool-budget>\` section calling out the 30-turn ceiling, the specific anti-pattern (\`gh api .../contents/...\`, \`Read\` on workspace paths, cross-branch file comparison), and the narrow allowed \`gh\` usage (\`gh issue view\`, \`gh pr view\`, issue comments).
- An explicit "write a partial REJECT rather than nothing" instruction — never exit without writing the verdicts file.
- Two new \`<never>\` rules: don't use \`gh api .../contents/...\`, don't exit without writing the verdicts file.

## Test plan

- [ ] Re-run on next-itsm with the same review package; confirm the manager produces verdicts well inside the 30-turn budget and doesn't call \`gh api .../contents/\`.
- [ ] Watch \`run-*-manager.stream.jsonl\` for \`stop_reason\` — should be \`end_turn\` or \`tool_use\` with verdicts written, never \`error_max_turns\`.
- [ ] Confirm the manager still uses \`gh issue view\` etc. when it genuinely needs issue-body context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)