### PR TITLE
feat(verdict): APPROVE_INTEGRATION tier (#388)

### DIFF
--- a/agent/prompts/manager.md
+++ b/agent/prompts/manager.md
@@ -144,10 +144,14 @@ Evaluate:
 - All requirements fully implemented, tests pass, code quality acceptable.
 - Action: Push branch, merge to integration branch (autonomous/dev) if enabled, or merge to base branch. Issue is labeled, NOT closed immediately -- it closes when promoted to main.
 
+### APPROVE_INTEGRATION
+- Work is complete and tested, but touches sensitive code (auth, payments, config) or is large enough to want CI-as-gate before landing.
+- Action: Push branch, open non-draft PR against the integration/dev branch, enable auto-merge (`gh pr merge --auto --squash`). CI gates the merge; no human review required.
+- Use this in preference to PR whenever tests pass and the only reason for human review would be "sensitivity". Reserve PR for cases where a human must actually look.
+
 ### PR
 - Work is solid but needs human review:
   - Large scope (>10 files)
-  - Touches sensitive code (auth, payments, config)
   - Tests pass but coverage is uncertain
   - Requirements are ambiguous
 - Action: Push branch, create PR for human review (do NOT close issue).
@@ -163,11 +167,14 @@ Evaluate:
 
 **Decision tree:**
 - Work incomplete? → **REJECT**
-- Work complete + large/sensitive? → **PR**
-- Work complete + normal scope? → **APPROVE**
+- Work complete + normal scope + non-sensitive? → **APPROVE**
+- Work complete + sensitive (auth/payments/config) + tests pass? → **APPROVE_INTEGRATION**
+- Work complete + ambiguous requirements OR tests skipped OR scope > 30 files? → **PR**
 - No work to do? → **SKIP**
 
 Use **SKIP** instead of REJECT when the employee did nothing wrong — there was simply nothing to do.
+
+Use **APPROVE_INTEGRATION** instead of **PR** whenever tests pass: a human-review PR that nobody clicks merges nothing; an auto-merge PR lands the moment CI passes.
 
 ### Confidence-Based Verdict Modifiers
 
@@ -176,7 +183,7 @@ When the employee report includes a `confidence` score, use it as an additional 
 | Confidence | Tests Pass? | Guidance |
 |-----------|------------|---------|
 | >= 0.9 | Yes | Strong candidate for APPROVE |
-| 0.7-0.9 | Yes | Consider PR for human review |
+| 0.7-0.9 | Yes | APPROVE_INTEGRATION (auto-merge to dev once CI passes) |
 | 0.5-0.7 | Any | Lean toward REJECT or PR |
 | < 0.5 | Any | Lean toward REJECT |
 

--- a/agent/scripts/run-manager.sh
+++ b/agent/scripts/run-manager.sh
@@ -2168,7 +2168,7 @@ print(best if scores[best] > 0 else 'mixed')
 
         # Redundant task outcome recording via HTTP API (fallback if decide.py fails)
         local _outcome_success="false"
-        [[ "$verdict" == "APPROVE" || "$verdict" == "PR" ]] && _outcome_success="true"
+        [[ "$verdict" == "APPROVE" || "$verdict" == "APPROVE_INTEGRATION" || "$verdict" == "PR" ]] && _outcome_success="true"
         local _oi="${issue_number:-}"
         [[ -z "$_oi" || "$_oi" == "None" || "$_oi" == "null" ]] && _oi=""
         local _outcome_json
@@ -2218,8 +2218,8 @@ print(json.dumps(d))
         if [ "$is_analyze_mode" = true ]; then
             log_info "Analyze mode detected — skipping push/merge operations"
 
-            if [ "$verdict" = "APPROVE" ]; then
-                log_ok "APPROVE (analyze mode): Analysis work accepted"
+            if [ "$verdict" = "APPROVE" ] || [ "$verdict" = "APPROVE_INTEGRATION" ]; then
+                log_ok "$verdict (analyze mode): Analysis work accepted"
 
                 if [ -n "$issue_number" ] && [ "$issue_number" != "None" ] && [ "$issue_number" != "null" ]; then
                     gh issue comment "$issue_number" --repo "$project" --body "## Analyze Mode Review: APPROVED
@@ -2270,6 +2270,69 @@ Run: $RUN_ID" 2>/dev/null || true
         fi
 
         case "$verdict" in
+            APPROVE_INTEGRATION)
+                log_info "APPROVE_INTEGRATION: pushing $branch, opening auto-merge PR against $pr_base_branch"
+                if ! integration_enabled; then
+                    log_warn "APPROVE_INTEGRATION but integration disabled — falling through to APPROVE"
+                    merge_to_dev "$project" "$branch" "$base_branch" "$issue_number" "$reasoning"
+                    if [ $? -eq 0 ]; then
+                        notify "approve" "APPROVED (fallback from APPROVE_INTEGRATION): $project #$issue_number"
+                        # Queue: walk to completed (fallback merge succeeded)
+                        local _aiid
+                        _aiid=$(queue_api GET "/api/queue?project_repo=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$project'))" 2>/dev/null)&run_id=run-$RUN_ID&limit=1" | python3 -c "import json,sys; items=json.load(sys.stdin).get('items',[]); print(items[0]['id'] if items else '')" 2>/dev/null || echo "")
+                        if [ -n "$_aiid" ]; then
+                            queue_complete_item "$_aiid"
+                        fi
+                    else
+                        notify "error" "APPROVE_INTEGRATION fallback to APPROVE-merge failed: $project #$issue_number"
+                    fi
+                else
+                    if ! git push -u origin "$branch" 2>&1; then
+                        log_error "git push failed for $branch"
+                        notify "error" "APPROVE_INTEGRATION push failed: $project #$issue_number"
+                        continue
+                    fi
+                    local pr_url
+                    pr_url=$(gh pr create --repo "$project" \
+                        --head "$branch" \
+                        --base "$pr_base_branch" \
+                        --title "autonomous: resolve #$issue_number" \
+                        --body "$reasoning
+
+Closes #$issue_number
+
+---
+Autonomous run: $RUN_ID
+Manager verdict: APPROVE_INTEGRATION — auto-merge armed against \`$pr_base_branch\`. CI gates merge." 2>&1) || {
+                        log_error "gh pr create failed: $pr_url"
+                        notify "error" "APPROVE_INTEGRATION pr create failed: $project #$issue_number"
+                        continue
+                    }
+                    log_ok "APPROVE_INTEGRATION: opened PR $pr_url"
+                    if ! gh pr merge --auto --squash "$pr_url" 2>&1; then
+                        log_warn "gh pr merge --auto failed for $pr_url — PR is open but auto-merge not armed"
+                    else
+                        log_ok "Auto-merge armed for $pr_url"
+                    fi
+                    if [ -n "$issue_number" ] && [ "$issue_number" != "None" ] && [ "$issue_number" != "null" ]; then
+                        gh issue comment "$issue_number" --repo "$project" --body "🤖 **Manager verdict: APPROVE_INTEGRATION** — auto-merge armed against \`$pr_base_branch\` ($pr_url). CI gates merge.
+
+$reasoning
+
+Run: $RUN_ID" 2>/dev/null || log_warn "Failed to comment on issue #$issue_number"
+                        gh issue edit "$issue_number" --repo "$project" --remove-label "autonomous-agent/done" 2>/dev/null || true
+                    fi
+                    notify "approve" "APPROVE_INTEGRATION (auto-merge armed): $project #$issue_number $pr_url"
+                    # Queue: walk to completed (auto-merge PR armed)
+                    local _aiid
+                    _aiid=$(queue_api GET "/api/queue?project_repo=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$project'))" 2>/dev/null)&run_id=run-$RUN_ID&limit=1" | python3 -c "import json,sys; items=json.load(sys.stdin).get('items',[]); print(items[0]['id'] if items else '')" 2>/dev/null || echo "")
+                    if [ -n "$_aiid" ]; then
+                        queue_complete_item "$_aiid"
+                    fi
+                    webhook_event "verdict_execute" project "$project" verdict "APPROVE_INTEGRATION" >&2
+                fi
+                ;;
+
             APPROVE)
                 log_info "APPROVE: Processing verdict (pr_base: $pr_base_branch, promote_to: $base_branch)"
 
@@ -2664,7 +2727,7 @@ print()
 
 print('## Verdicts')
 for v in data.get('verdicts', []):
-    icon = {'APPROVE': 'APPROVED', 'PR': 'PR CREATED', 'REJECT': 'REJECTED'}.get(v['verdict'], v['verdict'])
+    icon = {'APPROVE': 'APPROVED', 'APPROVE_INTEGRATION': 'APPROVED (auto-merge)', 'PR': 'PR CREATED', 'REJECT': 'REJECTED'}.get(v['verdict'], v['verdict'])
     print(f\"### {v['project']} - {icon}\")
     print(f\"Issue: #{v.get('issue_number', '?')}\")
     print(f\"Branch: {v.get('branch', '?')}\")

--- a/agent/scripts/tests/test_verdict_dispatch.bats
+++ b/agent/scripts/tests/test_verdict_dispatch.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Tests for the APPROVE_INTEGRATION case arm in run-manager.sh (issue #388).
+# Stubs `gh`, `git`, `webhook_event`, and integration helpers so the case
+# block runs in isolation.
+
+setup() {
+    export TMPDIR_RUN="$(mktemp -d)"
+    export PATH="${TMPDIR_RUN}/bin:${PATH}"
+    mkdir -p "${TMPDIR_RUN}/bin"
+    cat > "${TMPDIR_RUN}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+echo "GH_CALL:" "$@" >> "${TMPDIR_RUN}/calls.log"
+if [[ "$1" == "pr" && "$2" == "create" ]]; then
+    echo "https://github.com/owner/repo/pull/99"
+fi
+exit 0
+EOF
+    cat > "${TMPDIR_RUN}/bin/git" <<'EOF'
+#!/usr/bin/env bash
+echo "GIT_CALL:" "$@" >> "${TMPDIR_RUN}/calls.log"
+exit 0
+EOF
+    chmod +x "${TMPDIR_RUN}/bin/gh" "${TMPDIR_RUN}/bin/git"
+}
+
+teardown() {
+    rm -rf "${TMPDIR_RUN}"
+}
+
+@test "APPROVE_INTEGRATION runs push, non-draft pr create, auto-merge, issue comment" {
+    grep -n "APPROVE_INTEGRATION)" agent/scripts/run-manager.sh
+    [ "$status" -eq 0 ]
+
+    grep -A 25 "APPROVE_INTEGRATION)" agent/scripts/run-manager.sh > "${TMPDIR_RUN}/arm.txt"
+
+    # Must push the branch
+    grep -q "git push" "${TMPDIR_RUN}/arm.txt"
+
+    # Must create a non-draft PR — i.e. no "--draft" inside this arm
+    ! grep -q -- "--draft" "${TMPDIR_RUN}/arm.txt"
+
+    # Must invoke gh pr create with --base pr_base_branch
+    grep -q "gh pr create" "${TMPDIR_RUN}/arm.txt"
+    grep -q "\-\-base \"\$pr_base_branch\"" "${TMPDIR_RUN}/arm.txt"
+
+    # Must arm auto-merge
+    grep -q "gh pr merge --auto --squash" "${TMPDIR_RUN}/arm.txt"
+
+    # Must emit a webhook event
+    grep -q "webhook_event \"verdict_execute\"" "${TMPDIR_RUN}/arm.txt"
+}

--- a/agent/scripts/tests/test_verdict_dispatch.bats
+++ b/agent/scripts/tests/test_verdict_dispatch.bats
@@ -1,7 +1,22 @@
 #!/usr/bin/env bats
-# Tests for the APPROVE_INTEGRATION case arm in run-manager.sh (issue #388).
-# Stubs `gh`, `git`, `webhook_event`, and integration helpers so the case
-# block runs in isolation.
+# Contract test (source-grep, not executable) for the APPROVE_INTEGRATION
+# case arm in run-manager.sh (issue #388).
+#
+# This test verifies the STRUCTURE of the case arm by reading the source —
+# it does NOT execute the arm. Running the arm in isolation would require
+# sourcing run-manager.sh's globals + reproducing its dispatch loop, which
+# is out of scope for a smoke test. The `setup()` stubs below are scaffold
+# for a future execution-mode test; today they are unused.
+#
+# What this catches:
+#   - The case arm is present at all
+#   - The arm contains git push, gh pr create (non-draft), gh pr merge
+#     --auto --squash, webhook_event "verdict_execute"
+#
+# What this does NOT catch:
+#   - Variable substitution / quoting bugs in the arm body
+#   - Order of operations
+#   - Behaviour under failure paths (no execution)
 
 setup() {
     export TMPDIR_RUN="$(mktemp -d)"

--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -45,7 +45,13 @@ from agent.gh_client import gh_run
 
 logger = logging.getLogger(__name__)
 
-VerdictKind = Literal["APPROVE", "PR", "REJECT", "SKIP"]
+VerdictKind = Literal[
+    "APPROVE",              # Direct merge to base (today's APPROVE)
+    "APPROVE_INTEGRATION",  # Non-draft PR against integration branch + --auto --squash
+    "PR",                   # Draft PR for human review
+    "REJECT",
+    "SKIP",
+]
 
 
 @dataclass
@@ -291,6 +297,18 @@ def execute_skip(
         run_id=run_id, env=env, into=result,
     )
     return result
+
+
+def execute_approve_integration(
+    verdict: Verdict,
+    *,
+    workspace: Path,
+    run_id: str | None = None,
+    env: dict[str, str] | None = None,
+    dev_branch: str | None = None,
+) -> ExecutionResult:
+    """Placeholder — implemented in Task 2."""
+    raise NotImplementedError("execute_approve_integration not yet implemented")
 
 
 _EXECUTORS = {

--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -321,6 +321,10 @@ def execute_approve_integration(
             "degrading to APPROVE",
             verdict.project,
         )
+        # Intentionally re-passes only the kwargs execute_approve accepts.
+        # If the dispatcher gains new kwargs in the future, they are not
+        # forwarded here — degradation drops them on purpose so we don't
+        # surface APPROVE_INTEGRATION-specific options through APPROVE.
         return execute_approve(
             verdict, workspace=workspace, run_id=run_id, env=env,
         )

--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -307,12 +307,94 @@ def execute_approve_integration(
     env: dict[str, str] | None = None,
     dev_branch: str | None = None,
 ) -> ExecutionResult:
-    """Placeholder — implemented in Task 2."""
-    raise NotImplementedError("execute_approve_integration not yet implemented")
+    """Push the branch, open a non-draft PR against the integration/dev
+    branch, then arm GitHub auto-merge (``gh pr merge --auto --squash``).
+
+    If ``dev_branch`` is None or empty, the executor degrades to
+    :func:`execute_approve` with a warning — the manager should not have
+    emitted this verdict against a project without integration enabled,
+    but we accept rather than fail the run.
+    """
+    if not dev_branch:
+        logger.warning(
+            "APPROVE_INTEGRATION emitted without dev_branch for %s — "
+            "degrading to APPROVE",
+            verdict.project,
+        )
+        return execute_approve(
+            verdict, workspace=workspace, run_id=run_id, env=env,
+        )
+
+    result = ExecutionResult(
+        verdict="APPROVE_INTEGRATION",
+        project=verdict.project,
+        issue_number=verdict.issue_number,
+        success=False,
+    )
+
+    # 1. git push -u origin <branch>
+    push = subprocess.run(
+        ["git", "push", "-u", "origin", verdict.branch],
+        cwd=str(workspace), capture_output=True, text=True, env=env,
+    )
+    if push.returncode != 0:
+        result.error = f"git push failed: {push.stderr.strip()[:200]}"
+        return result
+    result.with_action("git push")
+
+    # 2. gh pr create — NO --draft; base = integration/dev branch.
+    pr = gh_run(
+        [
+            "pr", "create",
+            "--repo", verdict.project,
+            "--head", verdict.branch,
+            "--base", dev_branch,
+            "--title", _pr_title(verdict),
+            "--body", _build_pr_body(verdict, run_id=run_id),
+        ],
+        env=env,
+    )
+    if not pr.ok:
+        result.error = f"gh pr create failed: {pr.stderr.strip()[:200]}"
+        return result
+    result.pr_url = pr.stdout.strip()
+    result.with_action(f"gh pr create (non-draft) → {result.pr_url}")
+
+    # 3. gh pr merge --auto --squash <pr_url>. Best-effort: a failure to
+    # arm auto-merge (e.g. branch protection misconfigured) does not
+    # invalidate the PR itself.
+    merge = gh_run(
+        [
+            "pr", "merge", "--auto", "--squash", result.pr_url,
+        ],
+        env=env,
+    )
+    if merge.ok:
+        result.with_action("gh pr merge --auto --squash")
+    else:
+        logger.warning(
+            "verdict_execution: auto-merge arm failed for %s: %s",
+            result.pr_url, merge.stderr.strip()[:200],
+        )
+        result.with_action(f"gh pr merge --auto failed: {merge.stderr.strip()[:80]}")
+
+    # 4. Issue comment (best-effort).
+    if verdict.issue_number is not None:
+        _post_issue_comment(
+            verdict,
+            body_prefix=(
+                f"## Manager verdict: APPROVE_INTEGRATION — "
+                f"auto-merge armed against `{dev_branch}`. CI gates merge."
+            ),
+            run_id=run_id, env=env, into=result,
+        )
+    result.success = True
+    return result
 
 
 _EXECUTORS = {
     "APPROVE": execute_approve,
+    "APPROVE_INTEGRATION": execute_approve_integration,
     "PR": execute_pr,
     "REJECT": execute_reject,
     "SKIP": execute_skip,

--- a/dashboard/backend/tests/test_docs_388.py
+++ b/dashboard/backend/tests/test_docs_388.py
@@ -1,0 +1,14 @@
+"""Pin that docs/configuration.md documents APPROVE_INTEGRATION (issue #388)."""
+
+from pathlib import Path
+
+DOC = Path(__file__).resolve().parents[3] / "docs" / "configuration.md"
+
+
+def test_configuration_doc_mentions_approve_integration():
+    text = DOC.read_text(encoding="utf-8")
+    assert "APPROVE_INTEGRATION" in text
+    assert "auto-merge" in text.lower()
+    # Prerequisite: branch protection must require checks for auto-merge
+    # to be meaningful.
+    assert "required check" in text.lower() or "branch protection" in text.lower()

--- a/dashboard/backend/tests/test_manager_prompt_388.py
+++ b/dashboard/backend/tests/test_manager_prompt_388.py
@@ -1,0 +1,19 @@
+"""Smoke test that the manager prompt advertises APPROVE_INTEGRATION."""
+
+from pathlib import Path
+
+PROMPT = Path(__file__).resolve().parents[3] / "agent" / "prompts" / "manager.md"
+
+
+def test_manager_prompt_documents_approve_integration():
+    text = PROMPT.read_text(encoding="utf-8")
+    # Verdict ladder heading
+    assert "### APPROVE_INTEGRATION" in text, "ladder heading missing"
+    # Decision tree branch
+    assert "APPROVE_INTEGRATION" in text and "sensitive" in text.lower()
+    # Confidence table updated — the 0.7-0.9 row no longer says "Consider PR"
+    lines = [l for l in text.splitlines() if "0.7-0.9" in l]
+    assert lines, "0.7-0.9 confidence row not found"
+    assert "APPROVE_INTEGRATION" in lines[0], (
+        "0.7-0.9 row must recommend APPROVE_INTEGRATION; got: " + lines[0]
+    )

--- a/dashboard/backend/tests/test_runs.py
+++ b/dashboard/backend/tests/test_runs.py
@@ -637,3 +637,34 @@ async def test_active_employees_skips_synthesis_when_parent_terminal(client):
     employees = resp.json()
     assert all(e["run_id"] != run_id for e in employees), \
         f"phantom employee returned for terminal run: {employees}"
+
+
+@pytest.mark.asyncio
+async def test_list_runs_accepts_approve_integration_verdict_filter(client, setup_db):
+    """The runs router must accept ``?verdict=APPROVE_INTEGRATION`` (issue #388).
+
+    Run.verdict is Text — no migration needed — so the filter is purely a
+    SQL equality check. Seed one matching and one non-matching row and
+    assert the response contains only the matching one.
+    """
+    async with async_session() as db:
+        db.add(Run(
+            run_id="run-388-ai",
+            status="finished",
+            verdict="APPROVE_INTEGRATION",
+            started_at=datetime.now(timezone.utc),
+        ))
+        db.add(Run(
+            run_id="run-388-other",
+            status="finished",
+            verdict="APPROVE",
+            started_at=datetime.now(timezone.utc),
+        ))
+        await db.commit()
+
+    response = await client.get("/api/runs?verdict=APPROVE_INTEGRATION")
+    assert response.status_code == 200
+    data = response.json()
+    run_ids = [r["run_id"] for r in data["runs"]]
+    assert "run-388-ai" in run_ids
+    assert "run-388-other" not in run_ids

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -478,3 +478,32 @@ def test_execute_dispatcher_routes_approve_integration(tmp_path):
     mock_fn.assert_called_once()
 
 
+def test_execute_dispatcher_forwards_dev_branch_kwarg(tmp_path):
+    """The dispatcher must thread ``dev_branch`` through to the executor.
+
+    Pins the contract so future Python callers (post-#383 bash deletion)
+    know the kwarg name to pass.
+    """
+    from agent.verdict_execution import execute, Verdict, ExecutionResult, _EXECUTORS
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    verdict = Verdict(
+        project="owner/repo",
+        issue_number=1,
+        verdict="APPROVE_INTEGRATION",
+        branch="autonomous/issue-1",
+    )
+    mock_fn = MagicMock()
+    mock_fn.return_value = ExecutionResult(
+        verdict="APPROVE_INTEGRATION",
+        project="owner/repo",
+        issue_number=1,
+        success=True,
+    )
+    with patch.dict(_EXECUTORS, {"APPROVE_INTEGRATION": mock_fn}):
+        execute(verdict, workspace=workspace, dev_branch="dev")
+    _, kwargs = mock_fn.call_args
+    assert kwargs.get("dev_branch") == "dev"
+
+

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -299,3 +299,88 @@ def test_verdict_from_dict_accepts_approve_integration():
     assert parsed.branch == "autonomous/issue-42"
 
 
+def _stub_gh_ok(stdout: str = "https://github.com/owner/repo/pull/99") -> MagicMock:
+    """Build a stand-in for ``gh_run`` returning a success result."""
+    fake = MagicMock()
+    fake.ok = True
+    fake.stdout = stdout
+    fake.stderr = ""
+    return fake
+
+
+def test_execute_approve_integration_happy_path(tmp_path: Path):
+    """Push, non-draft PR against dev branch, auto-merge armed, comment posted."""
+    from agent.verdict_execution import execute_approve_integration, Verdict
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    verdict = Verdict(
+        project="owner/repo",
+        issue_number=42,
+        verdict="APPROVE_INTEGRATION",
+        branch="autonomous/issue-42",
+        base_branch="main",
+        reasoning="Auth change; tests pass; CI gates merge.",
+    )
+
+    pr_url = "https://github.com/owner/repo/pull/99"
+    call_log: list[tuple] = []
+
+    def gh_run_spy(args, env=None):  # noqa: ARG001
+        call_log.append(("gh", tuple(args)))
+        if args[:2] == ["pr", "create"]:
+            return _stub_gh_ok(pr_url)
+        if args[:3] == ["pr", "merge", "--auto"]:
+            return _stub_gh_ok("")
+        if args[:2] == ["issue", "comment"]:
+            return _stub_gh_ok("")
+        return _stub_gh_ok("")
+
+    def subprocess_run_spy(args, **kwargs):  # noqa: ARG001
+        call_log.append(("sub", tuple(args)))
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        result.stdout = ""
+        return result
+
+    with patch("agent.verdict_execution.gh_run", side_effect=gh_run_spy), \
+         patch("agent.verdict_execution.subprocess.run", side_effect=subprocess_run_spy):
+        result = execute_approve_integration(
+            verdict,
+            workspace=workspace,
+            run_id="run-20260514T100000Z",
+            dev_branch="dev",
+        )
+
+    assert result.success is True
+    assert result.pr_url == pr_url
+    assert result.verdict == "APPROVE_INTEGRATION"
+
+    # Order: git push, gh pr create (no --draft), gh pr merge --auto --squash, issue comment.
+    kinds = [c[0] for c in call_log]
+    assert kinds[:4] == ["sub", "gh", "gh", "gh"], call_log
+
+    # 1) git push -u origin <branch>
+    assert call_log[0][1][:5] == ("git", "push", "-u", "origin", "autonomous/issue-42")
+
+    # 2) gh pr create — base = dev, no --draft anywhere
+    create_args = call_log[1][1]
+    assert create_args[:2] == ("pr", "create")
+    assert "--base" in create_args
+    assert create_args[create_args.index("--base") + 1] == "dev"
+    assert "--draft" not in create_args
+    assert "--head" in create_args
+    assert create_args[create_args.index("--head") + 1] == "autonomous/issue-42"
+
+    # 3) gh pr merge --auto --squash <pr_url>
+    merge_args = call_log[2][1]
+    assert merge_args[:4] == ("pr", "merge", "--auto", "--squash")
+    assert pr_url in merge_args
+
+    # 4) issue comment
+    comment_args = call_log[3][1]
+    assert comment_args[:2] == ("issue", "comment")
+    assert "42" in comment_args
+
+

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -1,10 +1,13 @@
-"""Tests for agent.verdict_execution (#363).
+"""Tests for agent.verdict_execution (#363, #388).
 
 These tests pin the per-decision argv shape so reviewers can diff
 against the bash invocations in agent/scripts/run-manager.sh
 (~lines 2200–2500). Drift here means the Python module would push
 code, label issues, or comment in subtly different ways from the
 bash it replaces.
+
+Issue #388 adds APPROVE_INTEGRATION verdict: non-draft PR against
+integration branch with auto-merge armed, CI gates the merge.
 """
 
 from __future__ import annotations
@@ -272,3 +275,27 @@ def test_verdict_from_dict_handles_string_and_null_issue_number():
             "branch": "feat/foo",
         })
         assert v.issue_number is None, f"sentinel {sentinel!r} should map to None"
+
+
+# ── APPROVE_INTEGRATION (issue #388) ───────────────────────────────────
+
+
+def test_verdict_from_dict_accepts_approve_integration():
+    """Manager output with verdict='APPROVE_INTEGRATION' must round-trip."""
+    from agent.verdict_execution import Verdict
+
+    payload = {
+        "project": "owner/repo",
+        "issue_number": 42,
+        "verdict": "APPROVE_INTEGRATION",
+        "branch": "autonomous/issue-42",
+        "base_branch": "main",
+        "reasoning": "Auth refactor with passing tests",
+    }
+    parsed = Verdict.from_dict(payload)
+    assert parsed.verdict == "APPROVE_INTEGRATION"
+    assert parsed.project == "owner/repo"
+    assert parsed.issue_number == 42
+    assert parsed.branch == "autonomous/issue-42"
+
+

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -400,7 +400,7 @@ def test_execute_approve_integration_degrades_when_dev_branch_missing(tmp_path, 
     )
 
     with patch("agent.verdict_execution.execute_approve") as approve_mock, \
-         caplog.at_level("WARNING"):
+         caplog.at_level("WARNING", logger="agent.verdict_execution"):
         approve_mock.return_value = ExecutionResult(
             verdict="APPROVE",
             project=verdict.project,

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -384,3 +384,97 @@ def test_execute_approve_integration_happy_path(tmp_path: Path):
     assert "42" in comment_args
 
 
+def test_execute_approve_integration_degrades_when_dev_branch_missing(tmp_path, caplog):
+    """No dev_branch → degrade to execute_approve and emit a warning."""
+    from agent.verdict_execution import execute_approve_integration, Verdict, ExecutionResult
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    verdict = Verdict(
+        project="owner/repo",
+        issue_number=7,
+        verdict="APPROVE_INTEGRATION",
+        branch="autonomous/issue-7",
+        base_branch="main",
+        reasoning="Manager misemitted; integration disabled.",
+    )
+
+    with patch("agent.verdict_execution.execute_approve") as approve_mock, \
+         caplog.at_level("WARNING"):
+        approve_mock.return_value = ExecutionResult(
+            verdict="APPROVE",
+            project=verdict.project,
+            issue_number=7,
+            success=True,
+            pr_url="https://github.com/owner/repo/pull/12",
+        )
+        result = execute_approve_integration(
+            verdict, workspace=workspace, run_id="r1", dev_branch=None,
+        )
+
+    assert approve_mock.called
+    assert result.success is True
+    assert any("degrading to APPROVE" in rec.message for rec in caplog.records)
+
+
+def test_execute_approve_integration_push_failure_short_circuits(tmp_path):
+    """If ``git push`` fails, no PR is opened and no auto-merge is armed."""
+    from agent.verdict_execution import execute_approve_integration, Verdict
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    verdict = Verdict(
+        project="owner/repo",
+        issue_number=99,
+        verdict="APPROVE_INTEGRATION",
+        branch="autonomous/issue-99",
+        base_branch="main",
+    )
+
+    push_fail = MagicMock()
+    push_fail.returncode = 1
+    push_fail.stderr = "remote rejected"
+    push_fail.stdout = ""
+
+    gh_calls: list[tuple] = []
+
+    def gh_run_spy(args, env=None):  # noqa: ARG001
+        gh_calls.append(tuple(args))
+        return _stub_gh_ok("")
+
+    with patch("agent.verdict_execution.subprocess.run", return_value=push_fail), \
+         patch("agent.verdict_execution.gh_run", side_effect=gh_run_spy):
+        result = execute_approve_integration(
+            verdict, workspace=workspace, dev_branch="dev",
+        )
+
+    assert result.success is False
+    assert result.error is not None
+    assert "remote rejected" in result.error
+    assert gh_calls == [], "no gh calls expected after push failure"
+
+
+def test_execute_dispatcher_routes_approve_integration(tmp_path):
+    """The ``execute`` dispatcher must route APPROVE_INTEGRATION correctly."""
+    from agent.verdict_execution import execute, Verdict, ExecutionResult, _EXECUTORS
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    verdict = Verdict(
+        project="owner/repo",
+        issue_number=1,
+        verdict="APPROVE_INTEGRATION",
+        branch="autonomous/issue-1",
+    )
+    mock_fn = MagicMock()
+    mock_fn.return_value = ExecutionResult(
+        verdict="APPROVE_INTEGRATION",
+        project=verdict.project,
+        issue_number=1,
+        success=True,
+    )
+    with patch.dict(_EXECUTORS, {"APPROVE_INTEGRATION": mock_fn}):
+        execute(verdict, workspace=workspace, dev_branch="dev")
+    mock_fn.assert_called_once()
+
+

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -20,7 +20,7 @@ export type ProviderName = 'openai' | 'gemini';
 // --- Enums ---
 export type AgentMode = 'full' | 'analyze' | 'plan' | 'plan_only' | 'triage' | 'review' | 'fix';
 export type RunStatus = 'started' | 'employee_done' | 'reviewing' | 'finished' | 'verdict' | 'plan_reviewing' | 'plan_review_done' | 'awaiting_plan_review' | 'plan_approved' | 'plan_rejected' | string;
-export type Verdict = 'APPROVE' | 'PR' | 'REJECT';
+export type Verdict = 'APPROVE' | 'APPROVE_INTEGRATION' | 'PR' | 'REJECT';
 export type QueueState = 'pending' | 'assigned' | 'claimed' | 'planning' | 'in_progress' | 'review' | 'verifying' | 'approved' | 'rejected' | 'escalated' | 'paused' | 'failed' | 'cancelled' | 'completed';
 export type PlanStatus = 'draft' | 'approved' | 'implementing' | 'completed' | 'rejected';
 export type CoordinatorTaskStatus = 'pending' | 'ready' | 'running' | 'completed' | 'blocked' | 'failed' | 'orphaned';

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -326,6 +326,8 @@
               <span class="status run"><span class="run-tick"></span><span class="lab">Run</span></span>
             {:else if run.verdict === 'APPROVE'}
               <span class="status planok">Approved</span>
+            {:else if run.verdict === 'APPROVE_INTEGRATION'}
+              <span class="status integ">Auto-merge to dev</span>
             {:else if run.verdict === 'REJECT'}
               <span class="status planx">Rejected</span>
             {:else if run.verdict === 'PR'}
@@ -463,7 +465,7 @@
       <div class="qstat">
         <span class="k">Verdict</span>
         {#if run.verdict}
-          <span class="v {run.verdict === 'APPROVE' ? 'go' : run.verdict === 'REJECT' ? 'abort' : 'caution'}" style="font-size:14px">{run.verdict}</span>
+          <span class="v {run.verdict === 'APPROVE' ? 'go' : run.verdict === 'APPROVE_INTEGRATION' ? 'integ' : run.verdict === 'REJECT' ? 'abort' : 'caution'}" style="font-size:14px">{run.verdict}</span>
           <span class="sub">final</span>
         {:else}
           <span class="v nu">—</span><span class="sub">in progress</span>
@@ -1116,6 +1118,13 @@
   }
   .rd :global(.qstat .v.abort) {
     color: var(--abort);
+  }
+  .rd :global(.qstat .v.integ) {
+    background: rgba(20, 184, 166, 0.15);
+    color: rgb(20, 184, 166);
+    border: 1px solid rgba(20, 184, 166, 0.3);
+    padding: 2px 6px;
+    border-radius: 2px;
   }
   .rd :global(.qstat .v.nu) {
     color: var(--ash);

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -349,3 +349,20 @@ the only validation gate.
   ]
 }
 ```
+
+## Verdict tiers
+
+The manager produces one of four verdicts per project/issue:
+
+| Verdict | Action | When |
+|---|---|---|
+| `APPROVE` | Direct merge to base branch (or to integration's dev branch when enabled) | Tests pass, scope is normal, no sensitive code touched. |
+| `APPROVE_INTEGRATION` | Non-draft PR against the integration/dev branch with `gh pr merge --auto --squash` armed | Work is complete and tested but touches sensitive code (auth, payments, config), or scope is large enough to want CI as the gate before landing. CI passes → PR auto-merges with no human click. |
+| `PR` | Draft PR for human review | Ambiguous requirements, tests skipped, or scope > 30 files. A human must look. |
+| `REJECT` / `SKIP` | No merge | Work incomplete (`REJECT`) or no eligible work (`SKIP`). |
+
+### Prerequisite for `APPROVE_INTEGRATION`
+
+`APPROVE_INTEGRATION` arms GitHub's auto-merge feature. Auto-merge only meaningfully gates when the integration/dev branch has **at least one required check** in its branch protection rules. If no checks are required, `gh pr merge --auto --squash` will merge immediately. Configure required checks at `Settings → Branches → Branch protection rules → <dev_branch>` on each project before relying on this verdict.
+
+If the project does not have integration enabled (`integration.enabled = false`), the verdict degrades to `APPROVE` and a warning is logged — the manager should not have emitted `APPROVE_INTEGRATION` in that case, but the system accepts rather than failing the run.


### PR DESCRIPTION
## Summary

Adds a fourth manager verdict tier between `APPROVE` and `PR`. Closes operator complaint that "we keep producing PRs but nothing merges to integration": tested-but-sensitive work now opens a non-draft PR against the integration/dev branch with `gh pr merge --auto --squash` armed, so CI gates the merge rather than a human reviewer.

## What changes

- **Python executor (`agent/verdict_execution.py`)**: new `execute_approve_integration` — git push, non-draft `gh pr create --base $dev_branch`, best-effort `gh pr merge --auto --squash`, issue comment. Degrades to `execute_approve` with a warning when `dev_branch` is missing. Registered in `_EXECUTORS`.
- **Bash dispatcher (`agent/scripts/run-manager.sh`)**: new `APPROVE_INTEGRATION)` case arm with the same lifecycle, plus updates to `_outcome_success`, analyze-mode handling, icon dict, queue completion, and webhook emission. Fallback to `merge_to_dev` when integration disabled.
- **Manager prompt (`agent/prompts/manager.md`)**: new `### APPROVE_INTEGRATION` heading, decision tree branch ("sensitive + tests pass → APPROVE_INTEGRATION"), 0.7-0.9 confidence table entry, reinforcing sentence. Removed the contradicting "sensitive code → PR" bullet from the `### PR` section.
- **Dashboard (`dashboard/frontend/`)**: extended `Verdict` union, new badge branch + teal `.v.integ` CSS class in `RunDetail.svelte`.
- **Docs (`docs/configuration.md`)**: new "Verdict tiers" section with branch-protection prerequisite callout.

## Test plan

- [x] `pytest dashboard/backend/tests/test_verdict_execution.py` — 17 passed (round-trip, happy path, degradation, push-failure short-circuit, dispatcher routing, kwarg threading)
- [x] `pytest dashboard/backend/tests/test_manager_prompt_388.py` — 1 passed (prompt advertises new verdict)
- [x] `pytest dashboard/backend/tests/test_runs.py -k approve_integration` — 1 passed (router accepts ?verdict=APPROVE_INTEGRATION)
- [x] `pytest dashboard/backend/tests/test_docs_388.py` — 1 passed (docs mention auto-merge + branch protection)
- [x] Full backend suite — **1188 passed, 1 skipped, 0 failed in 38s**
- [x] `npm run build` in `dashboard/frontend` — clean TS build
- [x] Grep contract: APPROVE_INTEGRATION appears in `agent/verdict_execution.py`, `agent/scripts/run-manager.sh`, `agent/prompts/manager.md`, `dashboard/frontend/src/lib/types.ts`, `dashboard/frontend/src/pages/RunDetail.svelte`
- [ ] Manual: trigger one auth-touching issue on the dev box; confirm the manager emits `APPROVE_INTEGRATION` and the PR opens non-draft with auto-merge armed.

## Dependencies

Built on top of #399 (test baseline fix). Base branch is `fix/test-baseline-clear-station-api-key`; once #399 merges to `dev`, change this PR's base to `dev` (GitHub auto-rebase) and the diff will shrink to just the #388 work.

## Plan + spec

- Spec: `docs/superpowers/specs/2026-05-14-issue-388-approve-integration-verdict.md`
- Plan: `docs/superpowers/plans/2026-05-14-issue-388-approve-integration-verdict.md`
- Roadmap: `docs/superpowers/specs/2026-05-14-epic-382-roadmap.md` — Wave 1 of epic #382

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)