### PR TITLE
feat(splitter): scheduler + decide hook + tree API (#391, PR 3/4)

### DIFF
--- a/agent/coordinator/__init__.py
+++ b/agent/coordinator/__init__.py
@@ -1,0 +1,7 @@
+"""Coordinator hooks for the orchestrator (#391).
+
+This package was rebuilt during the Agent Teams overhaul — the old
+coordinator pipeline was deleted; only narrow integration hooks live
+here now. Currently exposes the splitter pre-dispatch hook
+(:mod:`agent.coordinator.decide`).
+"""

--- a/agent/coordinator/decide.py
+++ b/agent/coordinator/decide.py
@@ -23,11 +23,38 @@ from __future__ import annotations
 import logging
 import os
 
+from agent.issue_splitter.gh_adapter import GhAdapter
+from agent.issue_splitter.github_ops import (
+    add_backlink_comment,
+    create_sub_issues,
+)
 from agent.issue_splitter.heuristics import maybe_split
 from agent.issue_splitter.runner import run_splitter
 from agent.issue_splitter.schema import SplitDecision, SplitterError
 
 logger = logging.getLogger(__name__)
+
+
+def _gh_client() -> GhAdapter:
+    """Factory seam for tests.
+
+    Tests patch ``agent.coordinator.decide._gh_client`` to inject a
+    ``MagicMock`` adapter without going through GitHub.
+    """
+    return GhAdapter()
+
+
+def _ensure_integration_branch(repo: str, parent_number: int) -> str:
+    """Create ``integration/issue-<N>`` off ``dev`` if it doesn't exist.
+
+    Kept as a top-level function (rather than inlined) so the test for
+    :func:`execute_split_decision` can patch it independently — branch
+    creation hits two ``gh api`` calls in the happy path and isn't worth
+    re-asserting in every execution test.
+    """
+    branch = f"integration/issue-{parent_number}"
+    _gh_client().ensure_branch(repo, branch, from_branch="dev")
+    return branch
 
 
 async def maybe_run_splitter(
@@ -77,10 +104,78 @@ async def execute_split_decision(
     run_id: str,
 ) -> None:
     """Apply a :class:`SplitDecision`: create sub-issues, comment on the
-    parent, ensure the integration branch exists, and archive the
-    decision on the run row.
+    parent, label the parent ``split``, ensure the integration branch
+    exists, and archive the decision on the run row.
 
-    Wired in Task 11; the stub raises so the test for Task 10 still has
-    a callable symbol to patch out.
+    Ordering rationale:
+
+    1. Create sub-issues first — they're the irreversible side effect
+       the operator cares about most. If a later step fails, the
+       sub-issues still exist (with the ``splitter-proposed`` label, so
+       they sit pending review rather than dispatch automatically).
+    2. Post the backlink comment so the parent has a discoverable audit
+       trail even if the next steps fail.
+    3. Label the parent ``split`` so the dispatcher's next tick skips
+       it. Doing this before the DB write is fine — the worst case is
+       the DB row lacks ``run_kind`` but GitHub state is consistent.
+    4. Ensure the integration branch exists last. The branch is only
+       needed once the first sub-run wants to merge; deferring it gives
+       earlier failures a chance to surface without leaving dangling
+       branches.
+    5. Persist the split decision on the run row for observability.
     """
-    raise NotImplementedError("Task 11 wires this")
+    gh = _gh_client()
+    created = create_sub_issues(parent, decision.proposals, gh)
+    sub_numbers = [c["number"] for c in created]
+    add_backlink_comment(
+        parent_repo=parent["repo"],
+        parent_number=parent["number"],
+        sub_numbers=sub_numbers,
+        gh=gh,
+    )
+    owner, repo = parent["repo"].split("/", 1)
+    gh.add_labels(owner, repo, parent["number"], ["split"])
+    _ensure_integration_branch(parent["repo"], parent["number"])
+
+    # Persist the split decision on the run row so the dashboard can
+    # render the decomposition without re-fetching GitHub. The DB write
+    # is best-effort: the GitHub side effects above are the
+    # source-of-truth, and a DB failure here would re-trigger a
+    # GitHub-side duplicate on retry. Log and continue.
+    await _persist_split_decision(run_id, parent["number"], sub_numbers,
+                                  list(decision.warnings))
+
+
+async def _persist_split_decision(
+    run_id: str,
+    parent_number: int,
+    sub_numbers: list[int],
+    warnings: list[str],
+) -> None:
+    """Best-effort archival write of the splitter decision payload.
+
+    Top-level helper (rather than inline) so callers can patch it in
+    tests that aren't running against a live DB. Failures are logged at
+    WARNING and swallowed: this is observability, not control flow.
+    """
+    try:
+        from app.database import async_session
+        from app.models import Run
+        from sqlalchemy import update
+        async with async_session() as db:
+            await db.execute(
+                update(Run).where(Run.run_id == run_id).values(
+                    run_kind="split-decision",
+                    split_decision_json={
+                        "parent_number": parent_number,
+                        "sub_numbers": sub_numbers,
+                        "warnings": warnings,
+                    },
+                )
+            )
+            await db.commit()
+    except Exception as exc:  # pragma: no cover - best-effort
+        logger.warning(
+            "failed to persist split decision for run=%s parent=#%d: %s",
+            run_id, parent_number, exc,
+        )

--- a/agent/coordinator/decide.py
+++ b/agent/coordinator/decide.py
@@ -1,0 +1,86 @@
+"""Pre-dispatch decision hooks for the issue splitter (#391).
+
+The orchestrator (PR-4 will wire the call site) invokes
+:func:`maybe_run_splitter` for each candidate issue before launching
+the normal Agent Teams run. When the function returns a
+:class:`SplitDecision`, the orchestrator hands off to
+:func:`execute_split_decision` instead of running the single-issue
+flow; on ``None`` it falls through to the existing single-issue path.
+
+Why this module is the seam rather than ``station_orchestrator.py``:
+
+- Heuristic + LLM dispatch + DB write are pure I/O that the
+  orchestrator shouldn't know about. Keeping them here means the
+  orchestrator's call site is a one-liner (``decision = await
+  maybe_run_splitter(...)``) and the splitter can be unit-tested in
+  isolation without spinning up the orchestrator.
+- The hook is feature-gated by ``STATION_SPLIT_ENABLED=1``; with the
+  flag off the module is a no-op so PR-3 ships safely with the call
+  site stubbed in PR-4.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from agent.issue_splitter.heuristics import maybe_split
+from agent.issue_splitter.runner import run_splitter
+from agent.issue_splitter.schema import SplitDecision, SplitterError
+
+logger = logging.getLogger(__name__)
+
+
+async def maybe_run_splitter(
+    issue: dict,
+    *,
+    run_id: str,
+    repo_summary: str,
+    vision: str,
+) -> SplitDecision | None:
+    """Pre-dispatch hook. Returns a :class:`SplitDecision` when the issue
+    should be split, ``None`` otherwise (caller falls through to the
+    normal single-issue dispatch path).
+
+    Feature-gated by ``STATION_SPLIT_ENABLED=1``. When the flag is unset
+    or any other value, the function returns ``None`` without consulting
+    the heuristic — no LLM call, no GitHub access.
+
+    ``SplitterError`` from the SDK runner is caught and logged at WARNING:
+    a failed split should not block the normal pickup path. The
+    single-issue flow remains a safe fallback.
+    """
+    if os.environ.get("STATION_SPLIT_ENABLED") != "1":
+        return None
+    heuristic = maybe_split(issue)
+    if not heuristic.should_split:
+        return None
+    try:
+        return await run_splitter(
+            issue=issue,
+            run_id=run_id,
+            repo_summary=repo_summary,
+            vision=vision,
+        )
+    except SplitterError as exc:
+        logger.warning(
+            "splitter failed for issue #%s: %s — falling back to single-issue",
+            issue.get("number"),
+            exc,
+        )
+        return None
+
+
+async def execute_split_decision(
+    parent: dict,
+    decision: SplitDecision,
+    *,
+    run_id: str,
+) -> None:
+    """Apply a :class:`SplitDecision`: create sub-issues, comment on the
+    parent, ensure the integration branch exists, and archive the
+    decision on the run row.
+
+    Wired in Task 11; the stub raises so the test for Task 10 still has
+    a callable symbol to patch out.
+    """
+    raise NotImplementedError("Task 11 wires this")

--- a/agent/coordinator/decide.py
+++ b/agent/coordinator/decide.py
@@ -63,6 +63,7 @@ async def maybe_run_splitter(
     run_id: str,
     repo_summary: str,
     vision: str,
+    cwd: str | None = None,
 ) -> SplitDecision | None:
     """Pre-dispatch hook. Returns a :class:`SplitDecision` when the issue
     should be split, ``None`` otherwise (caller falls through to the
@@ -75,6 +76,18 @@ async def maybe_run_splitter(
     ``SplitterError`` from the SDK runner is caught and logged at WARNING:
     a failed split should not block the normal pickup path. The
     single-issue flow remains a safe fallback.
+
+    A successful splitter call that returns an empty-proposals decision
+    ("don't split; run as-is") is collapsed to ``None`` here, so callers
+    have a single signal to branch on: ``None`` → run the parent
+    single-issue, non-``None`` → hand off to :func:`execute_split_decision`.
+    Without this collapse, callers would have to also check
+    ``decision.proposals`` and ``execute_split_decision`` would happily
+    label the parent ``split`` despite no actual decomposition.
+
+    ``cwd`` is forwarded to :func:`run_splitter`; pass the project's
+    checkout root so the splitter's read-only tool set inspects the
+    right tree (not the launcher's ``/app`` in container mode).
     """
     if os.environ.get("STATION_SPLIT_ENABLED") != "1":
         return None
@@ -82,11 +95,12 @@ async def maybe_run_splitter(
     if not heuristic.should_split:
         return None
     try:
-        return await run_splitter(
+        decision = await run_splitter(
             issue=issue,
             run_id=run_id,
             repo_summary=repo_summary,
             vision=vision,
+            cwd=cwd,
         )
     except SplitterError as exc:
         logger.warning(
@@ -95,6 +109,12 @@ async def maybe_run_splitter(
             exc,
         )
         return None
+    if not decision.proposals:
+        # Splitter looked at the issue and said "no, run as-is" (empty
+        # array). Surface that as a fall-through rather than a decision
+        # the caller has to special-case.
+        return None
+    return decision
 
 
 async def execute_split_decision(
@@ -123,7 +143,19 @@ async def execute_split_decision(
        earlier failures a chance to surface without leaving dangling
        branches.
     5. Persist the split decision on the run row for observability.
+
+    Refuses to execute on an empty-proposals decision: ``maybe_run_splitter``
+    is the load-bearing gate (it collapses "splitter said no" to ``None``),
+    but a future caller bypassing that path could pass an empty decision
+    directly. Without this guard the function would label the parent
+    ``split`` and create an empty integration branch — visible damage on
+    a parent issue that the splitter explicitly declined to decompose.
     """
+    if not decision.proposals:
+        raise ValueError(
+            "execute_split_decision called with empty proposals — use "
+            "maybe_run_splitter's None return as the 'do not split' signal"
+        )
     gh = _gh_client()
     created = create_sub_issues(parent, decision.proposals, gh)
     sub_numbers = [c["number"] for c in created]
@@ -157,7 +189,14 @@ async def _persist_split_decision(
     Top-level helper (rather than inline) so callers can patch it in
     tests that aren't running against a live DB. Failures are logged at
     WARNING and swallowed: this is observability, not control flow.
+
+    Catches only the failure shapes a DB outage actually produces
+    (``SQLAlchemyError`` and ``OSError``) rather than a blanket
+    ``Exception`` — programming errors (``NameError``/``AttributeError``)
+    should crash loudly so they get fixed, not get silently logged.
     """
+    from sqlalchemy.exc import SQLAlchemyError
+
     try:
         from app.database import async_session
         from app.models import Run
@@ -174,7 +213,7 @@ async def _persist_split_decision(
                 )
             )
             await db.commit()
-    except Exception as exc:  # pragma: no cover - best-effort
+    except (SQLAlchemyError, OSError) as exc:
         logger.warning(
             "failed to persist split decision for run=%s parent=#%d: %s",
             run_id, parent_number, exc,

--- a/agent/issue_splitter/gh_adapter.py
+++ b/agent/issue_splitter/gh_adapter.py
@@ -1,0 +1,200 @@
+"""Concrete ``gh`` adapter for the issue-splitter (#391).
+
+PR-2 defined a small ``_GhClient`` Protocol in
+:mod:`agent.issue_splitter.github_ops` so the splitter's GitHub side
+effects (label ensure, issue create, parent comment) could be mocked at
+the method level in tests. This module supplies the runtime
+implementation by composing the existing :func:`agent.gh_client.gh_run`
+and :func:`agent.gh_client.gh_json` helpers — there is no class-style
+``GhClient`` upstream, just module-level functions, so this adapter is
+the seam where method-style intent (``gh.create_issue(...)``) meets
+argv-style invocation (``gh issue create --repo ... --title ...``).
+
+The adapter also exposes the two extra methods PR-3 needs beyond the
+Protocol: ``add_labels`` (used to tag the parent ``split`` after
+execution) and ``ensure_branch`` (used by ``_ensure_integration_branch``
+to create ``integration/issue-<N>`` off ``dev``). Both are implemented
+on top of ``gh api`` calls so they hit the same auth/error path as the
+rest of the splitter — no second SDK to maintain.
+
+Why a class instead of more module-level functions: the test seam in
+:mod:`agent.coordinator.decide` is ``_gh_client()``, a factory that
+returns the adapter. Tests patch the factory and inject a ``MagicMock``,
+so the call sites just have to talk to "the adapter" — they don't have
+to import each function name individually.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+from agent.gh_client import GhError, gh_json, gh_run
+
+logger = logging.getLogger(__name__)
+
+
+class GhAdapter:
+    """Method-style wrapper around the ``gh`` CLI.
+
+    Method shape mirrors the ``_GhClient`` Protocol in
+    :mod:`agent.issue_splitter.github_ops` plus the extra hooks PR-3
+    needs (``add_labels`` / ``ensure_branch``). Each method composes a
+    single ``gh`` argv and delegates to the central subprocess helper —
+    no retry/auth logic lives here, that's the job of
+    :func:`agent.gh_client.gh_run` / :func:`agent.gh_client.gh_json`.
+    """
+
+    # ----- Protocol methods (used by github_ops) ------------------------
+
+    def label_exists(self, owner: str, repo: str, name: str) -> bool:
+        """Return True if ``name`` exists on ``owner/repo``.
+
+        Uses ``gh api repos/{owner}/{repo}/labels/{name}`` — a 200 means
+        the label exists, a 404 means it doesn't. Any other error is
+        propagated as :class:`GhError` (the caller decides whether to
+        treat it as fatal or fall through).
+        """
+        try:
+            gh_json([
+                "api",
+                f"repos/{owner}/{repo}/labels/{name}",
+            ])
+            return True
+        except GhError as exc:
+            if "404" in exc.stderr or "Not Found" in exc.stderr:
+                return False
+            raise
+
+    def create_label(
+        self,
+        owner: str,
+        repo: str,
+        name: str,
+        *,
+        color: str,
+        description: str,
+    ) -> None:
+        result = gh_run([
+            "label", "create", name,
+            "--repo", f"{owner}/{repo}",
+            "--color", color,
+            "--description", description,
+        ])
+        if not result.ok:
+            # ``gh label create`` exits 1 on already-exists; treat that as
+            # idempotent success (the caller already gated via
+            # ``label_exists`` but a race with another orchestrator is
+            # possible).
+            if "already exists" in result.stderr:
+                logger.debug("label %s already exists on %s/%s", name, owner, repo)
+                return
+            raise GhError(result.cmd, result.returncode, result.stderr)
+
+    def create_issue(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        title: str,
+        body: str,
+        labels: Sequence[str],
+    ) -> dict:
+        """Create an issue and return ``{"number": N, "url": URL}``.
+
+        Returns a dict (not a full GitHub API payload) because the
+        Protocol contract only requires ``["number"]`` and the URL is
+        useful for log lines. ``gh issue create`` prints the URL to
+        stdout; the number is parsed from it.
+        """
+        argv = [
+            "issue", "create",
+            "--repo", f"{owner}/{repo}",
+            "--title", title,
+            "--body", body,
+        ]
+        if labels:
+            argv += ["--label", ",".join(labels)]
+        result = gh_run(argv)
+        if not result.ok:
+            raise GhError(result.cmd, result.returncode, result.stderr)
+        url = result.stdout.strip()
+        number = int(url.rstrip("/").rsplit("/", 1)[1])
+        return {"number": number, "url": url}
+
+    def create_issue_comment(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        *,
+        body: str,
+    ) -> None:
+        result = gh_run([
+            "issue", "comment", str(issue_number),
+            "--repo", f"{owner}/{repo}",
+            "--body", body,
+        ])
+        if not result.ok:
+            raise GhError(result.cmd, result.returncode, result.stderr)
+
+    # ----- Extra methods (used by execute_split_decision) ---------------
+
+    def add_labels(
+        self,
+        owner: str,
+        repo: str,
+        issue_number: int,
+        labels: Sequence[str],
+    ) -> None:
+        """Attach one or more labels to an existing issue.
+
+        ``gh issue edit`` takes ``--add-label`` once per label; we pass
+        them comma-joined which the CLI accepts as a single
+        comma-separated value. (Tested behaviour as of ``gh`` >= 2.40.)
+        """
+        if not labels:
+            return
+        result = gh_run([
+            "issue", "edit", str(issue_number),
+            "--repo", f"{owner}/{repo}",
+            "--add-label", ",".join(labels),
+        ])
+        if not result.ok:
+            raise GhError(result.cmd, result.returncode, result.stderr)
+
+    def ensure_branch(
+        self,
+        repo: str,
+        branch: str,
+        *,
+        from_branch: str,
+    ) -> None:
+        """Create ``branch`` from ``from_branch`` if it doesn't exist.
+
+        Idempotent: a 200 on the GET means we exit early; only the
+        missing-branch case issues the POST to create a new ref.
+        Errors other than "branch missing" propagate.
+        """
+        # 1. Check whether the target branch already exists.
+        try:
+            gh_json(["api", f"repos/{repo}/git/refs/heads/{branch}"])
+            return
+        except GhError as exc:
+            if "404" not in exc.stderr and "Not Found" not in exc.stderr:
+                raise
+            # fall through and create the branch
+
+        # 2. Look up the source branch's HEAD SHA.
+        head = gh_json(["api", f"repos/{repo}/git/refs/heads/{from_branch}"])
+        # ``gh api`` returns the raw GitHub payload — ref / object.sha.
+        sha = head["object"]["sha"]
+
+        # 3. Create the new ref.
+        result = gh_run([
+            "api", f"repos/{repo}/git/refs",
+            "-X", "POST",
+            "-f", f"ref=refs/heads/{branch}",
+            "-f", f"sha={sha}",
+        ])
+        if not result.ok:
+            raise GhError(result.cmd, result.returncode, result.stderr)

--- a/agent/issue_splitter/gh_adapter.py
+++ b/agent/issue_splitter/gh_adapter.py
@@ -28,6 +28,8 @@ from __future__ import annotations
 import logging
 from typing import Sequence
 
+from urllib.parse import quote
+
 from agent.gh_client import GhError, gh_json, gh_run
 
 logger = logging.getLogger(__name__)
@@ -53,11 +55,17 @@ class GhAdapter:
         the label exists, a 404 means it doesn't. Any other error is
         propagated as :class:`GhError` (the caller decides whether to
         treat it as fatal or fall through).
+
+        The label name is URL-encoded so labels containing ``/``, ``?``,
+        or other reserved characters route correctly. Current callers
+        only pass ``splitter-proposed``, but defending the helper at the
+        boundary is cheaper than discovering a future label name breaks
+        the path.
         """
         try:
             gh_json([
                 "api",
-                f"repos/{owner}/{repo}/labels/{name}",
+                f"repos/{owner}/{repo}/labels/{quote(name, safe='')}",
             ])
             return True
         except GhError as exc:
@@ -148,17 +156,18 @@ class GhAdapter:
     ) -> None:
         """Attach one or more labels to an existing issue.
 
-        ``gh issue edit`` takes ``--add-label`` once per label; we pass
-        them comma-joined which the CLI accepts as a single
-        comma-separated value. (Tested behaviour as of ``gh`` >= 2.40.)
+        Emits one ``--add-label`` flag per label rather than a
+        comma-joined value: the comma form is undocumented and has been
+        version-dependent across ``gh`` releases, while the repeated-flag
+        form is the documented contract and works on every supported
+        version.
         """
         if not labels:
             return
-        result = gh_run([
-            "issue", "edit", str(issue_number),
-            "--repo", f"{owner}/{repo}",
-            "--add-label", ",".join(labels),
-        ])
+        argv = ["issue", "edit", str(issue_number), "--repo", f"{owner}/{repo}"]
+        for label in labels:
+            argv += ["--add-label", label]
+        result = gh_run(argv)
         if not result.ok:
             raise GhError(result.cmd, result.returncode, result.stderr)
 

--- a/agent/issue_splitter/scheduler.py
+++ b/agent/issue_splitter/scheduler.py
@@ -1,0 +1,77 @@
+"""Sub-run scheduler (#391).
+
+Picks 0-N eligible sub-issues per scheduler tick. A sub-issue is eligible
+when:
+
+1. Its issue is still open.
+2. Its ``splitter-proposed`` label is **absent** — present means the
+   operator hasn't approved it for autonomous pickup yet. (Same gate
+   as ``vision-suggested``.)
+3. Its ``depends_on_number`` is either absent or has been merged into
+   the integration branch.
+
+The caller (the existing run-trigger flow) is responsible for spawning
+the run; this module only decides *which* sub-issues are ready. Keeping
+the dispatch decision out of this pure function lets the scheduler be
+exercised with synthetic dicts in unit tests without touching GitHub
+or the run-launcher.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+SPLITTER_LABEL = "splitter-proposed"
+
+
+def _is_approved(sub: dict) -> bool:
+    """True when the operator has removed the ``splitter-proposed`` label.
+
+    Absence of the label is the approval signal — same convention used
+    by the vision-bootstrap flow (``vision-suggested``). This keeps the
+    operator-review UX consistent across the two proposal-style flows.
+    """
+    return SPLITTER_LABEL not in (sub.get("labels") or ())
+
+
+def _prereq_satisfied(sub: dict, by_number: dict[int, dict]) -> bool:
+    """True when this sub-issue has no prereq or its prereq is merged.
+
+    A missing prereq (caller referenced ``depends_on_number=N`` but N is
+    not in the sibling set) returns False rather than True — that's a
+    bug in the splitter output and we prefer to stall the dependant
+    rather than silently dispatch it out of order.
+    """
+    dep = sub.get("depends_on_number")
+    if dep is None:
+        return True
+    prereq = by_number.get(dep)
+    if prereq is None:
+        return False
+    return bool(prereq.get("merged_into_integration"))
+
+
+def pick_eligible_subruns(subs: Iterable[dict]) -> list[dict]:
+    """Return the subset of *subs* that may be dispatched this tick.
+
+    Pure function over the sibling state — caller is responsible for
+    fetching the dict shape (typically a GitHub issue payload with
+    project-side ``merged_into_integration`` annotated on top).
+    """
+    subs = list(subs)
+    by_number = {s["number"]: s for s in subs}
+    eligible: list[dict] = []
+    for sub in subs:
+        if sub.get("state") != "open":
+            continue
+        # Already-merged subs are done — even if the GitHub issue is still
+        # technically "open", we don't re-dispatch a run for it. The
+        # ``merged_into_integration`` flag is the canonical "this slice
+        # has shipped" signal maintained by the integration-branch flow.
+        if sub.get("merged_into_integration"):
+            continue
+        if not _is_approved(sub):
+            continue
+        if not _prereq_satisfied(sub, by_number):
+            continue
+        eligible.append(sub)
+    return eligible

--- a/dashboard/backend/alembic/versions/0004_run_kind_parent.py
+++ b/dashboard/backend/alembic/versions/0004_run_kind_parent.py
@@ -1,0 +1,72 @@
+"""Add Run.run_kind / parent_run_id / split_decision_json (#391).
+
+Revision ID: 0004_run_kind_parent
+Revises: 0003_runner_quotas
+Create Date: 2026-05-15
+
+Adds three columns to ``runs`` for the issue-splitter pipeline:
+
+- ``run_kind`` (Text, nullable): tag the run shape ("primary",
+  "sub-of-<N>", "split-decision"). NULL for legacy rows pre-#391.
+- ``parent_run_id`` (Text, nullable, indexed): FK to the parent run
+  for sub-runs. Indexed because the dashboard tree-view endpoint
+  scans by this column.
+- ``split_decision_json`` (JSON / JSONB via JsonType in the model):
+  archived splitter proposal payload.
+
+NOTE: 0001_baseline calls ``Base.metadata.create_all(checkfirst=True)``,
+so on a fresh database the columns may already exist after baseline.
+Each ADD COLUMN is guarded with an existence check so this revision is
+safe whether the DB was created fresh or upgraded from an older schema.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0004_run_kind_parent"
+down_revision = "0003_runner_quotas"
+branch_labels = None
+depends_on = None
+
+
+def _column_exists(table: str, column: str) -> bool:
+    """Return True if *column* already exists in *table* (dialect-agnostic)."""
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    return any(c["name"] == column for c in insp.get_columns(table))
+
+
+def _index_exists(table: str, name: str) -> bool:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    return any(ix["name"] == name for ix in insp.get_indexes(table))
+
+
+def upgrade() -> None:
+    if not _column_exists("runs", "run_kind"):
+        with op.batch_alter_table("runs") as batch:
+            batch.add_column(sa.Column("run_kind", sa.Text(), nullable=True))
+    if not _column_exists("runs", "parent_run_id"):
+        with op.batch_alter_table("runs") as batch:
+            batch.add_column(sa.Column("parent_run_id", sa.Text(), nullable=True))
+    if not _column_exists("runs", "split_decision_json"):
+        with op.batch_alter_table("runs") as batch:
+            batch.add_column(sa.Column("split_decision_json", sa.JSON(), nullable=True))
+    if not _index_exists("runs", "ix_runs_parent_run_id"):
+        op.create_index("ix_runs_parent_run_id", "runs", ["parent_run_id"])
+
+
+def downgrade() -> None:
+    if _index_exists("runs", "ix_runs_parent_run_id"):
+        op.drop_index("ix_runs_parent_run_id", "runs")
+    if _column_exists("runs", "split_decision_json"):
+        with op.batch_alter_table("runs") as batch:
+            batch.drop_column("split_decision_json")
+    if _column_exists("runs", "parent_run_id"):
+        with op.batch_alter_table("runs") as batch:
+            batch.drop_column("parent_run_id")
+    if _column_exists("runs", "run_kind"):
+        with op.batch_alter_table("runs") as batch:
+            batch.drop_column("run_kind")

--- a/dashboard/backend/app/models.py
+++ b/dashboard/backend/app/models.py
@@ -99,6 +99,14 @@ class Run(Base):
     # Updated on every webhook event for this run_id. NULL for legacy
     # rows. See issue #348.
     last_event_at = Column(DateTime(timezone=True), nullable=True, default=None, index=True)
+    # Issue-splitter (#391). ``run_kind`` distinguishes ``primary`` from
+    # ``sub-of-<N>`` and ``split-decision`` rows; ``parent_run_id`` links
+    # a sub-run back to the parent run that decomposed the issue;
+    # ``split_decision_json`` archives the splitter's proposal payload
+    # for replay/observability after GitHub history rotates.
+    run_kind = Column(Text, nullable=True)
+    parent_run_id = Column(Text, nullable=True, index=True)
+    split_decision_json = Column(JsonType, nullable=True)
 
 
 class ConfigEntry(Base):

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -601,8 +601,15 @@ async def get_run_tree(run_id: str, db: AsyncSession = Depends(get_db)) -> RunTr
     parent = (await db.execute(select(Run).where(Run.run_id == run_id))).scalar_one_or_none()
     if parent is None:
         raise HTTPException(status_code=404, detail=f"run {run_id} not found")
+    # Order sub-runs by start time for deterministic dashboard rendering;
+    # without this, Postgres returns rows in arbitrary order and the
+    # frontend would flicker as the result set is re-fetched.
     subs = (
-        await db.execute(select(Run).where(Run.parent_run_id == run_id))
+        await db.execute(
+            select(Run)
+            .where(Run.parent_run_id == run_id)
+            .order_by(Run.started_at.asc())
+        )
     ).scalars().all()
     return RunTree(
         run_id=parent.run_id,

--- a/dashboard/backend/app/routers/runs.py
+++ b/dashboard/backend/app/routers/runs.py
@@ -40,6 +40,8 @@ from app.schemas import (
     RunMessage,
     RunOut,
     RunTimelinePage,
+    RunTree,
+    RunTreeSubRun,
     TeamSummary,
     TeammateStatus,
     TelemetryActive,
@@ -584,6 +586,36 @@ async def get_run_timeline(
         until=until,
         limit=limit,
         cursor=decoded_cursor,
+    )
+
+
+@router.get("/{run_id}/tree", response_model=RunTree)
+async def get_run_tree(run_id: str, db: AsyncSession = Depends(get_db)) -> RunTree:
+    """Return the parent run plus its sub-runs (issue-splitter, #391).
+
+    404 if the parent ``run_id`` doesn't exist; otherwise the response
+    always includes the ``sub_runs`` list (empty for non-split runs).
+    Scans ``Run.parent_run_id`` (indexed via the 0004 migration), so the
+    query is a single B-tree lookup regardless of run-table size.
+    """
+    parent = (await db.execute(select(Run).where(Run.run_id == run_id))).scalar_one_or_none()
+    if parent is None:
+        raise HTTPException(status_code=404, detail=f"run {run_id} not found")
+    subs = (
+        await db.execute(select(Run).where(Run.parent_run_id == run_id))
+    ).scalars().all()
+    return RunTree(
+        run_id=parent.run_id,
+        run_kind=parent.run_kind,
+        sub_runs=[
+            RunTreeSubRun(
+                run_id=s.run_id,
+                run_kind=s.run_kind,
+                verdict=s.verdict,
+                status=s.status,
+            )
+            for s in subs
+        ],
     )
 
 

--- a/dashboard/backend/app/schemas.py
+++ b/dashboard/backend/app/schemas.py
@@ -1028,3 +1028,25 @@ class RunTimelinePage(BaseModel):
     events: list[RunTimelineEvent]
     next_cursor: str | None = None
     has_more: bool = False
+
+
+class RunTreeSubRun(BaseModel):
+    """One sub-run in the splitter tree view (#391)."""
+
+    run_id: str
+    run_kind: str | None = None
+    verdict: str | None = None
+    status: str | None = None
+
+
+class RunTree(BaseModel):
+    """Splitter tree shape: a parent run plus the sub-runs it spawned (#391).
+
+    The dashboard's tree view (PR-4) renders this directly. Sub-runs
+    are returned flat — the splitter currently produces a single layer
+    of children, and nesting beyond that is intentionally out of scope.
+    """
+
+    run_id: str
+    run_kind: str | None
+    sub_runs: list[RunTreeSubRun]

--- a/dashboard/backend/tests/test_coordinator_decide_split_hook.py
+++ b/dashboard/backend/tests/test_coordinator_decide_split_hook.py
@@ -58,3 +58,60 @@ async def test_decide_invokes_splitter_when_eligible(monkeypatch):
                                                   repo_summary="", vision="")
     splitter_mock.assert_called_once()
     assert result is decision
+
+
+@pytest.mark.asyncio
+async def test_decide_collapses_empty_proposals_to_none(monkeypatch):
+    """The splitter's empty-array output ("don't split") parses as a
+    SplitDecision with proposals=(). The hook MUST collapse that to
+    ``None`` so the caller has a single signal to branch on; without
+    this collapse, execute_split_decision would happily label the
+    parent ``split`` and create an empty integration branch.
+
+    Regression guard for PR #423 review.
+    """
+    monkeypatch.setenv("STATION_SPLIT_ENABLED", "1")
+    from agent.coordinator import decide
+    from agent.issue_splitter.schema import SplitDecision
+
+    empty_decision = SplitDecision(proposals=(), warnings=())
+    issue = {"number": 27, "title": "x",
+             "body": "## Acceptance criteria\n- [ ] a\n- [ ] b\n- [ ] c\n- [ ] d\n",
+             "labels": []}
+    with patch("agent.coordinator.decide.run_splitter",
+               new=AsyncMock(return_value=empty_decision)):
+        result = await decide.maybe_run_splitter(
+            issue, run_id="r1", repo_summary="", vision="",
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_decide_threads_cwd_to_run_splitter(monkeypatch):
+    """``cwd`` must reach the SDK runner so the splitter inspects the
+    project tree rather than the launcher's ``/app`` (the very fix PR-2
+    landed). Regression guard for PR #423 review.
+    """
+    monkeypatch.setenv("STATION_SPLIT_ENABLED", "1")
+    from agent.coordinator import decide
+    from agent.issue_splitter.schema import SplitDecision, SubIssueProposal
+
+    decision = SplitDecision(proposals=(
+        SubIssueProposal("a", "b", (), ("x",)),
+        SubIssueProposal("c", "d", (), ("y",)),
+    ))
+    issue = {
+        "number": 27, "title": "x",
+        "body": "## Acceptance criteria\n- [ ] a\n- [ ] b\n- [ ] c\n- [ ] d\n",
+        "labels": [],
+    }
+    with patch(
+        "agent.coordinator.decide.run_splitter",
+        new=AsyncMock(return_value=decision),
+    ) as splitter_mock:
+        await decide.maybe_run_splitter(
+            issue, run_id="r1", repo_summary="", vision="",
+            cwd="/workspaces/x-y",
+        )
+    splitter_mock.assert_called_once()
+    assert splitter_mock.call_args.kwargs["cwd"] == "/workspaces/x-y"

--- a/dashboard/backend/tests/test_coordinator_decide_split_hook.py
+++ b/dashboard/backend/tests/test_coordinator_decide_split_hook.py
@@ -1,0 +1,60 @@
+"""coordinator/decide split pre-dispatch hook (#391).
+
+The hook is feature-gated by ``STATION_SPLIT_ENABLED=1``. With the flag
+off the call is a no-op so PR-3 merges to ``dev`` without changing
+production behaviour. Once an operator opts in, the hook calls the
+``maybe_split`` heuristic; on a positive signal it dispatches the
+splitter LLM agent (mocked here) and returns the decision payload for
+the caller to act on.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_decide_falls_through_when_flag_disabled(monkeypatch):
+    monkeypatch.delenv("STATION_SPLIT_ENABLED", raising=False)
+    from agent.coordinator import decide
+    issue = {"number": 27, "title": "x", "body": "y", "labels": []}
+    with patch("agent.coordinator.decide.run_splitter", new=AsyncMock()) as splitter_mock:
+        ok = await decide.maybe_run_splitter(issue, run_id="r1",
+                                              repo_summary="", vision="")
+    assert ok is None
+    splitter_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_decide_skips_splitter_when_heuristic_says_no(monkeypatch):
+    monkeypatch.setenv("STATION_SPLIT_ENABLED", "1")
+    from agent.coordinator import decide
+    issue = {"number": 27, "title": "x", "body": "small", "labels": []}
+    with patch("agent.coordinator.decide.run_splitter", new=AsyncMock()) as splitter_mock:
+        ok = await decide.maybe_run_splitter(issue, run_id="r1",
+                                              repo_summary="", vision="")
+    assert ok is None
+    splitter_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_decide_invokes_splitter_when_eligible(monkeypatch):
+    monkeypatch.setenv("STATION_SPLIT_ENABLED", "1")
+    from agent.coordinator import decide
+    from agent.issue_splitter.schema import SplitDecision, SubIssueProposal
+    decision = SplitDecision(
+        proposals=(
+            SubIssueProposal("a", "b", (), ("x",)),
+            SubIssueProposal("c", "d", (), ("y",)),
+        ),
+    )
+    issue = {"number": 27, "title": "x",
+             "body": "## Acceptance criteria\n- [ ] a\n- [ ] b\n- [ ] c\n- [ ] d\n",
+             "labels": []}
+    with patch("agent.coordinator.decide.run_splitter",
+               new=AsyncMock(return_value=decision)) as splitter_mock:
+        result = await decide.maybe_run_splitter(issue, run_id="r1",
+                                                  repo_summary="", vision="")
+    splitter_mock.assert_called_once()
+    assert result is decision

--- a/dashboard/backend/tests/test_execute_split_decision.py
+++ b/dashboard/backend/tests/test_execute_split_decision.py
@@ -1,0 +1,70 @@
+"""execute_split_decision side effects (#391).
+
+Verifies the full splitter execution pipeline: create sub-issues, post
+the backlink comment on the parent, label the parent ``split`` so it
+won't be re-considered, and ensure the integration branch exists.
+
+The GitHub client is replaced with a ``MagicMock`` via the
+``_gh_client`` factory seam, and ``_ensure_integration_branch`` is
+patched separately because it's a top-level helper with its own
+network calls.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.coordinator.decide import execute_split_decision
+from agent.issue_splitter.schema import SplitDecision, SubIssueProposal
+
+
+@pytest.mark.asyncio
+async def test_execute_split_decision_creates_sub_issues_and_backlinks():
+    decision = SplitDecision(
+        proposals=(
+            SubIssueProposal("A", "body-a", (), ("x",)),
+            SubIssueProposal("B", "body-b", (), ("y",), depends_on=0),
+        ),
+    )
+    parent = {"number": 27, "title": "auth", "labels": ["backend"],
+              "repo": "kenhaesler/claude-agent-station"}
+
+    gh = MagicMock()
+    gh.label_exists.return_value = True
+    gh.create_issue.side_effect = [{"number": 101}, {"number": 102}]
+    with patch("agent.coordinator.decide._gh_client", return_value=gh), \
+         patch("agent.coordinator.decide._ensure_integration_branch") as iib:
+        await execute_split_decision(parent, decision, run_id="rsd-1")
+
+    assert gh.create_issue.call_count == 2
+    gh.create_issue_comment.assert_called_once()
+    iib.assert_called_once_with("kenhaesler/claude-agent-station", 27)
+    # parent labelled "split" so the dispatcher won't re-pick it
+    gh.add_labels.assert_called_once_with(
+        "kenhaesler", "claude-agent-station", 27, ["split"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_split_decision_tolerates_db_failure():
+    """The DB persistence write is best-effort — a failure (e.g. legacy
+    run row missing, brief unavailability) must NOT prevent the GitHub
+    side effects from being considered successful. The helper swallows
+    its own exceptions and logs at WARNING; this test guards against
+    a regression that would surface a raw exception to the caller.
+    """
+    decision = SplitDecision(
+        proposals=(SubIssueProposal("A", "b", (), ("x",)),),
+    )
+    parent = {"number": 27, "title": "x", "labels": [],
+              "repo": "kenhaesler/claude-agent-station"}
+    gh = MagicMock()
+    gh.label_exists.return_value = True
+    gh.create_issue.return_value = {"number": 101}
+    # No real DB is set up in this test; the helper hits an "async_session
+    # not configured" / "no such table" path and swallows it.
+    with patch("agent.coordinator.decide._gh_client", return_value=gh), \
+         patch("agent.coordinator.decide._ensure_integration_branch"):
+        await execute_split_decision(parent, decision, run_id="rsd-2")
+    gh.create_issue.assert_called_once()

--- a/dashboard/backend/tests/test_execute_split_decision.py
+++ b/dashboard/backend/tests/test_execute_split_decision.py
@@ -47,6 +47,30 @@ async def test_execute_split_decision_creates_sub_issues_and_backlinks():
 
 
 @pytest.mark.asyncio
+async def test_execute_split_decision_refuses_empty_proposals():
+    """``maybe_run_splitter`` collapses empty-array decisions to ``None``,
+    but a defensive guard at the execution layer makes the contract
+    explicit: an empty SplitDecision is a programming error, not a
+    valid input. Without this guard a caller bypassing
+    ``maybe_run_splitter`` could label the parent ``split`` and create
+    an empty integration branch on a non-split issue. Regression guard
+    for PR #423 review.
+    """
+    decision = SplitDecision(proposals=(), warnings=())
+    parent = {"number": 27, "title": "x", "labels": [],
+              "repo": "kenhaesler/claude-agent-station"}
+    gh = MagicMock()
+    with patch("agent.coordinator.decide._gh_client", return_value=gh), \
+         patch("agent.coordinator.decide._ensure_integration_branch"):
+        with pytest.raises(ValueError, match="empty proposals"):
+            await execute_split_decision(parent, decision, run_id="rsd-empty")
+    # No GitHub calls — refusal happens before the side effects.
+    gh.create_issue.assert_not_called()
+    gh.create_issue_comment.assert_not_called()
+    gh.add_labels.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_execute_split_decision_tolerates_db_failure():
     """The DB persistence write is best-effort — a failure (e.g. legacy
     run row missing, brief unavailability) must NOT prevent the GitHub

--- a/dashboard/backend/tests/test_gh_adapter.py
+++ b/dashboard/backend/tests/test_gh_adapter.py
@@ -1,0 +1,99 @@
+"""Unit tests for :class:`agent.issue_splitter.gh_adapter.GhAdapter` (#391).
+
+Subprocess is mocked at the ``gh_run`` / ``gh_json`` seam; no live
+``gh`` binary is required.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.gh_client import GhError, GhResult
+from agent.issue_splitter.gh_adapter import GhAdapter
+
+
+def _err(stderr: str, rc: int = 1) -> GhError:
+    return GhError(cmd=["gh", "api"], returncode=rc, stderr=stderr)
+
+
+def test_label_exists_returns_true_on_success():
+    with patch("agent.issue_splitter.gh_adapter.gh_json", return_value={"name": "split"}):
+        assert GhAdapter().label_exists("o", "r", "split") is True
+
+
+def test_label_exists_returns_false_on_404():
+    with patch("agent.issue_splitter.gh_adapter.gh_json",
+               side_effect=_err("HTTP 404: Not Found")):
+        assert GhAdapter().label_exists("o", "r", "split") is False
+
+
+def test_label_exists_reraises_other_errors():
+    with patch("agent.issue_splitter.gh_adapter.gh_json",
+               side_effect=_err("HTTP 500: server boom")):
+        with pytest.raises(GhError):
+            GhAdapter().label_exists("o", "r", "split")
+
+
+def test_create_issue_parses_number_from_url():
+    ok = GhResult(cmd=["gh"], returncode=0,
+                  stdout="https://github.com/o/r/issues/42\n", stderr="")
+    with patch("agent.issue_splitter.gh_adapter.gh_run", return_value=ok) as run:
+        out = GhAdapter().create_issue("o", "r", title="t", body="b",
+                                       labels=["a", "b"])
+    assert out == {"number": 42, "url": "https://github.com/o/r/issues/42"}
+    argv = run.call_args.args[0]
+    assert "--label" in argv
+    assert argv[argv.index("--label") + 1] == "a,b"
+
+
+def test_create_issue_raises_on_failure():
+    bad = GhResult(cmd=["gh"], returncode=1, stdout="", stderr="auth required")
+    with patch("agent.issue_splitter.gh_adapter.gh_run", return_value=bad):
+        with pytest.raises(GhError):
+            GhAdapter().create_issue("o", "r", title="t", body="b", labels=[])
+
+
+def test_add_labels_invokes_gh_issue_edit():
+    ok = GhResult(cmd=["gh"], returncode=0, stdout="", stderr="")
+    with patch("agent.issue_splitter.gh_adapter.gh_run", return_value=ok) as run:
+        GhAdapter().add_labels("o", "r", 27, ["split"])
+    argv = run.call_args.args[0]
+    assert argv[:3] == ["issue", "edit", "27"]
+    assert argv[argv.index("--repo") + 1] == "o/r"
+    assert argv[argv.index("--add-label") + 1] == "split"
+
+
+def test_add_labels_noop_when_empty():
+    with patch("agent.issue_splitter.gh_adapter.gh_run") as run:
+        GhAdapter().add_labels("o", "r", 27, [])
+    run.assert_not_called()
+
+
+def test_ensure_branch_skips_when_already_present():
+    with patch("agent.issue_splitter.gh_adapter.gh_json",
+               return_value={"object": {"sha": "deadbeef"}}) as gj, \
+         patch("agent.issue_splitter.gh_adapter.gh_run") as gr:
+        GhAdapter().ensure_branch("o/r", "integration/issue-27", from_branch="dev")
+    assert gj.call_count == 1  # only the existence check
+    gr.assert_not_called()
+
+
+def test_ensure_branch_creates_when_missing():
+    # First gh_json call (existence) raises 404; second (HEAD lookup)
+    # returns the dev SHA.
+    def gj_side_effect(args, **_kw):
+        if "integration/issue-27" in "/".join(args):
+            raise _err("HTTP 404: Not Found")
+        return {"object": {"sha": "feedface"}}
+
+    ok = GhResult(cmd=["gh"], returncode=0, stdout="", stderr="")
+    with patch("agent.issue_splitter.gh_adapter.gh_json",
+               side_effect=gj_side_effect), \
+         patch("agent.issue_splitter.gh_adapter.gh_run", return_value=ok) as gr:
+        GhAdapter().ensure_branch("o/r", "integration/issue-27", from_branch="dev")
+
+    argv = gr.call_args.args[0]
+    assert argv[:2] == ["api", "repos/o/r/git/refs"]
+    assert "ref=refs/heads/integration/issue-27" in argv
+    assert "sha=feedface" in argv

--- a/dashboard/backend/tests/test_issue_splitter_scheduler.py
+++ b/dashboard/backend/tests/test_issue_splitter_scheduler.py
@@ -1,0 +1,57 @@
+"""Scheduler dependency / failure semantics (#391).
+
+Eligibility rules under test:
+
+1. Independent sub-issues (no ``depends_on_number``) are eligible.
+2. A sub-issue with ``depends_on_number`` is eligible only after its
+   prerequisite is merged into the integration branch.
+3. A sibling that has failed (state != "open") does not block others —
+   the splitter pipeline accepts partial completion.
+4. Sub-issues still carrying the ``splitter-proposed`` label are
+   considered unapproved by the operator and held back.
+"""
+from __future__ import annotations
+
+from agent.issue_splitter.scheduler import pick_eligible_subruns
+
+
+def _sub(number: int, *, depends_on_number: int | None = None,
+         state: str = "open", merged: bool = False,
+         labels: list[str] | None = None) -> dict:
+    """Helper to build a sub-issue dict for the scheduler tests.
+
+    Default labels is ``[]`` (approved). Pass ``labels=["splitter-proposed"]``
+    to opt into the unapproved/pending-review case.
+    """
+    return {
+        "number": number,
+        "labels": labels if labels is not None else [],
+        "depends_on_number": depends_on_number,
+        "state": state,
+        "merged_into_integration": merged,
+    }
+
+
+def test_picks_all_independents_first():
+    subs = [_sub(101), _sub(102), _sub(103, depends_on_number=101)]
+    eligible = pick_eligible_subruns(subs)
+    numbers = {s["number"] for s in eligible}
+    assert numbers == {101, 102}
+
+
+def test_dependent_unlocks_after_prereq_merged():
+    subs = [_sub(101, merged=True), _sub(102, depends_on_number=101)]
+    eligible = pick_eligible_subruns(subs)
+    assert {s["number"] for s in eligible} == {102}
+
+
+def test_failed_sibling_does_not_block_others():
+    subs = [_sub(101, state="closed"), _sub(102)]
+    eligible = pick_eligible_subruns(subs)
+    assert {s["number"] for s in eligible} == {102}
+
+
+def test_unapproved_sub_not_picked():
+    subs = [_sub(101, labels=["splitter-proposed"])]
+    eligible = pick_eligible_subruns(subs)
+    assert eligible == []

--- a/dashboard/backend/tests/test_run_kind_parent.py
+++ b/dashboard/backend/tests/test_run_kind_parent.py
@@ -1,0 +1,75 @@
+"""Run.run_kind / parent_run_id / split_decision_json columns (#391).
+
+Why these columns matter for the splitter (#391):
+
+- ``run_kind`` distinguishes the three run shapes the splitter pipeline
+  produces: ``primary`` (a normal single-issue run), ``sub-of-<N>``
+  (a sub-run spawned from parent issue #N), and ``split-decision``
+  (the meta-run whose only output is the proposal set + integration
+  branch — no code change).
+- ``parent_run_id`` is the FK the tree-view endpoint scans by;
+  indexing is non-negotiable because the typical query is
+  ``WHERE parent_run_id = :id`` issued live from the dashboard.
+- ``split_decision_json`` archives the decision payload alongside the
+  run row so operators can replay the splitter's reasoning even after
+  GitHub history rotates.
+
+Uses the ``app.database.engine`` + ``Base.metadata.create_all`` pattern
+shared with the other model tests (e.g. ``test_audit_log.py``) rather
+than the session-scoped ``async_session_factory``; the session-scoped
+engine binds connections to its initial event loop and breaks when
+multiple tests target ``async_session_factory[postgres]`` in the same
+pytest run (pre-existing infrastructure limitation).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, inspect as sa_inspect
+
+from app.database import Base, async_session, engine
+from app.models import Run
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_run_kind_parent_columns(setup_db):
+    async with async_session() as db:
+        db.add(Run(run_id="run-parent-1", run_kind="primary",
+                   started_at=datetime.now(timezone.utc),
+                   split_decision_json={"proposals": 4}))
+        db.add(Run(run_id="run-sub-a", run_kind="sub-of-27",
+                   parent_run_id="run-parent-1",
+                   started_at=datetime.now(timezone.utc)))
+        await db.commit()
+
+    async with async_session() as db:
+        sub = (await db.execute(select(Run).where(Run.run_id == "run-sub-a"))).scalar_one()
+        assert sub.run_kind == "sub-of-27"
+        assert sub.parent_run_id == "run-parent-1"
+        parent = (await db.execute(select(Run).where(Run.run_id == "run-parent-1"))).scalar_one()
+        assert parent.split_decision_json == {"proposals": 4}
+
+
+@pytest.mark.asyncio
+async def test_parent_run_id_indexed(setup_db):
+    """The tree-view endpoint scans by ``parent_run_id`` — without an
+    index that becomes a full table scan on every dashboard render.
+    """
+    def _check(sync_conn):
+        insp = sa_inspect(sync_conn)
+        idx_columns = {tuple(ix["column_names"]) for ix in insp.get_indexes("runs")}
+        assert ("parent_run_id",) in idx_columns
+
+    async with engine.begin() as conn:
+        await conn.run_sync(_check)

--- a/dashboard/backend/tests/test_runs_tree.py
+++ b/dashboard/backend/tests/test_runs_tree.py
@@ -1,0 +1,83 @@
+"""GET /api/runs/{run_id}/tree (#391).
+
+The endpoint returns the parent run's identity plus a flat list of its
+sub-runs, scanned via ``Run.parent_run_id``. The dashboard's tree view
+(landed in PR-4) renders this payload directly.
+
+Uses the ``app.database.engine`` + ``Base.metadata.create_all`` pattern
+shared by the other router tests (see ``test_audit_log.py``); the
+parametrized ``async_session_factory`` fixture targets the alembic-
+migrated test DBs which the in-process app engine doesn't share.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import Base, async_session, engine
+from app.main import app
+from app.models import Run
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_tree_endpoint_returns_parent_and_subs(client):
+    async with async_session() as db:
+        db.add(Run(run_id="run-pt-1", run_kind="primary",
+                   started_at=datetime.now(timezone.utc)))
+        db.add(Run(run_id="run-pt-1-a", run_kind="sub-of-27",
+                   parent_run_id="run-pt-1",
+                   started_at=datetime.now(timezone.utc),
+                   verdict="APPROVE"))
+        db.add(Run(run_id="run-pt-1-b", run_kind="sub-of-27",
+                   parent_run_id="run-pt-1",
+                   started_at=datetime.now(timezone.utc),
+                   verdict="PR"))
+        await db.commit()
+
+    resp = await client.get("/api/runs/run-pt-1/tree")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run_id"] == "run-pt-1"
+    assert body["run_kind"] == "primary"
+    sub_ids = {s["run_id"] for s in body["sub_runs"]}
+    assert sub_ids == {"run-pt-1-a", "run-pt-1-b"}
+
+
+@pytest.mark.asyncio
+async def test_tree_endpoint_404_for_unknown(client):
+    resp = await client.get("/api/runs/run-does-not-exist/tree")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_tree_endpoint_returns_empty_subs_for_non_split_run(client):
+    """A regular non-split run still has a tree response, just empty."""
+    async with async_session() as db:
+        db.add(Run(run_id="run-solo", run_kind=None,
+                   started_at=datetime.now(timezone.utc)))
+        await db.commit()
+
+    resp = await client.get("/api/runs/run-solo/tree")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sub_runs"] == []
+    assert body["run_kind"] is None


### PR DESCRIPTION
Third of four PRs for #391 (decompose long runs). Builds on PR-1 (#421 schema/heuristics/role) and PR-2 (#422 github ops/SDK runner), both merged.

## Summary
- **DB (Task 8)**: \`Run.run_kind\` (Text, nullable), \`Run.parent_run_id\` (Text, indexed nullable), \`Run.split_decision_json\` (JsonType). Migration \`0004_run_kind_parent\` with idempotent guards matching the existing \`0003_runner_quotas\` style.
- **Scheduler (Task 9)**: \`agent/issue_splitter/scheduler.py\` exposes \`pick_eligible_subruns(subs)\` — open + \`splitter-proposed\` removed + prereq merged.
- **Pre-dispatch hook (Task 10)**: new \`agent/coordinator/decide.py\` (the old module was removed in the Agent Teams overhaul; rebuilt from scratch). \`maybe_run_splitter\` is feature-flagged on \`STATION_SPLIT_ENABLED=1\` — off by default, no production behaviour change.
- **\`execute_split_decision\` (Task 11)**: creates sub-issues, posts backlink comment, labels parent \`split\`, ensures \`integration/issue-<N>\` exists, archives the decision on the run row. DB write is best-effort.
- **\`GhAdapter\` (Task 11)**: new concrete adapter at \`agent/issue_splitter/gh_adapter.py\` satisfying PR-2's \`_GhClient\` Protocol + the extra methods PR-3 needs (\`add_labels\`, \`ensure_branch\`). Wraps the existing \`gh_run\` / \`gh_json\` module-level helpers — no class-style \`GhClient\` upstream to extend. Tested with \`gh\` subprocess fully mocked.
- **Tree API (Task 12)**: \`GET /api/runs/{run_id}/tree\` returns parent + sub-runs. New \`RunTree\` + \`RunTreeSubRun\` schemas.

## Test plan
- [x] **Full backend suite: 1399 passed, 1 skipped** (was 1376 on PR-2 merge; +23 new tests across the five tasks).
- [x] Migration safe whether DB was created via baseline + create_all or upgraded from older schema (idempotent \`_column_exists\` / \`_index_exists\` guards).
- [x] No real \`gh\` invocation in tests; \`gh_run\` / \`gh_json\` mocked at the subprocess seam.
- [x] No real SDK invocation; \`_invoke_splitter_sdk\` mocked wholesale (real SDK exercised by PR-4 integration test).

## Plan-vs-reality reconciliations
1. **\`agent/coordinator/decide.py\`** did not exist on \`dev\` (Agent Teams overhaul). Created from scratch with just \`maybe_run_splitter\` + \`execute_split_decision\` + the test seams.
2. **\`GhClient\`** class did not exist; only module-level \`gh_run\` / \`gh_json\`. Built \`GhAdapter\` at \`agent/issue_splitter/gh_adapter.py\` as a class-style wrapper — the natural seam for the Protocol-mocked tests.
3. **Migration head was \`0003_runner_quotas\`** not \`0002\` as the plan assumed. New migration is \`0004_run_kind_parent\`.

## Scope (NOT in this PR)
- Orchestrator call site → PR-4. \`station_orchestrator.py\` needs one line to invoke \`maybe_run_splitter\` before the team dispatch.
- Frontend tree view → PR-4.
- Integration test (synthetic split flow) → PR-4.
- Operator docs for \`STATION_SPLIT_ENABLED\` + splitter labels → PR-4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)