### PR TITLE
feat(splitter): schema + heuristics + agent role (#391, PR 1/4)

### DIFF
--- a/agent/agents/issue-splitter.md
+++ b/agent/agents/issue-splitter.md
@@ -1,0 +1,23 @@
+---
+name: issue-splitter
+description: Decomposes a large GitHub issue into 2-5 self-contained sub-issues with acceptance criteria and dependency hints.
+tools: Read, Glob, Grep, Bash
+model: claude-sonnet-4-6
+permissionMode: bypassPermissions
+maxTurns: 30
+---
+
+You are the **issue splitter** for Claude Agent Station. Your job is to
+inspect a single GitHub issue and decide whether it should be implemented
+as one short run or split into 2-5 smaller, independently-implementable
+sub-issues.
+
+You are **read-only on the repository**. You can read files, run `git`
+commands, and inspect the codebase to understand scope. You must not
+edit, write, or create files outside the explicit output file path you
+are given in the spawn prompt.
+
+Follow the format in `agent/prompts/issue-splitter.md` exactly. Your
+output is parsed by a strict JSON validator; any deviation causes the
+run to fall back to single-issue mode and the parent issue stays
+untouched.

--- a/agent/agents/issue-splitter.md
+++ b/agent/agents/issue-splitter.md
@@ -17,7 +17,15 @@ commands, and inspect the codebase to understand scope. You must not
 edit, write, or create files outside the explicit output file path you
 are given in the spawn prompt.
 
+Note for reviewers: the `Bash` tool is granted for inspection commands
+(`git log`, `rg`, `find`). This is honor-system read-only enforcement,
+not tool-permission enforcement — `Bash` could theoretically write
+files. The integration test in PR-4 verifies that splitter runs leave
+the working tree clean.
+
 Follow the format in `agent/prompts/issue-splitter.md` exactly. Your
 output is parsed by a strict JSON validator; any deviation causes the
 run to fall back to single-issue mode and the parent issue stays
-untouched.
+untouched. The parser tolerates a ` ```json ` markdown fence around
+the JSON (defensive — the prompt asks for no fence), so don't add one
+on purpose.

--- a/agent/issue_splitter/heuristics.py
+++ b/agent/issue_splitter/heuristics.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-LONG_BODY_TOKENS = 1200
+# Whitespace-token threshold (call them words; one whitespace token ≈ 0.75
+# LLM tokens, so 1200 words ≈ 900-1000 LLM tokens — well past the point
+# where a single specialist run starts dropping context mid-implementation).
+LONG_BODY_WORDS = 1200
 ACCEPTANCE_COUNT_THRESHOLD = 4
 CROSS_CUTTING_TRIPLES: tuple[frozenset[str], ...] = (
     frozenset({"backend", "frontend", "db-migration"}),
@@ -40,10 +43,10 @@ def _acceptance_count(body: str) -> int:
     return len(_BULLET_RE.findall(body or ""))
 
 
-def _body_token_estimate(body: str) -> int:
-    # Whitespace-split word count is a deliberate over-estimate vs. real
-    # tokenisation; pulling in tiktoken for one threshold isn't worth the
-    # extra dependency on the splitter's hot path.
+def _body_word_count(body: str) -> int:
+    # Whitespace-split count is a deliberate proxy for "context size";
+    # pulling in tiktoken for one threshold isn't worth the extra
+    # dependency on the splitter's hot path.
     return len((body or "").split())
 
 
@@ -57,7 +60,7 @@ def maybe_split(issue: dict) -> HeuristicResult:
     reasons: list[str] = []
     body = issue.get("body") or ""
 
-    if _body_token_estimate(body) > LONG_BODY_TOKENS:
+    if _body_word_count(body) > LONG_BODY_WORDS:
         reasons.append("body_length")
 
     if _acceptance_count(body) >= ACCEPTANCE_COUNT_THRESHOLD:

--- a/agent/issue_splitter/heuristics.py
+++ b/agent/issue_splitter/heuristics.py
@@ -1,0 +1,69 @@
+"""Pre-dispatch heuristics for the issue splitter (#391).
+
+Default policy: don't split. The five triggers below escalate an issue to a
+"split candidate" — the SDK splitter still makes the final call. Triggers:
+
+1. Long body (crude token-estimate threshold).
+2. Four or more acceptance criteria checkboxes in the body.
+3. Cross-cutting label sets (e.g. backend + frontend + db-migration).
+4. Operator opt-in label ``split-me``.
+5. Operator opt-out label ``do-not-split`` — the only hard veto. It beats
+   ``split-me`` and every other trigger so an operator always has an escape
+   hatch when the heuristic misjudges.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+LONG_BODY_TOKENS = 1200
+ACCEPTANCE_COUNT_THRESHOLD = 4
+CROSS_CUTTING_TRIPLES: tuple[frozenset[str], ...] = (
+    frozenset({"backend", "frontend", "db-migration"}),
+    frozenset({"backend", "frontend", "infra"}),
+)
+
+OPT_IN_LABEL = "split-me"
+OPT_OUT_LABEL = "do-not-split"
+
+
+@dataclass(frozen=True, slots=True)
+class HeuristicResult:
+    should_split: bool
+    reasons: tuple[str, ...]
+
+
+_BULLET_RE = re.compile(r"^\s*[-*]\s*\[[ xX]\]", re.MULTILINE)
+
+
+def _acceptance_count(body: str) -> int:
+    return len(_BULLET_RE.findall(body or ""))
+
+
+def _body_token_estimate(body: str) -> int:
+    # Whitespace-split word count is a deliberate over-estimate vs. real
+    # tokenisation; pulling in tiktoken for one threshold isn't worth the
+    # extra dependency on the splitter's hot path.
+    return len((body or "").split())
+
+
+def maybe_split(issue: dict) -> HeuristicResult:
+    labels = set(issue.get("labels") or ())
+    if OPT_OUT_LABEL in labels:
+        return HeuristicResult(should_split=False, reasons=("opt_out",))
+    if OPT_IN_LABEL in labels:
+        return HeuristicResult(should_split=True, reasons=("opt_in",))
+
+    reasons: list[str] = []
+    body = issue.get("body") or ""
+
+    if _body_token_estimate(body) > LONG_BODY_TOKENS:
+        reasons.append("body_length")
+
+    if _acceptance_count(body) >= ACCEPTANCE_COUNT_THRESHOLD:
+        reasons.append("acceptance_count")
+
+    if any(triple <= labels for triple in CROSS_CUTTING_TRIPLES):
+        reasons.append("cross_cutting")
+
+    return HeuristicResult(should_split=bool(reasons), reasons=tuple(reasons))

--- a/agent/issue_splitter/schema.py
+++ b/agent/issue_splitter/schema.py
@@ -1,0 +1,115 @@
+"""Splitter output schema + parser (#391).
+
+The splitter emits a JSON array of sub-issue proposals. Strict validation
+keeps the autonomous flow from acting on malformed output — on any
+validation failure the run falls back to single-issue mode and the parent
+issue stays untouched.
+
+An empty array (``[]``) is the splitter's explicit signal of "don't split,
+run the parent issue as-is". It is intentionally distinct from a validation
+error: a clean empty decision is forwarded to the scheduler unchanged.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+
+MAX_PROPOSALS = 5
+MIN_PROPOSALS = 2
+
+REQUIRED_FIELDS = ("title", "body", "labels", "acceptance")
+
+_FENCE_RE = re.compile(
+    r"^\s*```(?:json)?\s*\n?(?P<body>.*?)\n?```\s*$",
+    re.DOTALL,
+)
+
+
+class SplitterError(Exception):
+    """Raised by :func:`parse_splitter_output` on any validation failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class SubIssueProposal:
+    title: str
+    body: str
+    labels: tuple[str, ...]
+    acceptance: tuple[str, ...]
+    depends_on: int | None = None  # zero-based index into the proposals tuple
+
+
+@dataclass(frozen=True, slots=True)
+class SplitDecision:
+    proposals: tuple[SubIssueProposal, ...]
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _strip_markdown_fence(raw: str) -> str:
+    """Tolerate ```json fences around the JSON payload.
+
+    Sonnet wraps structured output in a fenced block by default; rejecting
+    that would force the prompt to fight the model. The parser stays strict
+    once the fence is gone.
+    """
+    match = _FENCE_RE.match(raw.strip())
+    if match is None:
+        return raw
+    return match.group("body")
+
+
+def parse_splitter_output(raw: str) -> SplitDecision:
+    payload = _strip_markdown_fence(raw)
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise SplitterError(f"invalid json: {exc}") from exc
+
+    if not isinstance(data, list):
+        raise SplitterError("top-level must be a json array")
+
+    if len(data) == 0:
+        # Splitter explicitly chose not to split; let the run proceed as-is.
+        return SplitDecision(proposals=(), warnings=())
+
+    if len(data) < MIN_PROPOSALS:
+        raise SplitterError(
+            f"need at least {MIN_PROPOSALS} proposals or an empty array, got {len(data)}"
+        )
+
+    warnings: list[str] = []
+    items = data
+    if len(items) > MAX_PROPOSALS:
+        warnings.append(f"truncated {len(items)} proposals to {MAX_PROPOSALS}")
+        items = items[:MAX_PROPOSALS]
+
+    proposals: list[SubIssueProposal] = []
+    for i, item in enumerate(items):
+        if not isinstance(item, dict):
+            raise SplitterError(f"item {i} is not an object")
+        missing = [f for f in REQUIRED_FIELDS if f not in item]
+        if missing:
+            raise SplitterError(f"item {i} missing fields: {missing}")
+        proposals.append(
+            SubIssueProposal(
+                title=str(item["title"]),
+                body=str(item["body"]),
+                labels=tuple(map(str, item.get("labels") or ())),
+                acceptance=tuple(map(str, item.get("acceptance") or ())),
+                depends_on=item.get("depends_on"),
+            )
+        )
+
+    for i, prop in enumerate(proposals):
+        if prop.depends_on is None:
+            continue
+        if not isinstance(prop.depends_on, int) or isinstance(prop.depends_on, bool):
+            raise SplitterError(f"item {i} depends_on must be int or null")
+        if not 0 <= prop.depends_on < len(proposals):
+            raise SplitterError(
+                f"item {i} depends_on={prop.depends_on} out of range"
+            )
+        if prop.depends_on == i:
+            raise SplitterError(f"item {i} depends_on itself")
+
+    return SplitDecision(proposals=tuple(proposals), warnings=tuple(warnings))

--- a/agent/issue_splitter/schema.py
+++ b/agent/issue_splitter/schema.py
@@ -77,19 +77,37 @@ def parse_splitter_output(raw: str) -> SplitDecision:
             f"need at least {MIN_PROPOSALS} proposals or an empty array, got {len(data)}"
         )
 
-    warnings: list[str] = []
-    items = data
-    if len(items) > MAX_PROPOSALS:
-        warnings.append(f"truncated {len(items)} proposals to {MAX_PROPOSALS}")
-        items = items[:MAX_PROPOSALS]
+    # Refuse rather than truncate: silently dropping proposals would
+    # invalidate the splitter's depends_on index math (an index pointing
+    # at a discarded item would become a separate "out of range" error)
+    # and discards work the operator might want to see. The prompt's
+    # 2-5 contract is the source of truth — anything outside that is
+    # the model violating the contract, not something for us to paper
+    # over. Reviewers: see PR #421 finding "truncation silently drops".
+    if len(data) > MAX_PROPOSALS:
+        raise SplitterError(
+            f"at most {MAX_PROPOSALS} proposals allowed, got {len(data)}"
+        )
 
+    warnings: list[str] = []
     proposals: list[SubIssueProposal] = []
-    for i, item in enumerate(items):
+    for i, item in enumerate(data):
         if not isinstance(item, dict):
             raise SplitterError(f"item {i} is not an object")
         missing = [f for f in REQUIRED_FIELDS if f not in item]
         if missing:
             raise SplitterError(f"item {i} missing fields: {missing}")
+        # ``labels`` and ``acceptance`` MUST be JSON arrays — strings are
+        # iterable in Python, so a bare ``"labels": "backend"`` would
+        # otherwise produce per-character labels like ('b','a','c',...)
+        # and PR-2's GitHub label-creation step would land seven garbage
+        # labels on the issue. Reject explicitly. See PR #421 review.
+        for field_name in ("labels", "acceptance"):
+            value = item.get(field_name)
+            if value is not None and not isinstance(value, list):
+                raise SplitterError(
+                    f"item {i} {field_name} must be a json array, got {type(value).__name__}"
+                )
         proposals.append(
             SubIssueProposal(
                 title=str(item["title"]),

--- a/agent/prompts/issue-splitter.md
+++ b/agent/prompts/issue-splitter.md
@@ -1,0 +1,73 @@
+# Issue Splitter — Prompt
+
+## Inputs
+
+You will receive:
+
+- The **parent issue body** (Markdown), including its title, labels, and acceptance criteria.
+- A **repo summary** (file tree depth-3, recent commits, README excerpt).
+- The current **project vision** (if present in `docs/vision.md`).
+- A **budget hint**: target each sub-run to complete in **4-10 minutes** of agent wall-clock.
+
+## Task
+
+Decide if the parent issue is decomposable into 2-5 atomic sub-issues
+that can be implemented independently by a single specialist team.
+
+If the parent is already small (about 30 minutes or less of expected
+work, single acceptance criterion, scoped to one subsystem), **do not
+split** — emit an empty array `[]`. The harness treats this as "run
+as-is".
+
+If the parent is decomposable, emit a JSON array of 2-5 sub-issue
+proposals. **No prose around the JSON** — your entire output must be
+the JSON array, parseable by `json.loads`.
+
+## Constraints
+
+- Each sub-issue must be **implementable end-to-end by a single
+  specialist team in 15 minutes or less of agent time**.
+- Each sub-issue must have **testable acceptance criteria** — no vague
+  "make it work" criteria.
+- Sub-issue **bodies must be self-contained** — a downstream agent
+  reading only the sub-issue body must have enough context to implement
+  it. Inline the relevant excerpt from the parent.
+- **`depends_on`** is the index (zero-based) of a prerequisite sibling
+  in this same array, or `null` if independent. Use sparingly — only
+  when sub-issue B actually requires sub-issue A's branch to be merged
+  before B can compile.
+- **Never** propose splitting a sub-issue further (no recursive splits
+  — this is single-level).
+- **Never** propose sub-issues whose union is larger than the parent.
+  Decomposition, not amplification.
+
+## Output
+
+A JSON array of objects:
+
+```json
+[
+  {
+    "title": "Add /api/auth/login endpoint",
+    "body": "Full self-contained body. Inline parent context as needed.",
+    "labels": ["backend", "auth"],
+    "acceptance": [
+      "POST /api/auth/login with valid credentials returns 200 + JWT.",
+      "POST /api/auth/login with invalid credentials returns 401."
+    ],
+    "depends_on": null
+  },
+  {
+    "title": "Add /api/me endpoint",
+    "body": "...",
+    "labels": ["backend", "auth"],
+    "acceptance": ["GET /api/me with valid JWT returns the current user."],
+    "depends_on": 0
+  }
+]
+```
+
+If you decide **not** to split, emit `[]`.
+
+Output **only** the JSON array — no explanation, no commentary, no
+Markdown fence around it.

--- a/agent/prompts/issue-splitter.md
+++ b/agent/prompts/issue-splitter.md
@@ -7,7 +7,7 @@ You will receive:
 - The **parent issue body** (Markdown), including its title, labels, and acceptance criteria.
 - A **repo summary** (file tree depth-3, recent commits, README excerpt).
 - The current **project vision** (if present in `docs/vision.md`).
-- A **budget hint**: target each sub-run to complete in **4-10 minutes** of agent wall-clock.
+- A **budget hint**: target each sub-run to complete in **10-15 minutes** of agent wall-clock (see the hard upper bound under Constraints).
 
 ## Task
 

--- a/dashboard/backend/tests/test_issue_splitter_heuristics.py
+++ b/dashboard/backend/tests/test_issue_splitter_heuristics.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from agent.issue_splitter.heuristics import (
     HeuristicResult,
-    LONG_BODY_TOKENS,
+    LONG_BODY_WORDS,
     maybe_split,
 )
 
@@ -20,7 +20,7 @@ def test_short_simple_issue_does_not_split():
 
 
 def test_long_body_triggers_split():
-    body = "x " * (LONG_BODY_TOKENS + 100)
+    body = "x " * (LONG_BODY_WORDS + 100)
     res = maybe_split(_issue(body=body))
     assert res.should_split is True
     assert "body_length" in res.reasons
@@ -52,7 +52,7 @@ def test_split_me_label_forces_split():
 
 
 def test_do_not_split_label_forces_no_split():
-    body = "x " * (LONG_BODY_TOKENS + 500)
+    body = "x " * (LONG_BODY_WORDS + 500)
     res = maybe_split(_issue(body=body, labels=("do-not-split",)))
     assert res.should_split is False
     assert "opt_out" in res.reasons
@@ -72,7 +72,7 @@ def test_missing_body_field_is_safe():
 
 
 def test_multiple_triggers_are_all_reported():
-    body = ("x " * (LONG_BODY_TOKENS + 50)) + (
+    body = ("x " * (LONG_BODY_WORDS + 50)) + (
         "\n- [ ] a\n- [ ] b\n- [ ] c\n- [ ] d\n"
     )
     res = maybe_split(_issue(body=body, labels=("backend", "frontend", "infra")))

--- a/dashboard/backend/tests/test_issue_splitter_heuristics.py
+++ b/dashboard/backend/tests/test_issue_splitter_heuristics.py
@@ -1,0 +1,80 @@
+"""maybe_split heuristic tests (#391)."""
+from __future__ import annotations
+
+from agent.issue_splitter.heuristics import (
+    HeuristicResult,
+    LONG_BODY_TOKENS,
+    maybe_split,
+)
+
+
+def _issue(*, body: str = "", labels: tuple[str, ...] = ()) -> dict:
+    return {"number": 27, "title": "auth", "body": body, "labels": list(labels)}
+
+
+def test_short_simple_issue_does_not_split():
+    res = maybe_split(_issue(body="Add a tooltip."))
+    assert isinstance(res, HeuristicResult)
+    assert res.should_split is False
+    assert res.reasons == ()
+
+
+def test_long_body_triggers_split():
+    body = "x " * (LONG_BODY_TOKENS + 100)
+    res = maybe_split(_issue(body=body))
+    assert res.should_split is True
+    assert "body_length" in res.reasons
+
+
+def test_four_acceptance_criteria_triggers_split():
+    body = (
+        "## Acceptance criteria\n"
+        "- [ ] login api\n"
+        "- [ ] me endpoint\n"
+        "- [ ] oauth callback\n"
+        "- [ ] route middleware\n"
+    )
+    res = maybe_split(_issue(body=body))
+    assert res.should_split is True
+    assert "acceptance_count" in res.reasons
+
+
+def test_cross_cutting_labels_trigger_split():
+    res = maybe_split(_issue(labels=("backend", "frontend", "db-migration")))
+    assert res.should_split is True
+    assert "cross_cutting" in res.reasons
+
+
+def test_split_me_label_forces_split():
+    res = maybe_split(_issue(body="x", labels=("split-me",)))
+    assert res.should_split is True
+    assert "opt_in" in res.reasons
+
+
+def test_do_not_split_label_forces_no_split():
+    body = "x " * (LONG_BODY_TOKENS + 500)
+    res = maybe_split(_issue(body=body, labels=("do-not-split",)))
+    assert res.should_split is False
+    assert "opt_out" in res.reasons
+
+
+def test_opt_out_beats_opt_in():
+    """Operator escape hatch wins over operator opt-in."""
+    res = maybe_split(_issue(labels=("split-me", "do-not-split")))
+    assert res.should_split is False
+    assert "opt_out" in res.reasons
+
+
+def test_missing_body_field_is_safe():
+    """Real GitHub issues sometimes omit the body field entirely."""
+    res = maybe_split({"number": 1, "title": "x", "labels": []})
+    assert res.should_split is False
+
+
+def test_multiple_triggers_are_all_reported():
+    body = ("x " * (LONG_BODY_TOKENS + 50)) + (
+        "\n- [ ] a\n- [ ] b\n- [ ] c\n- [ ] d\n"
+    )
+    res = maybe_split(_issue(body=body, labels=("backend", "frontend", "infra")))
+    assert res.should_split is True
+    assert {"body_length", "acceptance_count", "cross_cutting"} <= set(res.reasons)

--- a/dashboard/backend/tests/test_issue_splitter_prompt.py
+++ b/dashboard/backend/tests/test_issue_splitter_prompt.py
@@ -1,0 +1,37 @@
+"""Splitter agent role + prompt presence (#391)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_agent_role_file_exists():
+    p = REPO_ROOT / "agent/agents/issue-splitter.md"
+    assert p.exists(), p
+    text = p.read_text()
+    assert "name: issue-splitter" in text
+    assert "tools:" in text
+    # Read-only: no Edit / Write tools granted.
+    assert "Edit" not in text
+    assert "Write" not in text
+    assert "model:" in text
+
+
+def test_prompt_file_lists_required_sections():
+    p = REPO_ROOT / "agent/prompts/issue-splitter.md"
+    assert p.exists(), p
+    text = p.read_text()
+    for section in ("## Inputs", "## Task", "## Constraints", "## Output"):
+        assert section in text, section
+    # JSON schema sketch must be present.
+    assert '"title"' in text
+    assert '"acceptance"' in text
+    assert '"depends_on"' in text
+
+
+def test_prompt_documents_empty_array_as_no_split():
+    """Downstream parser treats ``[]`` as "run as-is"; the prompt must say so."""
+    p = REPO_ROOT / "agent/prompts/issue-splitter.md"
+    text = p.read_text()
+    assert "[]" in text

--- a/dashboard/backend/tests/test_issue_splitter_schema.py
+++ b/dashboard/backend/tests/test_issue_splitter_schema.py
@@ -1,0 +1,99 @@
+"""Splitter JSON output parser (#391)."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.issue_splitter.schema import (
+    SplitDecision,
+    SplitterError,
+    SubIssueProposal,
+    parse_splitter_output,
+)
+
+
+def test_parse_minimum_valid_two_items():
+    raw = json.dumps([
+        {"title": "Add login endpoint",
+         "body": "POST /api/auth/login returns 200 + token.",
+         "labels": ["backend"],
+         "acceptance": ["Returns 200", "Issues JWT"],
+         "depends_on": None},
+        {"title": "Add /me endpoint",
+         "body": "GET /api/me returns the current user from the token.",
+         "labels": ["backend"],
+         "acceptance": ["Returns 200 when authenticated"],
+         "depends_on": 0},
+    ])
+    decision = parse_splitter_output(raw)
+    assert isinstance(decision, SplitDecision)
+    assert len(decision.proposals) == 2
+    assert decision.proposals[0].title == "Add login endpoint"
+    assert decision.proposals[1].depends_on == 0
+
+
+def test_parse_rejects_single_item():
+    raw = json.dumps([{"title": "x", "body": "y", "labels": [], "acceptance": ["a"]}])
+    with pytest.raises(SplitterError, match="at least 2"):
+        parse_splitter_output(raw)
+
+
+def test_parse_truncates_to_five():
+    items = [
+        {"title": f"item {i}", "body": "b", "labels": [], "acceptance": ["a"], "depends_on": None}
+        for i in range(7)
+    ]
+    decision = parse_splitter_output(json.dumps(items))
+    assert len(decision.proposals) == 5
+    assert decision.warnings  # truncation warning recorded
+
+
+def test_parse_rejects_malformed_json():
+    with pytest.raises(SplitterError, match="json"):
+        parse_splitter_output("not json")
+
+
+def test_parse_rejects_missing_required_fields():
+    raw = json.dumps([
+        {"title": "a", "body": "b", "labels": [], "acceptance": ["x"]},
+        {"title": "c"},  # missing body, labels, acceptance
+    ])
+    with pytest.raises(SplitterError, match="missing"):
+        parse_splitter_output(raw)
+
+
+def test_parse_rejects_invalid_depends_on():
+    raw = json.dumps([
+        {"title": "a", "body": "b", "labels": [], "acceptance": ["x"], "depends_on": None},
+        {"title": "c", "body": "d", "labels": [], "acceptance": ["x"], "depends_on": 99},
+    ])
+    with pytest.raises(SplitterError, match="depends_on"):
+        parse_splitter_output(raw)
+
+
+def test_parse_accepts_fenced_json_block():
+    """The SDK splitter sometimes wraps its output in ```json fences."""
+    items = [
+        {"title": "a", "body": "b", "labels": [], "acceptance": ["x"], "depends_on": None},
+        {"title": "c", "body": "d", "labels": [], "acceptance": ["y"], "depends_on": None},
+    ]
+    raw = "```json\n" + json.dumps(items) + "\n```"
+    decision = parse_splitter_output(raw)
+    assert len(decision.proposals) == 2
+
+
+def test_parse_empty_array_is_run_as_is():
+    """An empty array means the splitter chose not to split — valid."""
+    decision = parse_splitter_output("[]")
+    assert decision.proposals == ()
+    assert decision.warnings == ()
+
+
+def test_parse_rejects_self_dependency():
+    raw = json.dumps([
+        {"title": "a", "body": "b", "labels": [], "acceptance": ["x"], "depends_on": None},
+        {"title": "c", "body": "d", "labels": [], "acceptance": ["y"], "depends_on": 1},
+    ])
+    with pytest.raises(SplitterError, match="depends_on"):
+        parse_splitter_output(raw)

--- a/dashboard/backend/tests/test_issue_splitter_schema.py
+++ b/dashboard/backend/tests/test_issue_splitter_schema.py
@@ -39,14 +39,44 @@ def test_parse_rejects_single_item():
         parse_splitter_output(raw)
 
 
-def test_parse_truncates_to_five():
+def test_parse_rejects_more_than_five():
+    """Refuse rather than truncate: silently dropping items would break
+    depends_on index math and lose work. The prompt's 2-5 cap is the
+    contract — violations are the splitter's bug, not ours to paper over.
+    """
     items = [
         {"title": f"item {i}", "body": "b", "labels": [], "acceptance": ["a"], "depends_on": None}
         for i in range(7)
     ]
-    decision = parse_splitter_output(json.dumps(items))
-    assert len(decision.proposals) == 5
-    assert decision.warnings  # truncation warning recorded
+    with pytest.raises(SplitterError, match="at most 5"):
+        parse_splitter_output(json.dumps(items))
+
+
+def test_parse_rejects_string_where_labels_list_expected():
+    """A bare string for ``labels`` (Sonnet's known quirk for single-label
+    issues) would otherwise be iterated character-by-character and produce
+    garbage labels like ('b','a','c','k','e','n','d'). Refuse explicitly.
+    Regression guard for PR #421 review finding."""
+    raw = json.dumps([
+        {"title": "a", "body": "b", "labels": "backend",
+         "acceptance": ["x"], "depends_on": None},
+        {"title": "c", "body": "d", "labels": ["backend"],
+         "acceptance": ["y"], "depends_on": None},
+    ])
+    with pytest.raises(SplitterError, match="labels"):
+        parse_splitter_output(raw)
+
+
+def test_parse_rejects_string_where_acceptance_list_expected():
+    """Same defence for ``acceptance``."""
+    raw = json.dumps([
+        {"title": "a", "body": "b", "labels": [],
+         "acceptance": "must work", "depends_on": None},
+        {"title": "c", "body": "d", "labels": [],
+         "acceptance": ["x"], "depends_on": None},
+    ])
+    with pytest.raises(SplitterError, match="acceptance"):
+        parse_splitter_output(raw)
 
 
 def test_parse_rejects_malformed_json():

--- a/dashboard/backend/tests/test_prompt_contracts.py
+++ b/dashboard/backend/tests/test_prompt_contracts.py
@@ -139,15 +139,18 @@ class TestPromptRouterSync:
         """
         from app.routers.prompts import PROMPT_ROLES
 
-        # Document the known gap: 7 files on disk, only 5 in router
+        # Document the known gap: harness-style prompts live next to the
+        # orchestrator role prompts but aren't surfaced through the router.
         # Excludes: REPORT-SCHEMAS (shared schema doc), conflict_resolver
         # (system prompt for the agent.conflict_resolver harness, not an
         # orchestrator role agent — see
-        # docs/superpowers/specs/2026-05-10-conflict-resolution-design.md).
+        # docs/superpowers/specs/2026-05-10-conflict-resolution-design.md),
+        # issue-splitter (system prompt for the agent.issue_splitter harness
+        # — see docs/superpowers/specs/2026-05-14-issue-391-decompose-long-runs.md).
         # TODO(v1.1): replace this denylist with a frontmatter convention
         # (e.g. `role: harness`) or a directory split — review finding #8.
         # Each new harness-style prompt currently requires a manual addition.
-        _NON_ROLE_PROMPTS = {"REPORT-SCHEMAS", "conflict_resolver"}
+        _NON_ROLE_PROMPTS = {"REPORT-SCHEMAS", "conflict_resolver", "issue-splitter"}
         actual_files_count = len([
             p for p in _PROMPTS_DIR.glob("*.md")
             if p.stem not in _NON_ROLE_PROMPTS


### PR DESCRIPTION
First of four PRs for #391 (decompose long runs). Foundation — no DB, no SDK invocation, no scheduling. Pure data structures, validation, and the agent role definition.

## Summary
- **\`agent/issue_splitter/schema.py\`** — \`SubIssueProposal\` + \`SplitDecision\` frozen dataclasses, \`parse_splitter_output()\` strict JSON parser. Tolerates markdown \`\`\`json fences (Sonnet wraps structured output by default), enforces 2-5 proposal range, validates \`depends_on\` indices, rejects self-dependencies. Empty array \`[]\` is a valid no-op decision distinct from validation failure.
- **\`agent/issue_splitter/heuristics.py\`** — \`maybe_split(issue)\` pre-dispatch screen. Five triggers (long body, ≥4 acceptance criteria, cross-cutting label triples, \`split-me\` opt-in, \`do-not-split\` opt-out). Opt-out is the only hard veto.
- **\`agent/agents/issue-splitter.md\`** + **\`agent/prompts/issue-splitter.md\`** — Agent Teams role definition + harness prompt. Sonnet 4.6, 30-turn cap, read-only tool set.
- **\`test_prompt_contracts.py\`** — allow-list the splitter prompt as a harness prompt (precedent: \`conflict_resolver\`).

## Test plan
- [x] **Full backend suite: 1359 passed, 1 skipped** (was 1338 on Wave 8 complete; +21 new tests: 9 schema, 9 heuristics, 3 prompt presence).
- [x] Schema parser handles fenced JSON, empty array no-op, range violations, malformed JSON, missing fields, bad \`depends_on\`.
- [x] Heuristics covers all five triggers plus opt-out beats opt-in.

## Plan vs spec resolution
The plan's reference \`parse_splitter_output\` rejected \`len < 2\`, but the prompt instructs the splitter to emit \`[]\` for don't-split. Resolved here by accepting \`[]\` as a valid no-op \`SplitDecision(proposals=(), warnings=())\`. PR-2's scheduler and PR-3's \`decide.py\` integration must treat \`proposals == ()\` as "do not fan out — run parent as-is".

## Scope (NOT in this PR)
- GitHub issue creation + back-link comments → PR-2
- SDK splitter invocation → PR-2
- DB columns (\`run_kind\`, \`parent_run_id\`) + Alembic → PR-3
- Scheduler + decide-hook integration → PR-3
- Frontend + integration test + docs → PR-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)