### PR TITLE
fix(runner): #386 spawn integration — volume prefixes, env whitelist, bind mounts

### DIFF
--- a/agent/launcher.py
+++ b/agent/launcher.py
@@ -140,14 +140,24 @@ def _get_docker_client():
     return _docker_client
 
 
-# STATION_* env vars that are safe to copy into the runner container. This
-# whitelist intentionally EXCLUDES the dashboard's authentication secrets
-# (STATION_API_KEY, STATION_WEBHOOK_SECRET, STATION_LAUNCHER_TOKEN,
-# STATION_GITHUB_WEBHOOK_SECRET): the runner authenticates back to the
-# dashboard via the launcher token already mounted at the agent layer, and
-# leaking the inbound webhook/API secrets into every runner expands the
-# blast radius for no benefit. Add to this list only when the runner
-# genuinely needs a variable; default-deny is the safe default.
+# STATION_* env vars copied into the runner container.
+#
+# Earlier iterations of this whitelist (PR #419 review) excluded the
+# webhook/API secrets to "prevent leaking secrets into runners". That
+# reasoning was wrong: the runner IS the orchestrator process — it has
+# to authenticate back to the dashboard, and its trust level is identical
+# to the launcher's. Excluding the secrets just produced 401 on every
+# webhook the runner emitted and the orchestrator aborted before doing
+# anything useful. See post-#386 PR-3 end-to-end repro.
+#
+# What we still NEVER copy:
+#   - ``STATION_LAUNCHER_TOKEN`` — that token authenticates the
+#     dashboard → launcher hop; the runner has no reason to call its own
+#     launcher endpoint, so propagating it would expand the blast
+#     radius of a runner compromise without enabling any feature.
+#   - Anything outside the ``STATION_*`` namespace, with the documented
+#     exception of ``IS_SANDBOX`` (Claude CLI requires it under root —
+#     see compose.yml's agent service for the rationale).
 _RUNNER_ENV_WHITELIST: frozenset[str] = frozenset({
     "STATION_DB_URL",
     "STATION_DB_PASSWORD_FILE",
@@ -158,6 +168,14 @@ _RUNNER_ENV_WHITELIST: frozenset[str] = frozenset({
     "STATION_DASHBOARD_BASE_URL",
     "STATION_WEBHOOK_URL",
     "STATION_DEPLOY_MODE",
+    # Runner → dashboard auth — without these the orchestrator's webhooks
+    # and /api/* calls 401 and the run aborts in preflight.
+    "STATION_WEBHOOK_SECRET",
+    "STATION_API_KEY",
+    "STATION_GITHUB_WEBHOOK_SECRET",
+    # Not STATION_-prefixed but required: Claude CLI refuses
+    # ``--dangerously-skip-permissions`` under root unless this is set.
+    "IS_SANDBOX",
 })
 
 
@@ -220,18 +238,109 @@ async def _resolve_quotas(project_repo: str | None) -> dict:
 
 
 def _env_passthrough() -> dict:
-    """STATION_* env vars to inject into the runner.
+    """Build the env dict for the spawned runner.
 
-    Default-deny: only the explicitly whitelisted keys from
-    ``_RUNNER_ENV_WHITELIST`` are forwarded. Dashboard secrets
-    (API key, webhook secrets, launcher token) MUST NOT reach
-    runner subprocesses.
+    Default-deny across the ``STATION_*`` namespace via
+    :data:`_RUNNER_ENV_WHITELIST`. See that constant's docstring for the
+    threat-model reasoning and the list of keys we deliberately exclude.
     """
     return {
         key: value
         for key, value in os.environ.items()
         if key in _RUNNER_ENV_WHITELIST
     }
+
+
+# Destinations on the launcher's container that runners MUST also see.
+# These hold credentials (Claude OAuth, gh auth) and the db_password
+# secret — operator-level state shared across all runs on the host.
+# Without them the runner can't authenticate the Claude CLI, can't run
+# ``gh`` commands, and can't open a DB connection. The launcher inspects
+# its own container at startup, finds these destinations, and propagates
+# the underlying host source paths into each spawned runner.
+_INHERITED_MOUNT_DESTINATIONS: frozenset[str] = frozenset({
+    "/root/.claude",
+    "/root/.config/gh",
+    "/run/secrets/db_password",
+})
+
+_inherited_mounts: list[dict] | None = None
+
+
+def _read_own_container_id() -> str | None:
+    """Best-effort: return the launcher's own container ID.
+
+    ``/etc/hostname`` is the canonical short ID inside a Docker container.
+    Falls back to ``None`` outside Docker (unit tests, bare-metal systemd
+    deploys) — callers degrade gracefully when no inherited mounts are
+    available.
+    """
+    try:
+        with open("/etc/hostname", encoding="utf-8") as fh:
+            return fh.read().strip() or None
+    except OSError:
+        return None
+
+
+def _get_inherited_mounts() -> list[dict]:
+    """Inspect the launcher's own container and return the mounts each
+    runner inherits.
+
+    Cached in module state so we hit the Docker socket once per uvicorn
+    worker, not once per ``/run`` call. Returns ``[]`` outside Docker
+    (no container ID, no daemon) so unit tests don't have to mock this
+    out — the orchestrator just won't see those mounts.
+
+    The returned dicts match the Docker SDK's ``volumes={}`` kwarg shape
+    so :func:`agent.runner_spawn.spawn_runner` can merge them with the
+    named-volume mounts it already provides.
+    """
+    global _inherited_mounts
+    if _inherited_mounts is not None:
+        return _inherited_mounts
+
+    cid = _read_own_container_id()
+    if cid is None:
+        _inherited_mounts = []
+        return _inherited_mounts
+
+    try:
+        own = _get_docker_client().containers.get(cid)
+    except Exception as exc:
+        # Most commonly: cid doesn't match a container the daemon
+        # acknowledges (cgroup-only container, mismatched namespaces).
+        logger.warning("launcher: could not inspect own container %s: %s", cid, exc)
+        _inherited_mounts = []
+        return _inherited_mounts
+
+    mounts: list[dict] = []
+    for mount in own.attrs.get("Mounts", []):
+        if mount.get("Destination") not in _INHERITED_MOUNT_DESTINATIONS:
+            continue
+        # Docker SDK accepts ``volumes={host_or_volname: {"bind": dst, "mode": "..."}}``;
+        # source for a bind mount is the host path, for a named volume
+        # it's the volume name. We treat both the same — the daemon
+        # resolves to the same backing storage either way.
+        mode = "ro" if not mount.get("RW", True) else "rw"
+        mounts.append({
+            "source": mount["Source"],
+            "destination": mount["Destination"],
+            "mode": mode,
+        })
+
+    _inherited_mounts = mounts
+    if mounts:
+        logger.info(
+            "launcher: spawned runners will inherit %d mount(s): %s",
+            len(mounts), [m["destination"] for m in mounts],
+        )
+    else:
+        logger.warning(
+            "launcher: no inherited mounts found on container %s — runners "
+            "will lack Claude/gh credentials and may fail at first CLI call",
+            cid,
+        )
+    return mounts
 
 
 async def _spawn_runner_container(hint_run_id: str, project_repo: str | None) -> dict:
@@ -253,6 +362,7 @@ async def _spawn_runner_container(hint_run_id: str, project_repo: str | None) ->
         image=settings.runner_image,
         config_path=os.environ.get("STATION_CONFIG", "/var/lib/claude-agent-station/manager-config.json"),
         workspaces_dir=os.environ.get("STATION_WORKSPACES", "/var/lib/claude-agent-station/workspaces"),
+        inherited_mounts=_get_inherited_mounts(),
     )
     _runners[hint_run_id] = handle
     return {"status": "triggered", "container": handle.container_name, "run_id": handle.run_id}

--- a/agent/runner_spawn.py
+++ b/agent/runner_spawn.py
@@ -37,6 +37,7 @@ def spawn_runner(
     image: str,
     config_path: str,
     workspaces_dir: str,
+    inherited_mounts: list[dict] | None = None,
 ) -> RunnerHandle:
     """Spawn a detached, auto-removed runner container.
 
@@ -44,12 +45,39 @@ def spawn_runner(
     ``quotas`` is ``{"memory": "2g", "cpus": "1.0"}`` — strings come from the
     Project row's columns; defaults are resolved upstream.
     ``env_passthrough`` carries every STATION_* the orchestrator needs.
+
+    ``inherited_mounts`` carries the operator-level bind mounts the
+    runner needs to inherit from the launcher's container — Claude OAuth
+    creds at ``/root/.claude``, ``gh`` auth at ``/root/.config/gh``, the
+    Postgres password secret at ``/run/secrets/db_password``. The
+    launcher resolves these by inspecting its own container; tests pass
+    ``[]`` (or just omit the kwarg) since the unit tests don't have a
+    real Docker daemon to inspect.
     """
     name = _container_name(hint_run_id)
     env = dict(env_passthrough)
     env["STATION_RUN_ID"] = hint_run_id
     if project_repo is not None:
         env["STATION_PROJECT_REPO"] = project_repo
+
+    # Named volumes that hold workspace + log state shared across all
+    # runs. Both must be explicitly named in compose.yml (``name:`` key)
+    # so compose doesn't project-prefix them, or these mounts will
+    # silently land on freshly-created EMPTY volumes — see compose.yml
+    # for the relevant override.
+    volumes: dict[str, dict] = {
+        "station-data": {"bind": "/var/lib/claude-agent-station", "mode": "rw"},
+        "station-logs": {"bind": "/var/log/claude-agent", "mode": "rw"},
+    }
+    # Layer the inherited bind mounts on top. We intentionally re-bind
+    # whatever destination the launcher had — same host path, same mode
+    # — because the runner needs an identical view of the Claude/gh
+    # credential dirs to authenticate.
+    for mount in inherited_mounts or ():
+        volumes[mount["source"]] = {
+            "bind": mount["destination"],
+            "mode": mount.get("mode", "rw"),
+        }
 
     container = client.containers.run(
         image=image,
@@ -61,16 +89,7 @@ def spawn_runner(
         mem_limit=quotas["memory"],
         nano_cpus=_cpus_to_nano(quotas["cpus"]),
         environment=env,
-        volumes={
-            "station-data": {
-                "bind": "/var/lib/claude-agent-station",
-                "mode": "rw",
-            },
-            "station-logs": {
-                "bind": "/var/log/claude-agent",
-                "mode": "rw",
-            },
-        },
+        volumes=volumes,
         command=[
             "python", "-m", "agent.station_orchestrator",
             "--driver",

--- a/compose.yml
+++ b/compose.yml
@@ -230,8 +230,18 @@ networks:
   default:
 
 volumes:
+  # ``name:`` overrides compose's default project-prefixing
+  # (``claude-agent-station_station-data``). ``agent/runner_spawn.py``
+  # mounts these volumes by their bare name when it spawns runner
+  # containers; without the override Docker silently creates EMPTY
+  # volumes named ``station-data`` / ``station-logs`` and the runner
+  # sees a blank ``/var/lib/claude-agent-station/`` with no
+  # ``manager-config.json`` — orchestrator aborts in preflight.
+  # Same fix pattern as the ``agent-net`` network above. See #386.
   station-data:
+    name: station-data
   station-logs:
+    name: station-logs
   station-pgdata:
 
 secrets:

--- a/dashboard/backend/tests/test_compose_runner.py
+++ b/dashboard/backend/tests/test_compose_runner.py
@@ -40,6 +40,26 @@ def test_agent_net_has_explicit_name_to_avoid_project_prefix():
     )
 
 
+def test_station_volumes_have_explicit_name_to_avoid_project_prefix():
+    """Same project-prefix gotcha as ``agent-net``: ``runner_spawn.py``
+    mounts ``station-data`` / ``station-logs`` by bare name, but compose
+    defaults to ``claude-agent-station_station-data``. Without the
+    ``name:`` override the runner gets EMPTY auto-created volumes and
+    aborts in preflight ("manager-config.json: No such file"). See
+    follow-up to #386.
+    """
+    c = _compose()
+    for vol_name in ("station-data", "station-logs"):
+        vol = c["volumes"][vol_name]
+        assert isinstance(vol, dict), (
+            f"{vol_name} must be a mapping with an explicit ``name:`` override"
+        )
+        assert vol.get("name") == vol_name, (
+            f"compose.yml must set ``name: {vol_name}`` so the bare name "
+            f"matches what runner_spawn.py mounts"
+        )
+
+
 def test_agent_runner_mode_env_present():
     c = _compose()
     env = c["services"]["agent"]["environment"]

--- a/dashboard/backend/tests/test_launcher_spawn.py
+++ b/dashboard/backend/tests/test_launcher_spawn.py
@@ -60,6 +60,72 @@ def test_spawn_runner_passes_expected_args(monkeypatch):
     assert handle.project_repo == "x/y"
 
 
+def test_spawn_runner_layers_inherited_mounts():
+    """Inherited mounts (Claude creds, gh auth, db_password) are added
+    on top of the named-volume mounts. Without them the runner can't
+    authenticate the Claude CLI or open a DB connection.
+    """
+    from agent.runner_spawn import spawn_runner
+
+    fake_client = MagicMock()
+    fake_container = MagicMock()
+    fake_container.name = "cas-runner-mnt"
+    fake_client.containers.run.return_value = fake_container
+
+    inherited = [
+        {"source": "/home/op/.claude", "destination": "/root/.claude", "mode": "rw"},
+        {"source": "/home/op/.config/gh", "destination": "/root/.config/gh", "mode": "ro"},
+        {"source": "/host/secrets/db_password",
+         "destination": "/run/secrets/db_password", "mode": "ro"},
+    ]
+    spawn_runner(
+        fake_client,
+        hint_run_id="run-mnt",
+        project_repo=None,
+        quotas=_quotas(),
+        env_passthrough={},
+        image="claude-agent-station/agent:dev",
+        config_path="/cfg.json",
+        workspaces_dir="/ws",
+        inherited_mounts=inherited,
+    )
+    volumes = fake_client.containers.run.call_args.kwargs["volumes"]
+    # Named volumes still present.
+    assert volumes["station-data"]["bind"] == "/var/lib/claude-agent-station"
+    assert volumes["station-logs"]["bind"] == "/var/log/claude-agent"
+    # Inherited binds added.
+    assert volumes["/home/op/.claude"]["bind"] == "/root/.claude"
+    assert volumes["/home/op/.claude"]["mode"] == "rw"
+    assert volumes["/home/op/.config/gh"]["mode"] == "ro"
+    assert volumes["/host/secrets/db_password"]["bind"] == "/run/secrets/db_password"
+
+
+def test_spawn_runner_accepts_none_inherited_mounts():
+    """``inherited_mounts=None`` (the default) is treated as 'no extras'.
+
+    The launcher passes ``[]`` when running outside Docker — runner_spawn
+    must accept both ``None`` and ``[]`` without raising.
+    """
+    from agent.runner_spawn import spawn_runner
+
+    fake_client = MagicMock()
+    fake_client.containers.run.return_value.name = "cas-runner-none"
+    spawn_runner(
+        fake_client,
+        hint_run_id="run-none",
+        project_repo=None,
+        quotas=_quotas(),
+        env_passthrough={},
+        image="x:latest",
+        config_path="/c",
+        workspaces_dir="/w",
+        inherited_mounts=None,
+    )
+    volumes = fake_client.containers.run.call_args.kwargs["volumes"]
+    # Only the named-volume mounts.
+    assert set(volumes.keys()) == {"station-data", "station-logs"}
+
+
 from unittest.mock import patch
 
 
@@ -103,29 +169,105 @@ def test_post_run_falls_back_to_inline_when_mode_inline(monkeypatch):
     assert resp.json()["pid"] == 4242
 
 
-def test_env_passthrough_excludes_dashboard_secrets(monkeypatch):
-    """Dashboard auth secrets must never reach runner containers.
+def test_env_passthrough_whitelist_runner_needs(monkeypatch):
+    """The runner is the orchestrator process — it MUST receive the
+    auth secrets it uses to call back to the dashboard. The earlier
+    too-strict whitelist (PR #419 review) blocked the webhook secret
+    and the runner 401'd on every event, aborting in preflight.
 
-    Regression guard for the PR #419 review finding: the original
-    implementation forwarded every ``STATION_*`` variable, which leaked
-    ``STATION_API_KEY`` / ``STATION_WEBHOOK_SECRET`` etc. into runners.
+    What we still refuse to copy:
+    - ``STATION_LAUNCHER_TOKEN`` (dashboard → launcher hop only)
+    - Everything outside the whitelist
     """
-    monkeypatch.setenv("STATION_API_KEY", "leak-me")
-    monkeypatch.setenv("STATION_WEBHOOK_SECRET", "leak-me")
-    monkeypatch.setenv("STATION_GITHUB_WEBHOOK_SECRET", "leak-me")
-    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "leak-me")
+    monkeypatch.setenv("STATION_API_KEY", "secret-api")
+    monkeypatch.setenv("STATION_WEBHOOK_SECRET", "secret-webhook")
+    monkeypatch.setenv("STATION_GITHUB_WEBHOOK_SECRET", "secret-gh-wh")
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "secret-launcher-token")
     monkeypatch.setenv("STATION_DB_URL", "postgresql+asyncpg://u:p@db/h")
     monkeypatch.setenv("STATION_CONFIG", "/tmp/cfg.json")
+    monkeypatch.setenv("IS_SANDBOX", "1")
+    monkeypatch.setenv("PATH", "/should/not/leak")
+    monkeypatch.setenv("HOME", "/should/not/leak")
 
     import importlib
     import agent.launcher as launcher_mod
     importlib.reload(launcher_mod)
 
     env = launcher_mod._env_passthrough()
-    assert "STATION_API_KEY" not in env
-    assert "STATION_WEBHOOK_SECRET" not in env
-    assert "STATION_GITHUB_WEBHOOK_SECRET" not in env
-    assert "STATION_LAUNCHER_TOKEN" not in env
+    # Required for runner → dashboard auth.
+    assert env["STATION_API_KEY"] == "secret-api"
+    assert env["STATION_WEBHOOK_SECRET"] == "secret-webhook"
+    assert env["STATION_GITHUB_WEBHOOK_SECRET"] == "secret-gh-wh"
+    # Required for Claude CLI under root.
+    assert env["IS_SANDBOX"] == "1"
     # Whitelisted entries must flow through unchanged.
     assert env["STATION_DB_URL"].startswith("postgresql+asyncpg://")
     assert env["STATION_CONFIG"] == "/tmp/cfg.json"
+    # Launcher token still excluded — runner has no reason to call the
+    # launcher's own endpoints.
+    assert "STATION_LAUNCHER_TOKEN" not in env
+    # Random non-whitelisted env vars don't leak.
+    assert "PATH" not in env
+    assert "HOME" not in env
+
+
+def test_get_inherited_mounts_returns_empty_outside_docker(monkeypatch):
+    """Without ``/etc/hostname`` resolving to a real container, the
+    helper degrades to an empty list rather than raising. Unit tests
+    rely on this — they import the module without a Docker daemon
+    handy.
+    """
+    import importlib
+    import agent.launcher as launcher_mod
+    importlib.reload(launcher_mod)
+
+    # Force the "no container id" fallback by patching the file reader.
+    monkeypatch.setattr(launcher_mod, "_read_own_container_id", lambda: None)
+    # Reset the cache so we get a fresh probe.
+    launcher_mod._inherited_mounts = None
+
+    assert launcher_mod._get_inherited_mounts() == []
+
+
+def test_get_inherited_mounts_filters_to_known_destinations(monkeypatch):
+    """The helper only forwards the operator-level mounts the runner
+    needs (Claude creds, gh auth, db_password secret). Random binds on
+    the launcher (e.g. ``/var/log/journal``) are NOT inherited.
+    """
+    import importlib
+    from unittest.mock import MagicMock
+    import agent.launcher as launcher_mod
+    importlib.reload(launcher_mod)
+
+    monkeypatch.setattr(launcher_mod, "_read_own_container_id", lambda: "deadbeef")
+
+    fake_container = MagicMock()
+    fake_container.attrs = {
+        "Mounts": [
+            {"Type": "bind", "Source": "/home/op/.claude",
+             "Destination": "/root/.claude", "RW": True},
+            {"Type": "bind", "Source": "/home/op/.config/gh",
+             "Destination": "/root/.config/gh", "RW": False},
+            {"Type": "bind", "Source": "/host/secrets/db_password",
+             "Destination": "/run/secrets/db_password", "RW": False},
+            {"Type": "bind", "Source": "/var/log/journal",
+             "Destination": "/var/log/journal", "RW": True},  # not inherited
+        ],
+    }
+    fake_client = MagicMock()
+    fake_client.containers.get.return_value = fake_container
+    monkeypatch.setattr(launcher_mod, "_get_docker_client", lambda: fake_client)
+    launcher_mod._inherited_mounts = None
+
+    mounts = launcher_mod._get_inherited_mounts()
+    destinations = {m["destination"] for m in mounts}
+    assert destinations == {
+        "/root/.claude",
+        "/root/.config/gh",
+        "/run/secrets/db_password",
+    }
+    # ``ro`` flag preserved for read-only mounts.
+    by_dst = {m["destination"]: m for m in mounts}
+    assert by_dst["/root/.claude"]["mode"] == "rw"
+    assert by_dst["/root/.config/gh"]["mode"] == "ro"
+    assert by_dst["/run/secrets/db_password"]["mode"] == "ro"


### PR DESCRIPTION
Follow-up to #386 (#418/#419/#420). PR #386's three sub-PRs shipped the Docker SDK launcher machinery but never spawned a real runner end-to-end — every test mocked the SDK. The first live triggered run after rebuild surfaced three interlocking bugs.

## 1. Volume name prefix
Compose project-prefixes named volumes to \`claude-agent-station_station-data\`, but \`runner_spawn.py\` mounts \`station-data\` / \`station-logs\` by bare name. Docker silently creates EMPTY volumes when the bare names don't exist → runner sees a blank \`/var/lib/claude-agent-station/\` → orchestrator aborts with \`manager-config.json: No such file\`.

**Fix**: \`name:\` overrides on both volumes in compose.yml, same pattern as the \`agent-net\` network fix in PR #425.

## 2. Too-strict env whitelist
PR #419 review (mine — incorrect) excluded webhook/API secrets from \`_RUNNER_ENV_WHITELIST\` "to prevent leaking secrets". But the runner IS the orchestrator process. Without \`STATION_WEBHOOK_SECRET\` every webhook 401'd; without \`STATION_API_KEY\` every /api/queue call would 401.

**Fix**: whitelist \`STATION_WEBHOOK_SECRET\`, \`STATION_API_KEY\`, \`STATION_GITHUB_WEBHOOK_SECRET\`, plus \`IS_SANDBOX\` (Claude CLI requires it under root). \`STATION_LAUNCHER_TOKEN\` stays excluded — that's for the dashboard → launcher hop only.

## 3. Missing bind mounts
The launcher bind-mounts \`~/.claude\` (Claude OAuth), \`~/.config/gh\` (gh auth), and the \`db_password\` secret. Runners inherit none of these, so the orchestrator can't authenticate the Claude CLI, can't run \`gh\`, and can't open a DB connection.

**Fix**: new \`_get_inherited_mounts()\` inspects the launcher's own container at startup (via Docker API on \`/etc/hostname\`), filters mounts to the three known operator-level destinations, and resolves host source paths. Result cached per uvicorn worker. \`spawn_runner\` gained an \`inherited_mounts\` kwarg layered on top of the named-volume mounts.

## Why existing tests missed all three
- Unit tests mocked \`client.containers.run\` entirely, so volume/network/mount mismatches never hit a daemon.
- PR-3's integration tests (\`test_runner_spawn.py\`, \`test_concurrent_runs.py\`) used \`alpine:3.20\` with a long-running \`sleep\` command — they validated container lifecycle but not orchestrator startup. Real \`station_orchestrator\` startup requires the config file, the auth secrets, and the CLI credentials.

## Test plan
- [x] **Full backend suite: 1422 passed, 1 skipped** (was 1417 on dev; +5 new tests).
- [x] All three bug classes have a regression guard at the unit-test seam.
- [ ] Manual smoke after rebuild: trigger a run; \`docker ps\` shows \`cas-runner-…\`; \`docker logs cas-runner-…\` shows the orchestrator booting past preflight (it'll still need a valid project + GH auth to actually do work, but the spawn path itself now functions).

## Follow-ups
- \`STATION_LAUNCHER_ZOMBIE_TIMEOUT_S\` is read at module import — runners spawned with custom timeouts would inherit the launcher's, not their own. Not in scope here.
- The integration tests in \`tests/integration/test_runner_spawn.py\` / \`test_concurrent_runs.py\` could be promoted from \`alpine:3.20\` to the real \`claude-agent-station/agent:dev\` image and assert the orchestrator emits its first webhook — that would have caught all three bugs. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)