### PR TITLE
fix: trigger 500 + queue/plan_usage Postgres errors after stack rebuild

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -217,7 +217,15 @@ networks:
   # this network so they can reach the dashboard at http://dashboard:8420
   # for webhook callbacks. ``default`` is kept so existing inter-service
   # DNS (db, dashboard, agent) keeps working unchanged. See #386.
+  #
+  # ``name: agent-net`` overrides compose's default project-prefixing
+  # (would otherwise create ``claude-agent-station_agent-net``). The
+  # runner spawn code in ``agent/runner_spawn.py`` joins by the bare
+  # name, so the two must match. Discovered when the post-#386 stack
+  # rebuild produced ``failed to set up container networking: network
+  # agent-net not found`` on every triggered run.
   agent-net:
+    name: agent-net
     driver: bridge
   default:
 

--- a/dashboard/backend/app/routers/plan_usage.py
+++ b/dashboard/backend/app/routers/plan_usage.py
@@ -126,7 +126,7 @@ async def get_plan_usage(
             func.coalesce(func.sum(Run.tokens_input), 0).label("input_tokens"),
             func.coalesce(func.sum(Run.tokens_output), 0).label("output_tokens"),
         ).where(
-            Run.started_at >= week_start.isoformat(),
+            Run.started_at >= week_start,
             Run.status.isnot(None),
         )
     )
@@ -141,7 +141,7 @@ async def get_plan_usage(
             func.coalesce(func.sum(Run.tokens_input), 0).label("input_tokens"),
             func.coalesce(func.sum(Run.tokens_output), 0).label("output_tokens"),
         ).where(
-            Run.started_at >= week_start.isoformat(),
+            Run.started_at >= week_start,
             Run.model.isnot(None),
             Run.status.isnot(None),
         ).group_by(Run.model)
@@ -167,7 +167,7 @@ async def get_plan_usage(
         select(
             func.coalesce(func.sum(Run.tokens_input), 0).label("input_tokens"),
             func.coalesce(func.sum(Run.tokens_output), 0).label("output_tokens"),
-        ).where(Run.started_at >= session_cutoff.isoformat())
+        ).where(Run.started_at >= session_cutoff)
     )
     session_row = session_result.one()
     session_tokens = session_row.input_tokens + session_row.output_tokens
@@ -245,7 +245,7 @@ async def record_usage_snapshot(
             func.coalesce(func.sum(Run.tokens_input), 0).label("input_tokens"),
             func.coalesce(func.sum(Run.tokens_output), 0).label("output_tokens"),
         ).where(
-            Run.started_at >= week_start.isoformat(),
+            Run.started_at >= week_start,
             Run.status.isnot(None),
         )
     )
@@ -260,7 +260,7 @@ async def record_usage_snapshot(
             func.coalesce(func.sum(Run.tokens_input), 0).label("input_tokens"),
             func.coalesce(func.sum(Run.tokens_output), 0).label("output_tokens"),
         ).where(
-            Run.started_at >= week_start.isoformat(),
+            Run.started_at >= week_start,
             Run.model.isnot(None),
             Run.status.isnot(None),
         ).group_by(Run.model)

--- a/dashboard/backend/app/routers/queue.py
+++ b/dashboard/backend/app/routers/queue.py
@@ -120,11 +120,16 @@ async def queue_pressure(db: AsyncSession = Depends(get_db)):
     # Use weekly token consumption as the primary backpressure signal
     now = datetime.now(timezone.utc)
     week_start = now - timedelta(days=7)
+    # Pass the datetime directly. ``.isoformat()`` would bind the value as
+    # VARCHAR, which Postgres refuses to compare against ``timestamp with
+    # time zone`` (``operator does not exist: timestamp with time zone >=
+    # character varying``). SQLite silently coerces, so this bug only
+    # surfaced after the #393 Postgres migration.
     weekly_result = await db.execute(
         select(
             func.coalesce(func.sum(Run.tokens_input), 0).label("input_tokens"),
             func.coalesce(func.sum(Run.tokens_output), 0).label("output_tokens"),
-        ).where(Run.started_at >= week_start.isoformat())
+        ).where(Run.started_at >= week_start)
     )
     weekly_row = weekly_result.one()
     weekly_tokens = weekly_row.input_tokens + weekly_row.output_tokens

