### PR TITLE
fix(orchestrator): stale project field names from bash port (#383)

### DIFF
--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -176,7 +176,7 @@ def iterate_projects(
         except WorkspaceError as exc:
             logger.error("workspace: %s", exc)
             exit_code = 3
-            results.append({"project": project["name"], "decision": "ERROR", "error": str(exc)})
+            results.append({"project": project["repo"], "decision": "ERROR", "error": str(exc)})
             continue
 
         try:
@@ -193,9 +193,9 @@ def iterate_projects(
             # record. NEVER absorb these into a "project failed" bucket.
             raise
         except Exception as exc:  # noqa: BLE001
-            logger.exception("orchestrate_project failed for %s", project["name"])
+            logger.exception("orchestrate_project failed for %s", project["repo"])
             exit_code = 4
-            results.append({"project": project["name"], "decision": "ERROR", "error": str(exc)})
+            results.append({"project": project["repo"], "decision": "ERROR", "error": str(exc)})
             continue
 
         # #390: the manager is now a sibling agent inside the lead's SDK
@@ -221,14 +221,14 @@ def iterate_projects(
                 from agent.webhook_emitter import emit as _emit
                 _emit("manager_no_verdicts", {
                     "run_id": f"run-{run_id}",
-                    "project": project.get("name", ""),
+                    "project": project.get("repo", ""),
                     "verdicts_path": str(verdicts_path),
                 })
             except Exception:  # noqa: BLE001 — best-effort signal
                 logger.warning("manager_no_verdicts webhook emit failed")
             exit_code = max(exit_code, 6)
             results.append({
-                "project": project.get("name", ""),
+                "project": project.get("repo", ""),
                 "decision": "ERROR",
                 "error": f"manager produced no verdicts file at {verdicts_path}",
             })

--- a/agent/workspace_setup.py
+++ b/agent/workspace_setup.py
@@ -21,9 +21,19 @@ def _slug(name: str) -> str:
 
 
 def ensure_workspace(project: dict, workspaces_dir: str) -> str:
-    """Clone or refresh the project workspace. Returns the absolute path."""
-    repo = project["name"]
-    base = project.get("base_branch", "main")
+    """Clone or refresh the project workspace. Returns the absolute path.
+
+    The ``project`` dict is read from ``manager-config.json`` (written by
+    the dashboard's ``services/config_sync.py``) and follows the same
+    field names as the ``Project`` SQLAlchemy model: ``repo`` for
+    ``owner/name`` and ``branch`` for the base branch. The bash→Python
+    port (#383) accidentally carried over the bash variable names
+    ``name`` / ``base_branch``; SQLite-only tests didn't surface the
+    mismatch and the first live triggered run after the post-#386 stack
+    rebuild blew up with ``KeyError: 'name'``.
+    """
+    repo = project["repo"]
+    base = project.get("branch", "main")
     ws_root = Path(workspaces_dir)
     ws_root.mkdir(parents=True, exist_ok=True)
     workspace = ws_root / _slug(repo)

--- a/dashboard/backend/tests/test_workspace_setup.py
+++ b/dashboard/backend/tests/test_workspace_setup.py
@@ -16,7 +16,7 @@ def test_fresh_clone(tmp_path, monkeypatch):
     monkeypatch.setattr("agent.workspace_setup.subprocess.run", MagicMock(side_effect=_git_ok))
     monkeypatch.setattr("agent.workspace_setup.Path.exists", lambda self: False)
 
-    project = {"name": "owner/repo", "base_branch": "main"}
+    project = {"repo": "owner/repo", "branch": "main"}
     path = ensure_workspace(project, str(tmp_path))
 
     # Should have called git clone at least once.
@@ -31,7 +31,7 @@ def test_refresh_existing(tmp_path, monkeypatch):
     (tmp_path / "owner__repo").mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr("agent.workspace_setup.subprocess.run", MagicMock(side_effect=_git_ok))
 
-    project = {"name": "owner/repo", "base_branch": "main"}
+    project = {"repo": "owner/repo", "branch": "main"}
     ensure_workspace(project, str(tmp_path))
 
     calls = subprocess.run.call_args_list  # type: ignore[attr-defined]
@@ -46,7 +46,7 @@ def test_worktree_prune_runs(tmp_path, monkeypatch):
     (tmp_path / "owner__repo").mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr("agent.workspace_setup.subprocess.run", MagicMock(side_effect=_git_ok))
 
-    ensure_workspace({"name": "owner/repo"}, str(tmp_path))
+    ensure_workspace({"repo": "owner/repo"}, str(tmp_path))
 
     calls = subprocess.run.call_args_list  # type: ignore[attr-defined]
     assert any("worktree" in str(c) and "prune" in str(c) for c in calls), (
@@ -64,4 +64,42 @@ def test_bad_remote_raises(tmp_path, monkeypatch):
     monkeypatch.setattr("agent.workspace_setup.subprocess.run", MagicMock(side_effect=_fail))
 
     with pytest.raises(WorkspaceError, match="clone"):
-        ensure_workspace({"name": "owner/bad"}, str(tmp_path))
+        ensure_workspace({"repo": "owner/bad"}, str(tmp_path))
+
+
+def test_rejects_legacy_name_field_loudly(tmp_path, monkeypatch):
+    """The bash port (#383) originally read ``project["name"]`` and
+    ``project.get("base_branch")``, but ``manager-config.json`` (written
+    by the dashboard's config_sync) uses ``repo`` / ``branch``. The
+    first live triggered run after the post-#386 stack rebuild aborted
+    with ``KeyError: 'name'``. Pin the contract on the canonical names.
+    """
+    from agent.workspace_setup import ensure_workspace
+
+    monkeypatch.setattr("agent.workspace_setup.subprocess.run", MagicMock(side_effect=_git_ok))
+    monkeypatch.setattr("agent.workspace_setup.Path.exists", lambda self: False)
+
+    # Legacy field name MUST NOT silently work — without ``repo`` we
+    # expect KeyError, not a silent fall-through that produces an
+    # empty repo path.
+    with pytest.raises(KeyError, match="repo"):
+        ensure_workspace({"name": "owner/legacy"}, str(tmp_path))
+
+
+def test_branch_field_is_canonical(tmp_path, monkeypatch):
+    """``branch`` is the field the dashboard writes (matches the
+    SQLAlchemy ``Project.branch`` column). ``base_branch`` was the
+    bash variable name; ignoring it silently let runs check out
+    ``main`` instead of the project's configured branch.
+    """
+    from agent.workspace_setup import ensure_workspace
+
+    (tmp_path / "owner__rep").mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("agent.workspace_setup.subprocess.run", MagicMock(side_effect=_git_ok))
+
+    ensure_workspace({"repo": "owner/rep", "branch": "develop"}, str(tmp_path))
+    calls = subprocess.run.call_args_list  # type: ignore[attr-defined]
+    cmd_strs = [str(c) for c in calls]
+    assert any("checkout" in s and "develop" in s for s in cmd_strs), (
+        "ensure_workspace must read ``branch``, not the legacy ``base_branch``"
+    )


### PR DESCRIPTION
**Bug discovered while observing the first live triggered run after the post-#386 stack fixes.**

The bash→Python port (#383) carried over bash variable names — \`project[\"name\"]\` and \`project.get(\"base_branch\")\` — but the rest of the system uses \`repo\` and \`branch\`:
- SQLAlchemy \`Project\` model: \`repo\`, \`branch\`
- Dashboard \`services/config_sync.py\` writes \`{\"repo\": ..., \"branch\": ...}\` to \`manager-config.json\`
- \`/api/projects\` exposes \`repo\` / \`branch\`
- \`agent/station_orchestrator.py:2027\` correctly reads \`project[\"repo\"]\`

But \`agent/workspace_setup.py\` and 5 call sites in \`agent/project_loop.py\` read \`project[\"name\"]\`, and \`workspace_setup\` also reads \`project.get(\"base_branch\", \"main\")\`. First live trigger after my four prior compose/runner-spawn fixes hit:

\`\`\`
File \"/app/agent/workspace_setup.py\", line 25, in ensure_workspace
    repo = project[\"name\"]
KeyError: 'name'
\`\`\`

## Why existing tests missed it
The test fixtures in \`test_workspace_setup.py\` used \`{\"name\": \"owner/repo\", \"base_branch\": \"main\"}\` — they validated the WRONG contract, so they passed despite the schema being broken in production.

## Fix
- \`agent/workspace_setup.py\`: read \`repo\` / \`branch\` instead of \`name\` / \`base_branch\`.
- \`agent/project_loop.py\`: 5 call sites updated to \`repo\`.
- Test fixtures updated to canonical field names.
- New regression guards: \`test_rejects_legacy_name_field_loudly\` (KeyError on legacy \`name\`), \`test_branch_field_is_canonical\` (configured branch must reach \`git checkout\`).

## Test plan
- [x] **Full backend suite: 1424 passed, 1 skipped** (was 1422 on dev; +2 regression tests).
- [ ] Manual smoke: re-trigger a run after the next stack rebuild — runner should now reach \`orchestrate_project\` instead of crashing in \`iterate_projects\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)