### PR TITLE
fix(tests): await async handle_stream_event in manager-token test

### DIFF
--- a/dashboard/backend/tests/test_manager_sibling.py
+++ b/dashboard/backend/tests/test_manager_sibling.py
@@ -261,22 +261,26 @@ def test_canonical_manager_prompt_reflects_sibling_context():
     assert "sibling" in text.lower() or "agent teams" in text.lower()
 
 
-def test_handle_stream_event_accumulates_manager_tokens_via_assistantmessage():
+@pytest.mark.asyncio
+async def test_handle_stream_event_accumulates_manager_tokens_via_assistantmessage():
     """The manager's AssistantMessage.usage must flow through the same
     state.tokens_in / state.tokens_out the lead and teammates already use.
+
+    ``handle_stream_event`` became ``async`` in #389 (inline audit
+    moved sqlite3 writes off the event loop via asyncio.to_thread).
+    This test was added in #390 before #389's async conversion landed
+    on the same branch — after both merged, the synchronous call here
+    was a RuntimeWarning + a tokens_in=0 assertion failure. Awaiting
+    the coroutine restores the contract.
     """
     from agent import station_orchestrator as so
     from claude_agent_sdk.types import AssistantMessage
 
     msg = AssistantMessage(content=[], model="claude-sonnet-4-6")
-    try:
-        msg.usage = {"input_tokens": 100, "output_tokens": 50}
-    except AttributeError:
-        msg.usage = {"input_tokens": 100, "output_tokens": 50}
+    msg.usage = {"input_tokens": 100, "output_tokens": 50}
 
     state = so._StreamState()
-    # handle_stream_event is synchronous (not async)
-    so.handle_stream_event(msg, {"webhook_url": ""}, "test", state=state)
+    await so.handle_stream_event(msg, {"webhook_url": ""}, "test", state=state)
     assert state.tokens_in == 100
     assert state.tokens_out == 50
 


### PR DESCRIPTION
## Summary

One-line follow-up flagged in PR #409 review notes.

\`test_handle_stream_event_accumulates_manager_tokens_via_assistantmessage\` (added by PR #409) called \`handle_stream_event\` synchronously. PR #408 (merged minutes later) made the function \`async\`. After both merged on \`dev\`, the test produced a \`RuntimeWarning: coroutine was never awaited\` and failed with \`tokens_in == 0 != 100\`.

## What changes

- \`@pytest.mark.asyncio\` decorator
- \`await\` the \`handle_stream_event\` call
- Removed the now-vestigial \`try/except AttributeError\` around \`msg.usage =\` assignment (was a defensive no-op)
- Docstring expanded to record the regression history so a future contributor doesn't re-introduce the sync call

## Test plan

- [x] \`pytest dashboard/backend/tests/test_manager_sibling.py\` — 21 passed
- [x] Full backend suite — **1286 passed, 1 skipped, 0 failed** (was 1285 passed, 1 failed pre-fix)

## Origin

Flagged in my own PR #409 re-review as \"after both PRs merge, the test will need a one-line \`await\` follow-up.\" #408 and #409 merged on 2026-05-14 within ~4 seconds of each other. The follow-up didn't ride either PR; landing it now to unblock the Wave 5 (#393 PR-2) baseline.

Refs: #389, #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)