--- a/dashboard/backend/tests/test_compose_runner.py
+++ b/dashboard/backend/tests/test_compose_runner.py
@@ -22,6 +22,24 @@ def test_agent_net_network_declared():
     assert "agent-net" in c.get("networks", {})
 
 
+def test_agent_net_has_explicit_name_to_avoid_project_prefix():
+    """Compose prefixes network names with the project slug by default
+    (``claude-agent-station_agent-net``), but ``agent/runner_spawn.py``
+    joins runner containers by the bare name ``agent-net``. The two
+    must match or every triggered run fails with ``failed to set up
+    container networking: network agent-net not found``. Pin the
+    ``name: agent-net`` override.
+    """
+    c = _compose()
+    agent_net = c["networks"]["agent-net"]
+    assert isinstance(agent_net, dict), "agent-net must be a mapping, not the implicit form"
+    assert agent_net.get("name") == "agent-net", (
+        "compose.yml must set `name: agent-net` on the agent-net network so "
+        "compose doesn't prepend the project prefix; runner_spawn.py joins by "
+        "the bare name"
+    )
+
+
 def test_agent_runner_mode_env_present():
     c = _compose()
     env = c["services"]["agent"]["environment"]

--- a/dashboard/backend/tests/test_started_at_typing.py
+++ b/dashboard/backend/tests/test_started_at_typing.py
@@ -1,0 +1,110 @@
+"""Regression guard: ``Run.started_at`` comparisons must bind a ``datetime``.
+
+Binding an ISO-formatted string (``.isoformat()``) works on SQLite via silent
+type coercion, but Postgres refuses with::
+
+    operator does not exist: timestamp with time zone >= character varying
+
+This was the root cause of the post-#393 Postgres-migration regression that
+broke ``/api/queue/pressure`` and the ``/api/plan_usage/*`` endpoints — the
+SQLite test path didn't catch it because SQLite is lenient.
+
+Two layers of defence:
+
+1. **Static check**: grep the routers for ``started_at >=`` and assert the
+   right-hand side is not an ``.isoformat()`` call. Cheap, no DB needed.
+2. **Parametrized runtime check**: execute the same aggregation pattern
+   against both ``[sqlite, postgres]`` via ``async_session_factory`` and
+   confirm it doesn't raise.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select
+
+from app.database import Base, async_session, engine
+
+ROUTERS_DIR = Path(__file__).resolve().parent.parent / "app" / "routers"
+
+# Match ``Run.started_at >= <expr>`` or ``Run.started_at > <expr>`` where the
+# right-hand side is an ``.isoformat()`` call. Multiline-aware so the
+# ``.where(\n    Run.started_at >= week_start.isoformat()`` shape is caught.
+_BAD_PATTERN = re.compile(
+    r"Run\.started_at\s*>=?\s*[A-Za-z_][A-Za-z0-9_]*\.isoformat\(\)",
+    re.MULTILINE,
+)
+
+
+def test_no_isoformat_in_started_at_comparisons():
+    """Every router file: zero ``Run.started_at >= x.isoformat()`` occurrences."""
+    offenders: list[str] = []
+    for py_file in sorted(ROUTERS_DIR.glob("*.py")):
+        text = py_file.read_text()
+        for match in _BAD_PATTERN.finditer(text):
+            line_no = text[: match.start()].count("\n") + 1
+            offenders.append(f"{py_file.name}:{line_no} — {match.group(0)}")
+    assert offenders == [], (
+        "Found Run.started_at compared against .isoformat() string — Postgres "
+        "rejects this. Pass the datetime directly:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    """Per-function schema setup against the in-process engine.
+
+    Avoids the session-scoped ``async_session_factory[postgres]`` event-
+    loop binding flake (PR-3 ``test_runs_tree.py`` docstring documents
+    the same workaround). Bound to whatever ``STATION_DB_URL`` configures
+    — sqlite locally, Postgres in CI.
+    """
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest.mark.asyncio
+async def test_started_at_aggregation_against_configured_dialect(
+    setup_db,
+) -> None:
+    """The exact aggregation pattern from ``queue.py``/``plan_usage.py`` must
+    work against whichever dialect the test DB is configured with. On
+    Postgres (the production target post-#393) it would have failed
+    before this PR with ``UndefinedFunctionError``; the regression guard
+    here ensures the fix isn't reverted.
+    """
+    from app.models import Run
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=7)
+
+    async with async_session() as db:
+        db.add(Run(
+            run_id="run-typing-1",
+            status="completed",
+            started_at=now,
+            tokens_input=100,
+            tokens_output=200,
+        ))
+        await db.commit()
+
+    async with async_session() as db:
+        result = await db.execute(
+            select(
+                func.coalesce(func.sum(Run.tokens_input), 0).label("input_tokens"),
+                func.coalesce(func.sum(Run.tokens_output), 0).label("output_tokens"),
+            ).where(Run.started_at >= cutoff)
+        )
+        row = result.one()
+        # The bug would surface as a raised ProgrammingError before this
+        # assertion; we just assert the inserted row's tokens contribute.
+        assert row.input_tokens >= 100
+        assert row.output_tokens >= 200


### PR DESCRIPTION
Two bugs exposed when the dashboard + agent containers were rebuilt against the post-#386/#393/#391 \`dev\` tree.

## Bug 1 — Trigger 500: network name mismatch
\`compose.yml\` declared the \`agent-net\` bridge with compose's implicit naming, which prepends the project slug (\`claude-agent-station_agent-net\`). \`agent/runner_spawn.py\` joins runner containers by the bare name \`agent-net\`, so every triggered run failed with:

\`\`\`
docker.errors.NotFound: failed to set up container networking:
network agent-net not found
\`\`\`

**Fix**: add \`name: agent-net\` to override the prefix. The compose-shape test in \`test_compose_runner.py\` was passing because it only checked the YAML key existed — false-positive coverage. Added \`test_agent_net_has_explicit_name_to_avoid_project_prefix\` that asserts the explicit \`name:\` override.

## Bug 2 — \`/api/queue/pressure\` + \`/api/plan_usage/*\` 500: timestamp vs varchar
Six call sites in \`routers/queue.py\` (1) + \`routers/plan_usage.py\` (5) filtered \`Run.started_at\` against an ISO-formatted string (\`week_start.isoformat()\`). SQLite silently coerces; Postgres refuses:

\`\`\`
operator does not exist: timestamp with time zone >= character varying
HINT: No operator matches the given name and argument types.
\`\`\`

**Fix**: pass the \`datetime\` directly. Two-layer regression guard in new \`test_started_at_typing.py\`:
- **Static check**: grep \`app/routers/\` for \`Run.started_at >= x.isoformat()\` — fast, no DB needed, catches the bug class even in dead code paths.
- **Runtime check**: per-function engine fixture runs the same aggregation pattern against whichever dialect the test DB is configured for (sqlite locally, Postgres in CI).

## Why these slipped past existing tests
- The compose-shape test only inspected the static YAML, not compose's runtime network-naming behaviour.
- The timestamp bug is a SQLite-vs-Postgres divergence; \`test_queue.py\` and \`test_plan_usage.py\` both use SQLite-only fixtures, so the silent string coercion masked it. The #393 Postgres migration was the proximate trigger.

## Test plan
- [x] **Full backend suite: 1417 passed, 1 skipped** (was 1414 on \`dev\`; +3 regression tests: 1 compose-shape + 1 static-grep + 1 runtime-aggregation).
- [x] Static grep finds zero remaining offenders in \`app/routers/\`.
- [ ] Manual smoke after rebuild: dashboard loads without 500s on \`/api/queue/pressure\`; triggering a run produces a \`cas-runner-<id>\` container that joins \`agent-net\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)