### PR TITLE
feat(splitter): GitHub ops + SDK runner (#391, PR 2/4)

### DIFF
--- a/agent/issue_splitter/github_ops.py
+++ b/agent/issue_splitter/github_ops.py
@@ -119,7 +119,33 @@ def create_sub_issues(
     means a parent's ``backend`` label carries forward without forcing
     the splitter prompt to re-emit it, and proposal-specific labels like
     ``frontend`` for a UI-only slice still attach.
+
+    Partial-failure note: this function creates issues sequentially and
+    does NOT attempt to roll back if a later ``gh.create_issue`` raises.
+    On retry, the controller (PR-3) is responsible for either resuming
+    from the surviving issues or accepting duplicates — splitter-proposed
+    issues require human review before pickup, so duplicates are visible
+    rather than destructive.
+
+    Raises :class:`SplitterError` if any proposal references a sibling
+    that hasn't been created yet — the splitter is expected to order
+    proposals so dependencies precede dependants, and forward references
+    would otherwise KeyError mid-loop.
     """
+    # Schema only validates ``0 <= depends_on < len`` and ``!= own_index``;
+    # it does NOT enforce backward-only references, so a malicious or
+    # confused splitter could emit ``proposals[0].depends_on = 2`` and
+    # KeyError us mid-loop. Catch that here with a clear message rather
+    # than the schema (the schema layer is a pure parser; ordering is a
+    # consumer concern). Reviewer note (PR #422 finding).
+    for i, prop in enumerate(proposals):
+        if prop.depends_on is not None and prop.depends_on >= i:
+            from agent.issue_splitter.schema import SplitterError
+            raise SplitterError(
+                f"item {i} depends_on={prop.depends_on} is a forward reference; "
+                "proposals must list dependencies before dependants"
+            )
+
     owner, repo = parent["repo"].split("/", 1)
     ensure_splitter_label(owner, repo, gh)
 

--- a/agent/issue_splitter/github_ops.py
+++ b/agent/issue_splitter/github_ops.py
@@ -1,0 +1,168 @@
+"""GitHub issue creation for the issue-splitter (#391).
+
+Mirrors the issue-creation flow used by ``agent/vision_analyst.py`` (which
+seeds a ``vision-suggested`` label, then attaches it to every proposal it
+creates) but with a different label (``splitter-proposed``) and a per-
+sub-issue body template that inlines the ``Parent: #N`` back-link plus
+optional ``Depends on #M`` cross-reference.
+
+Why the ``gh`` parameter is an injected client rather than direct
+``subprocess.run(["gh", ...])`` calls (the pattern in ``vision_analyst``):
+
+- Three sites (label ensure, issue create, parent comment) need to
+  share state — the controller in PR-3 wants a single retry/auth/error
+  policy across all of them. A method-style seam keeps that policy in
+  one place instead of duplicating it inline in this module.
+- The seam is trivially mockable, so unit tests don't have to patch
+  ``subprocess.run`` and reason about argv shape; they assert on the
+  intent (``gh.create_issue(... labels=[...])``) instead.
+
+PR-3 provides the concrete ``gh`` adapter that wraps ``agent.gh_client``.
+"""
+from __future__ import annotations
+
+from typing import Iterable, Protocol, Sequence
+
+from agent.issue_splitter.schema import SubIssueProposal
+
+SPLITTER_LABEL = "splitter-proposed"
+SPLITTER_LABEL_COLOR = "0E8A16"  # matches existing PR:Approved green
+SPLITTER_LABEL_DESCRIPTION = (
+    "Issue proposed by Claude Station's issue-splitter agent. Review and "
+    "remove this label to make the issue eligible for autonomous pickup."
+)
+
+
+class _GhClient(Protocol):
+    """Method shape this module relies on. PR-3 supplies the adapter."""
+
+    def label_exists(self, owner: str, repo: str, name: str) -> bool: ...
+    def create_label(
+        self,
+        owner: str,
+        repo: str,
+        name: str,
+        *,
+        color: str,
+        description: str,
+    ) -> None: ...
+    def create_issue(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        title: str,
+        body: str,
+        labels: Sequence[str],
+    ) -> dict: ...
+    def create_issue_comment(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        *,
+        body: str,
+    ) -> None: ...
+
+
+def ensure_splitter_label(owner: str, repo: str, gh: _GhClient) -> None:
+    """Create the ``splitter-proposed`` label on ``owner/repo`` if missing.
+
+    Idempotent via ``gh.label_exists`` so callers can invoke this on every
+    splitter run without paying a create-and-ignore-409 round trip.
+    """
+    if gh.label_exists(owner, repo, SPLITTER_LABEL):
+        return
+    gh.create_label(
+        owner,
+        repo,
+        SPLITTER_LABEL,
+        color=SPLITTER_LABEL_COLOR,
+        description=SPLITTER_LABEL_DESCRIPTION,
+    )
+
+
+def _format_body(
+    parent_number: int,
+    proposal: SubIssueProposal,
+    sibling_numbers_by_index: dict[int, int],
+) -> str:
+    lines = [
+        f"_This sub-issue was proposed by Claude Station's issue-splitter "
+        f"from parent #{parent_number}. Review by removing the "
+        f"`{SPLITTER_LABEL}` label._",
+        "",
+        f"Parent: #{parent_number}",
+    ]
+    if proposal.depends_on is not None:
+        # depends_on is a zero-based index into the proposals tuple; the
+        # caller populates sibling_numbers_by_index as it creates each
+        # issue, so any back-reference is resolvable by the time we see
+        # it (the schema guarantees depends_on < own_index path the
+        # splitter produces, and parse rejects self-references).
+        prereq_number = sibling_numbers_by_index[proposal.depends_on]
+        lines.append(f"Depends on #{prereq_number}")
+    lines += ["", proposal.body, "", "## Acceptance criteria", ""]
+    lines += [f"- [ ] {c}" for c in proposal.acceptance]
+    return "\n".join(lines)
+
+
+def create_sub_issues(
+    parent: dict,
+    proposals: Sequence[SubIssueProposal],
+    gh: _GhClient,
+) -> list[dict]:
+    """Create one GitHub issue per proposal, returning the raw API payloads.
+
+    Each sub-issue gets ``SPLITTER_LABEL`` plus the union of the parent's
+    labels and the proposal's labels. The union (sorted for determinism)
+    means a parent's ``backend`` label carries forward without forcing
+    the splitter prompt to re-emit it, and proposal-specific labels like
+    ``frontend`` for a UI-only slice still attach.
+    """
+    owner, repo = parent["repo"].split("/", 1)
+    ensure_splitter_label(owner, repo, gh)
+
+    parent_labels = set(parent.get("labels") or ())
+    created: list[dict] = []
+    sibling_numbers: dict[int, int] = {}
+    for i, prop in enumerate(proposals):
+        body = _format_body(parent["number"], prop, sibling_numbers)
+        labels = sorted({SPLITTER_LABEL, *parent_labels, *prop.labels})
+        issue = gh.create_issue(
+            owner,
+            repo,
+            title=prop.title,
+            body=body,
+            labels=labels,
+        )
+        sibling_numbers[i] = issue["number"]
+        created.append(issue)
+    return created
+
+
+def add_backlink_comment(
+    *,
+    parent_repo: str,
+    parent_number: int,
+    sub_numbers: Iterable[int],
+    gh: _GhClient,
+) -> None:
+    """Post a comment on the parent listing the new sub-issues.
+
+    The comment doubles as a discoverable audit trail — anyone landing on
+    the parent issue sees the decomposition without having to find the
+    splitter's run record in the dashboard.
+    """
+    owner, repo = parent_repo.split("/", 1)
+    lines = [
+        "Claude Station's issue-splitter has decomposed this issue:",
+        "",
+    ]
+    lines += [f"- #{n}" for n in sub_numbers]
+    lines += [
+        "",
+        "Each sub-issue requires manual approval (remove the "
+        f"`{SPLITTER_LABEL}` label) before autonomous pickup.",
+    ]
+    gh.create_issue_comment(owner, repo, parent_number, body="\n".join(lines))

--- a/agent/issue_splitter/runner.py
+++ b/agent/issue_splitter/runner.py
@@ -1,0 +1,133 @@
+"""Spawn the issue-splitter SDK session and return a SplitDecision (#391).
+
+The splitter is a single short-lived Sonnet run: read-only on the repo,
+capped at 30 turns, producing a JSON array on stdout. We invoke it via
+the Claude Agent SDK rather than as a bash subprocess so the SDK session
+is observable in the dashboard alongside every other run.
+
+Empty-array contract: an empty array is the splitter's explicit "run as-is"
+signal. We surface that as ``SplitDecision(proposals=(), warnings=())``
+rather than ``None`` — callers that need to branch on "did the splitter
+choose to split" check ``decision.proposals`` and don't have to also
+disambiguate ``None`` from a raised :class:`SplitterError`.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from claude_agent_sdk import ClaudeAgentOptions, query
+
+from agent.issue_splitter.schema import (
+    SplitDecision,
+    parse_splitter_output,
+)
+
+logger = logging.getLogger(__name__)
+
+ROLE_FILE = Path(__file__).resolve().parents[1] / "agents" / "issue-splitter.md"
+PROMPT_FILE = Path(__file__).resolve().parents[1] / "prompts" / "issue-splitter.md"
+
+SPLITTER_MODEL = "claude-sonnet-4-6"
+SPLITTER_MAX_TURNS = 30
+SPLITTER_ALLOWED_TOOLS = ["Read", "Glob", "Grep", "Bash"]
+
+_STREAM_CLOSE_TIMEOUT_MS = "1800000"
+
+
+def _ensure_stream_close_timeout() -> None:
+    """Set ``CLAUDE_CODE_STREAM_CLOSE_TIMEOUT`` on the current process env.
+
+    Same workaround as ``agent/conflict_resolver/sdk_runner.py``: after
+    #384's ClaudeSDKClient migration the bundled CLI begins a stdin-close
+    countdown once it emits its first ResultMessage; once stdin closes,
+    PreToolUse / PostToolUse callbacks raise "Stream closed". Modules
+    that still use the one-shot ``query()`` API own setting this.
+
+    ``setdefault`` rather than assignment so an operator debugging the
+    stdin-close path can override via the environment.
+    """
+    os.environ.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", _STREAM_CLOSE_TIMEOUT_MS)
+
+
+async def _invoke_splitter_sdk(
+    *,
+    issue: dict,
+    run_id: str,
+    repo_summary: str,
+    vision: str,
+) -> str:
+    """Spawn the SDK session and capture the splitter's JSON output.
+
+    Returns the raw string the splitter wrote as its final assistant
+    text. Schema validation happens in :func:`run_splitter`. Patched
+    wholesale in unit tests; the real SDK is exercised by PR-4's
+    integration test.
+
+    ``run_id`` is currently unused inside the function — it threads
+    through the call signature so the eventual audit-hook plumbing
+    (PR-3) can attribute tool calls to a specific splitter run without
+    a follow-up signature change.
+    """
+    _ensure_stream_close_timeout()
+
+    role_md = ROLE_FILE.read_text()
+    prompt_md = PROMPT_FILE.read_text()
+    user_message = (
+        f"{prompt_md}\n\n"
+        f"## Parent issue\n\n{json.dumps(issue, indent=2)}\n\n"
+        f"## Repo summary\n\n{repo_summary or '(no summary)'}\n\n"
+        f"## Vision\n\n{vision or '(no vision)'}\n\n"
+        "Output ONLY the JSON array. No prose."
+    )
+
+    options = ClaudeAgentOptions(
+        system_prompt=role_md,
+        model=SPLITTER_MODEL,
+        max_turns=SPLITTER_MAX_TURNS,
+        permission_mode="bypassPermissions",
+        allowed_tools=SPLITTER_ALLOWED_TOOLS,
+    )
+
+    # Mirror the conflict-resolver's accumulation pattern: walk every
+    # message, keep the latest assistant text, and treat the result
+    # message as the terminator. The splitter prompt instructs the model
+    # to emit *only* the JSON array as its final response, so the last
+    # captured text is what we parse.
+    last_text: str | None = None
+    async for message in query(prompt=user_message, options=options):
+        mtype = getattr(message, "type", None)
+        if mtype == "assistant":
+            content = getattr(message, "content", None)
+            if content:
+                last_text = str(content)
+        elif mtype == "result":
+            # ``result`` ends the stream; nothing more to capture.
+            break
+    return (last_text or "").strip()
+
+
+async def run_splitter(
+    *,
+    issue: dict,
+    run_id: str,
+    repo_summary: str,
+    vision: str,
+) -> SplitDecision:
+    """Return the parsed :class:`SplitDecision` for the given parent issue.
+
+    An empty-array output is a valid result and surfaces as a
+    ``SplitDecision`` with ``proposals=()`` — that's the splitter's
+    "don't split; run as-is" signal. Malformed output raises
+    :class:`SplitterError` (propagated from
+    :func:`parse_splitter_output`).
+    """
+    raw = await _invoke_splitter_sdk(
+        issue=issue,
+        run_id=run_id,
+        repo_summary=repo_summary,
+        vision=vision,
+    )
+    return parse_splitter_output(raw)

--- a/agent/issue_splitter/runner.py
+++ b/agent/issue_splitter/runner.py
@@ -52,12 +52,49 @@ def _ensure_stream_close_timeout() -> None:
     os.environ.setdefault("CLAUDE_CODE_STREAM_CLOSE_TIMEOUT", _STREAM_CLOSE_TIMEOUT_MS)
 
 
+def _extract_assistant_text(content) -> str | None:
+    """Pull the text-block payload out of an SDK assistant message.
+
+    ``message.content`` is a list of content blocks (see
+    ``agent/station_orchestrator.py`` for the canonical walking pattern);
+    each text block exposes its payload on ``.text`` (or ``["text"]``
+    when the SDK hands back a dict instead of a dataclass). Conflict-
+    resolver gets away with ``str(content)`` because it only uses the
+    captured text as a debugging breadcrumb for retry-failure messages;
+    we MUST extract the real text because the splitter's output is
+    parsed as JSON. Reviewer note (PR #422): catching this without an
+    integration test is hard — the unit tests mock _invoke_splitter_sdk
+    wholesale — so this helper has its own coverage at the seam.
+    """
+    if content is None:
+        return None
+    blocks = content if isinstance(content, list) else [content]
+    parts: list[str] = []
+    for block in blocks:
+        block_type = (
+            getattr(block, "type", None)
+            or (block.get("type") if isinstance(block, dict) else None)
+        )
+        if block_type != "text":
+            continue
+        text = (
+            getattr(block, "text", None)
+            or (block.get("text") if isinstance(block, dict) else None)
+        )
+        if text:
+            parts.append(text)
+    if not parts:
+        return None
+    return "\n".join(parts)
+
+
 async def _invoke_splitter_sdk(
     *,
     issue: dict,
     run_id: str,
     repo_summary: str,
     vision: str,
+    cwd: str | None = None,
 ) -> str:
     """Spawn the SDK session and capture the splitter's JSON output.
 
@@ -65,6 +102,12 @@ async def _invoke_splitter_sdk(
     text. Schema validation happens in :func:`run_splitter`. Patched
     wholesale in unit tests; the real SDK is exercised by PR-4's
     integration test.
+
+    ``cwd`` is the project repo the splitter inspects with its
+    read-only tool set; without it the SDK runs against the launcher's
+    cwd (``/app`` in container mode), where ``git log`` / ``rg`` find
+    nothing useful. PR-3's controller threads the workspace path
+    through here.
 
     ``run_id`` is currently unused inside the function — it threads
     through the call signature so the eventual audit-hook plumbing
@@ -84,6 +127,7 @@ async def _invoke_splitter_sdk(
     )
 
     options = ClaudeAgentOptions(
+        cwd=cwd,
         system_prompt=role_md,
         model=SPLITTER_MODEL,
         max_turns=SPLITTER_MAX_TURNS,
@@ -91,18 +135,17 @@ async def _invoke_splitter_sdk(
         allowed_tools=SPLITTER_ALLOWED_TOOLS,
     )
 
-    # Mirror the conflict-resolver's accumulation pattern: walk every
-    # message, keep the latest assistant text, and treat the result
-    # message as the terminator. The splitter prompt instructs the model
-    # to emit *only* the JSON array as its final response, so the last
-    # captured text is what we parse.
+    # Walk every message, keep the latest assistant text, and treat the
+    # result message as the terminator. The splitter prompt instructs
+    # the model to emit *only* the JSON array as its final response, so
+    # the last captured text is what we parse.
     last_text: str | None = None
     async for message in query(prompt=user_message, options=options):
         mtype = getattr(message, "type", None)
         if mtype == "assistant":
-            content = getattr(message, "content", None)
-            if content:
-                last_text = str(content)
+            text = _extract_assistant_text(getattr(message, "content", None))
+            if text:
+                last_text = text
         elif mtype == "result":
             # ``result`` ends the stream; nothing more to capture.
             break
@@ -115,6 +158,7 @@ async def run_splitter(
     run_id: str,
     repo_summary: str,
     vision: str,
+    cwd: str | None = None,
 ) -> SplitDecision:
     """Return the parsed :class:`SplitDecision` for the given parent issue.
 
@@ -123,11 +167,16 @@ async def run_splitter(
     "don't split; run as-is" signal. Malformed output raises
     :class:`SplitterError` (propagated from
     :func:`parse_splitter_output`).
+
+    ``cwd`` is forwarded to :func:`_invoke_splitter_sdk`; pass the
+    project's checkout root so the splitter's read-only tool set
+    (``git log``, ``rg``, ``find``) inspects the right tree.
     """
     raw = await _invoke_splitter_sdk(
         issue=issue,
         run_id=run_id,
         repo_summary=repo_summary,
         vision=vision,
+        cwd=cwd,
     )
     return parse_splitter_output(raw)

--- a/dashboard/backend/tests/test_issue_splitter_github_ops.py
+++ b/dashboard/backend/tests/test_issue_splitter_github_ops.py
@@ -92,6 +92,35 @@ def test_add_backlink_comment_writes_summary():
         gh=gh,
     )
     gh.create_issue_comment.assert_called_once()
-    args, kwargs = gh.create_issue_comment.call_args
-    body = kwargs.get("body") or args[3] if len(args) > 3 else kwargs.get("body")
+    body = gh.create_issue_comment.call_args.kwargs.get("body", "")
     assert "#101" in body and "#102" in body and "#103" in body
+
+
+def test_create_sub_issues_rejects_forward_reference():
+    """Schema validates depends_on bounds + self-ref but allows forward
+    references (proposal 0 depending on proposal 2). create_sub_issues
+    creates issues sequentially and populates the sibling-number map as
+    it goes, so a forward reference would KeyError mid-loop. Refuse
+    explicitly with a clear message. Regression guard for PR #422.
+    """
+    from agent.issue_splitter.schema import SplitterError
+
+    gh = MagicMock()
+    gh.label_exists.return_value = True
+    # Bypass parser; construct proposals directly so we can plant a
+    # forward reference the parser doesn't currently reject.
+    proposals = [
+        SubIssueProposal(
+            title="first", body="b", labels=(), acceptance=("x",),
+            depends_on=1,  # forward ref!
+        ),
+        SubIssueProposal(
+            title="second", body="b", labels=(), acceptance=("x",),
+            depends_on=None,
+        ),
+    ]
+    parent = {"number": 27, "labels": [], "repo": "x/y"}
+    with pytest.raises(SplitterError, match="forward reference"):
+        create_sub_issues(parent, proposals, gh)
+    # Nothing should have been created.
+    gh.create_issue.assert_not_called()

--- a/dashboard/backend/tests/test_issue_splitter_github_ops.py
+++ b/dashboard/backend/tests/test_issue_splitter_github_ops.py
@@ -1,0 +1,97 @@
+"""GitHub issue creation for splitter (#391).
+
+Tests verify the wiring against an injected ``gh`` client. The real ``gh``
+adapter lives in PR-3 (the splitter controller); these tests mock the
+methods this module calls so the unit boundary stays at the protocol seam.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.issue_splitter.github_ops import (
+    SPLITTER_LABEL,
+    add_backlink_comment,
+    create_sub_issues,
+    ensure_splitter_label,
+)
+from agent.issue_splitter.schema import SubIssueProposal
+
+
+def _proposal(title: str, depends_on: int | None = None) -> SubIssueProposal:
+    return SubIssueProposal(
+        title=title,
+        body="parent-context inlined here\n\nimplementation detail",
+        labels=("backend",),
+        acceptance=("Returns 200",),
+        depends_on=depends_on,
+    )
+
+
+def test_ensure_splitter_label_creates_when_missing():
+    gh = MagicMock()
+    gh.label_exists.return_value = False
+    ensure_splitter_label("kenhaesler", "claude-agent-station", gh)
+    gh.create_label.assert_called_once()
+    args, _ = gh.create_label.call_args
+    assert args[0] == "kenhaesler"
+    assert args[1] == "claude-agent-station"
+    assert args[2] == "splitter-proposed"
+
+
+def test_ensure_splitter_label_idempotent_when_present():
+    gh = MagicMock()
+    gh.label_exists.return_value = True
+    ensure_splitter_label("kenhaesler", "claude-agent-station", gh)
+    gh.create_label.assert_not_called()
+
+
+def test_create_sub_issues_posts_each_with_correct_labels():
+    gh = MagicMock()
+    gh.label_exists.return_value = True
+    gh.create_issue.side_effect = [
+        {"number": 101}, {"number": 102}, {"number": 103},
+    ]
+    parent = {
+        "number": 27,
+        "labels": ["backend", "auth"],
+        "repo": "kenhaesler/claude-agent-station",
+    }
+    proposals = [_proposal("a"), _proposal("b", depends_on=0), _proposal("c")]
+    created = create_sub_issues(parent, proposals, gh)
+
+    assert [c["number"] for c in created] == [101, 102, 103]
+    for call in gh.create_issue.call_args_list:
+        kwargs = call.kwargs
+        assert SPLITTER_LABEL in kwargs["labels"]
+    # Body includes parent back-link.
+    body_a = gh.create_issue.call_args_list[0].kwargs["body"]
+    assert "Parent: #27" in body_a
+    # depends_on of item 1 references sibling at index 0 -> #101.
+    body_b = gh.create_issue.call_args_list[1].kwargs["body"]
+    assert "Depends on #101" in body_b
+
+
+def test_create_sub_issues_applies_parent_label_set():
+    gh = MagicMock()
+    gh.label_exists.return_value = True
+    gh.create_issue.side_effect = [{"number": 101}, {"number": 102}]
+    parent = {"number": 27, "labels": ["backend"], "repo": "x/y"}
+    create_sub_issues(parent, [_proposal("a"), _proposal("b")], gh)
+    labels = gh.create_issue.call_args_list[0].kwargs["labels"]
+    assert "backend" in labels
+
+
+def test_add_backlink_comment_writes_summary():
+    gh = MagicMock()
+    add_backlink_comment(
+        parent_repo="x/y",
+        parent_number=27,
+        sub_numbers=[101, 102, 103],
+        gh=gh,
+    )
+    gh.create_issue_comment.assert_called_once()
+    args, kwargs = gh.create_issue_comment.call_args
+    body = kwargs.get("body") or args[3] if len(args) > 3 else kwargs.get("body")
+    assert "#101" in body and "#102" in body and "#103" in body

--- a/dashboard/backend/tests/test_issue_splitter_runner.py
+++ b/dashboard/backend/tests/test_issue_splitter_runner.py
@@ -1,0 +1,72 @@
+"""run_splitter spawns the SDK session and parses its output (#391).
+
+These tests mock ``_invoke_splitter_sdk`` so the real Claude Agent SDK
+is never touched — the SDK roundtrip is exercised by the integration
+test that lands with PR-4. Here we verify only the parse/return contract
+and error propagation.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent.issue_splitter.runner import run_splitter
+from agent.issue_splitter.schema import SplitDecision, SplitterError
+
+
+@pytest.mark.asyncio
+async def test_run_splitter_returns_parsed_decision():
+    captured = json.dumps([
+        {"title": "A", "body": "B", "labels": ["x"], "acceptance": ["a1"], "depends_on": None},
+        {"title": "B", "body": "C", "labels": ["x"], "acceptance": ["a1"], "depends_on": 0},
+    ])
+    with patch(
+        "agent.issue_splitter.runner._invoke_splitter_sdk",
+        new=AsyncMock(return_value=captured),
+    ):
+        decision = await run_splitter(
+            issue={"number": 27, "body": "x", "labels": []},
+            run_id="run-split-decision-1",
+            repo_summary="repo info",
+            vision="vision text",
+        )
+    assert isinstance(decision, SplitDecision)
+    assert len(decision.proposals) == 2
+    assert decision.proposals[1].depends_on == 0
+
+
+@pytest.mark.asyncio
+async def test_run_splitter_propagates_schema_errors():
+    with patch(
+        "agent.issue_splitter.runner._invoke_splitter_sdk",
+        new=AsyncMock(return_value="garbage"),
+    ):
+        with pytest.raises(SplitterError):
+            await run_splitter(
+                issue={"number": 1, "body": "x", "labels": []},
+                run_id="r1",
+                repo_summary="",
+                vision="",
+            )
+
+
+@pytest.mark.asyncio
+async def test_run_splitter_empty_array_means_run_as_is():
+    """Empty array -> SplitDecision with no proposals (controller's signal
+    to run the parent as-is). We always return SplitDecision rather than
+    ``None`` so callers don't have to disambiguate "splitter said no" from
+    "splitter errored" via the type system."""
+    with patch(
+        "agent.issue_splitter.runner._invoke_splitter_sdk",
+        new=AsyncMock(return_value="[]"),
+    ):
+        decision = await run_splitter(
+            issue={"number": 1, "body": "x", "labels": []},
+            run_id="r1",
+            repo_summary="",
+            vision="",
+        )
+    assert isinstance(decision, SplitDecision)
+    assert decision.proposals == ()

--- a/dashboard/backend/tests/test_issue_splitter_runner.py
+++ b/dashboard/backend/tests/test_issue_splitter_runner.py
@@ -70,3 +70,74 @@ async def test_run_splitter_empty_array_means_run_as_is():
         )
     assert isinstance(decision, SplitDecision)
     assert decision.proposals == ()
+
+
+# ---------------------------------------------------------------------------
+# _extract_assistant_text — regression guard for PR #422 finding.
+#
+# SDK assistant messages expose `content` as a list of content blocks
+# (TextBlock / ToolUseBlock / ToolResultBlock dataclasses, or dict shapes
+# in some SDK versions). `str(content)` would produce a Python repr like
+# `[TextBlock(text='[...]')]` instead of the actual JSON payload, and
+# `parse_splitter_output` would silently raise SplitterError downstream.
+# These tests lock in the block-walking extraction at the seam.
+# ---------------------------------------------------------------------------
+
+
+from dataclasses import dataclass
+
+from agent.issue_splitter.runner import _extract_assistant_text
+
+
+@dataclass
+class _TextBlock:
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class _ToolUseBlock:
+    name: str
+    type: str = "tool_use"
+
+
+def test_extract_text_from_block_list_dataclasses():
+    """Realistic SDK shape: content is a list of TextBlock dataclasses."""
+    content = [_TextBlock(text='[{"title": "a"}]')]
+    assert _extract_assistant_text(content) == '[{"title": "a"}]'
+
+
+def test_extract_text_skips_non_text_blocks():
+    """A tool_use block must not contaminate the captured text."""
+    content = [
+        _ToolUseBlock(name="Read"),
+        _TextBlock(text='[{"title": "a"}]'),
+    ]
+    assert _extract_assistant_text(content) == '[{"title": "a"}]'
+
+
+def test_extract_text_from_dict_block_shape():
+    """Some SDK versions hand back dict-shaped blocks instead of dataclasses."""
+    content = [
+        {"type": "text", "text": "first"},
+        {"type": "text", "text": "second"},
+    ]
+    assert _extract_assistant_text(content) == "first\nsecond"
+
+
+def test_extract_text_returns_none_when_no_text_blocks():
+    content = [_ToolUseBlock(name="Read"), _ToolUseBlock(name="Grep")]
+    assert _extract_assistant_text(content) is None
+
+
+def test_extract_text_handles_bare_string_content():
+    """Older SDK shapes occasionally hand back a single string."""
+    # We wrap in a single-element list internally; the string itself
+    # isn't a typed block, so we return None (no text-type marker).
+    # The function's contract is "extract from text-typed blocks";
+    # bare strings are out of contract.
+    assert _extract_assistant_text("just a string") is None
+
+
+def test_extract_text_returns_none_for_none_content():
+    assert _extract_assistant_text(None) is None


### PR DESCRIPTION
Second of four PRs for #391 (decompose long runs). Builds on PR-1 (#421, schema + heuristics + agent role) which is merged.

## Summary
- **\`agent/issue_splitter/github_ops.py\`** — \`ensure_splitter_label\` (idempotent), \`create_sub_issues\` (loops proposals, formats body with \`Parent: #N\` back-link + \`Depends on #M\` cross-reference + acceptance-criteria checkboxes, unions parent + proposal labels with the splitter label), \`add_backlink_comment\` (posts a decomposition summary on the parent). Operates through a \`_GhClient\` Protocol — PR-3 supplies the concrete adapter wrapping \`agent.gh_client\`.
- **\`agent/issue_splitter/runner.py\`** — \`run_splitter()\` invokes the Claude Agent SDK with \`ClaudeAgentOptions\` (Sonnet 4.6, 30-turn cap, read-only tools), accumulates the final assistant text, and parses it via PR-1's \`parse_splitter_output\`. Mirrors the one-shot \`query()\` pattern from \`agent/conflict_resolver/sdk_runner.py\` including the \`CLAUDE_CODE_STREAM_CLOSE_TIMEOUT\` workaround.

## Empty-array contract
\`run_splitter\` always returns a \`SplitDecision\`; an empty array surfaces as \`SplitDecision(proposals=(), warnings=())\`. Callers branch on \`decision.proposals\` for the "did the splitter choose to split" check, avoiding the need to disambiguate \`None\` from a raised \`SplitterError\`.

## Test plan
- [x] **Full backend suite: 1369 passed, 1 skipped** (was 1361 on PR-1 merge; +8 new tests — 5 github_ops + 3 runner).
- [x] Schema validation propagates: malformed SDK output raises \`SplitterError\`.
- [x] Real Docker/SDK NOT exercised — \`_invoke_splitter_sdk\` is mocked. PR-4 adds an integration test.

## Deviations from plan
- The plan's \`gh\` parameter described a method-bearing client; the codebase only has \`agent/gh_client.py\` (functional helpers) and \`subprocess.run\` patterns. Kept the plan's injected-client API as a \`Protocol\` documenting the contract PR-3 must fulfill — cleaner than three inline \`subprocess.run\` blocks.
- The plan's \`runner.py\` pseudocode passed a dict to \`query()\`; the real SDK takes \`ClaudeAgentOptions\`. Aligned with \`agent/conflict_resolver/sdk_runner.py\`.
- Labels sorted for deterministic ordering (was \`list({...})\`).

## Scope (NOT in this PR)
- \`_GhClient\` adapter implementation → PR-3
- DB columns + scheduler + decide-hook → PR-3
- Audit-hook plumbing for splitter tool calls (\`make_audited_policy\`) → PR-3
- Frontend + integration test + docs → PR-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)