### PR TITLE
fix(runner): inject GH_TOKEN + embed in clone URL (#386 follow-up)

### DIFF
--- a/agent/launcher.py
+++ b/agent/launcher.py
@@ -353,12 +353,25 @@ async def _spawn_runner_container(hint_run_id: str, project_repo: str | None) ->
         )
     client = _get_docker_client()
     quotas = await _resolve_quotas(project_repo)
+    env = _env_passthrough()
+    # Fetch a fresh GitHub App installation token for the runner — the
+    # legacy ``_spawn_run_manager`` (inline mode) does the same and the
+    # original PR #386 port forgot to carry it over. Without
+    # ``GH_TOKEN`` the runner's first ``git clone`` aborts with
+    # ``could not read Username for 'https://github.com'`` because the
+    # bare HTTPS URL has no credential helper inside the container.
+    # Best-effort: a missing token (dashboard unreachable, App not
+    # installed) lets the run proceed and fail at clone time with a
+    # clearer error than a silent webhook 401 loop.
+    gh_token = _fetch_gh_token()
+    if gh_token:
+        env["GH_TOKEN"] = gh_token
     handle = spawn_runner(
         client,
         hint_run_id=hint_run_id,
         project_repo=project_repo,
         quotas=quotas,
-        env_passthrough=_env_passthrough(),
+        env_passthrough=env,
         image=settings.runner_image,
         config_path=os.environ.get("STATION_CONFIG", "/var/lib/claude-agent-station/manager-config.json"),
         workspaces_dir=os.environ.get("STATION_WORKSPACES", "/var/lib/claude-agent-station/workspaces"),

--- a/agent/workspace_setup.py
+++ b/agent/workspace_setup.py
@@ -5,10 +5,39 @@ Python port of agent/scripts/run-manager.sh::setup_workspace (issue #383).
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+def _clone_url(repo: str) -> str:
+    """Build the HTTPS clone URL, embedding ``GH_TOKEN`` when set.
+
+    There's no git credential helper configured inside the runner
+    container, so a bare ``https://github.com/owner/repo.git`` URL
+    blocks waiting for stdin credentials — which is why the first live
+    triggered run aborted with ``could not read Username for
+    'https://github.com'``.
+
+    Embedding ``x-access-token:<token>@`` lets git use the GitHub App
+    installation token the launcher fetches at spawn time without
+    needing ``gh auth setup-git`` to have been run inside the image.
+    The token is operator-level and short-lived (App tokens are ~1 hour
+    TTL); leaking it into a clone URL command line is acceptable
+    because the runner container itself is the only environment that
+    sees it.
+
+    Falls back to the bare URL when no token is available so an
+    operator running the orchestrator outside the launcher (manual
+    debugging, local dev) still gets a clean failure rather than a
+    surprise behaviour change.
+    """
+    token = os.environ.get("GH_TOKEN", "").strip()
+    if not token:
+        return f"https://github.com/{repo}.git"
+    return f"https://x-access-token:{token}@github.com/{repo}.git"
 
 
 class WorkspaceError(RuntimeError):
@@ -40,13 +69,19 @@ def ensure_workspace(project: dict, workspaces_dir: str) -> str:
 
     if not workspace.exists():
         logger.info("workspace: cloning %s -> %s", repo, workspace)
-        url = f"https://github.com/{repo}.git"
+        url = _clone_url(repo)
         result = subprocess.run(
             ["git", "clone", url, str(workspace)],
             capture_output=True, text=True,
         )
         if result.returncode != 0:
-            raise WorkspaceError(f"clone failed: {result.stderr.strip()}")
+            # Redact the token from the URL before raising — the
+            # stderr buffer is the load-bearing diagnostic operators
+            # see, and "clone failed: fatal: ... https://x-access-token:
+            # ghs_xyz@github.com/..." is a bad day for whoever's
+            # screen the error lands on.
+            stderr = result.stderr.strip().replace(url, f"https://github.com/{repo}.git")
+            raise WorkspaceError(f"clone failed: {stderr}")
     else:
         logger.info("workspace: refreshing %s", workspace)
         for cmd in (

--- a/dashboard/backend/tests/test_launcher_spawn.py
+++ b/dashboard/backend/tests/test_launcher_spawn.py
@@ -211,6 +211,75 @@ def test_env_passthrough_whitelist_runner_needs(monkeypatch):
     assert "HOME" not in env
 
 
+def test_spawn_runner_container_injects_gh_token(monkeypatch):
+    """The runner needs ``GH_TOKEN`` so ``git clone`` can use the
+    GitHub App installation token via the embedded-URL credential path
+    (see ``workspace_setup._clone_url``). The legacy inline path
+    (``_spawn_run_manager``) already fetches the token; PR #386's
+    runner port forgot to carry it over and the first live triggered
+    run aborted at clone time.
+    """
+    monkeypatch.setenv("STATION_RUNNER_MODE", "container")
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "")
+    import importlib
+    from fastapi.testclient import TestClient
+    from agent.runner_spawn import RunnerHandle
+    from datetime import datetime, timezone
+    import agent.launcher as launcher
+    importlib.reload(launcher)  # pick up the empty LAUNCHER_TOKEN
+
+    with patch("agent.launcher._fetch_gh_token", return_value="ghs_app_token") as fetch, \
+         patch("agent.launcher._get_docker_client") as get_client, \
+         patch("agent.launcher._get_inherited_mounts", return_value=[]), \
+         patch("agent.launcher.spawn_runner") as spawn:
+        spawn.return_value = RunnerHandle(
+            run_id="run-tok", container_name="cas-runner-tok",
+            started_at=datetime.now(timezone.utc),
+            last_webhook_at=datetime.now(timezone.utc),
+            project_repo=None,
+        )
+        get_client.return_value = MagicMock()
+        resp = TestClient(launcher.app).post("/run", json={"hint_run_id": "run-tok"})
+
+    assert resp.status_code == 200
+    fetch.assert_called_once()
+    env = spawn.call_args.kwargs["env_passthrough"]
+    assert env["GH_TOKEN"] == "ghs_app_token"
+
+
+def test_spawn_runner_container_tolerates_missing_gh_token(monkeypatch):
+    """When the dashboard's GitHub App isn't installed (or unreachable),
+    ``_fetch_gh_token`` returns ``None``. The runner spawn must still
+    proceed — git clone will fail with a clear stdin-auth error rather
+    than this code path raising.
+    """
+    monkeypatch.setenv("STATION_RUNNER_MODE", "container")
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "")
+    import importlib
+    from fastapi.testclient import TestClient
+    from agent.runner_spawn import RunnerHandle
+    from datetime import datetime, timezone
+    import agent.launcher as launcher
+    importlib.reload(launcher)
+
+    with patch("agent.launcher._fetch_gh_token", return_value=None), \
+         patch("agent.launcher._get_docker_client") as get_client, \
+         patch("agent.launcher._get_inherited_mounts", return_value=[]), \
+         patch("agent.launcher.spawn_runner") as spawn:
+        spawn.return_value = RunnerHandle(
+            run_id="run-no-tok", container_name="cas-runner-no-tok",
+            started_at=datetime.now(timezone.utc),
+            last_webhook_at=datetime.now(timezone.utc),
+            project_repo=None,
+        )
+        get_client.return_value = MagicMock()
+        resp = TestClient(launcher.app).post("/run", json={"hint_run_id": "run-no-tok"})
+
+    assert resp.status_code == 200
+    env = spawn.call_args.kwargs["env_passthrough"]
+    assert "GH_TOKEN" not in env
+
+
 def test_get_inherited_mounts_returns_empty_outside_docker(monkeypatch):
     """Without ``/etc/hostname`` resolving to a real container, the
     helper degrades to an empty list rather than raising. Unit tests

--- a/dashboard/backend/tests/test_workspace_setup.py
+++ b/dashboard/backend/tests/test_workspace_setup.py
@@ -86,6 +86,72 @@ def test_rejects_legacy_name_field_loudly(tmp_path, monkeypatch):
         ensure_workspace({"name": "owner/legacy"}, str(tmp_path))
 
 
+def test_clone_url_embeds_gh_token_when_present(monkeypatch):
+    """Without an embedded credential the bare HTTPS URL blocks waiting
+    for stdin auth inside the runner container — first live triggered
+    run aborted with ``could not read Username for 'https://github.com'``.
+    The runner has ``GH_TOKEN`` in its env (set by the launcher); embed
+    it as the user portion of the URL.
+    """
+    from agent.workspace_setup import _clone_url
+
+    monkeypatch.setenv("GH_TOKEN", "ghs_dummy_token_xyz")
+    url = _clone_url("owner/repo")
+    assert url.startswith("https://x-access-token:ghs_dummy_token_xyz@")
+    assert "github.com/owner/repo.git" in url
+
+
+def test_clone_url_falls_back_to_bare_https_when_no_token(monkeypatch):
+    """No token → no embedding. Operators running the orchestrator
+    outside the launcher (manual debugging) get a clean recognisable
+    URL and a clean recognisable failure mode.
+    """
+    from agent.workspace_setup import _clone_url
+
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    assert _clone_url("owner/repo") == "https://github.com/owner/repo.git"
+
+
+def test_clone_url_treats_empty_token_as_missing(monkeypatch):
+    """An empty ``GH_TOKEN`` (e.g. ``STATION_GH_TOKEN=""`` in .env) must
+    not produce a malformed URL like ``https://x-access-token:@github.com/``.
+    """
+    from agent.workspace_setup import _clone_url
+
+    monkeypatch.setenv("GH_TOKEN", "   ")
+    assert _clone_url("owner/repo") == "https://github.com/owner/repo.git"
+
+
+def test_clone_failure_redacts_token_from_stderr(tmp_path, monkeypatch):
+    """If ``git clone`` fails the URL containing the token MUST be
+    scrubbed before reaching :class:`WorkspaceError`. Otherwise the
+    operator's screen / logs carry the short-lived but live App token
+    in plaintext.
+    """
+    from agent.workspace_setup import ensure_workspace, WorkspaceError
+
+    monkeypatch.setenv("GH_TOKEN", "ghs_sensitive_token")
+    monkeypatch.setattr("agent.workspace_setup.Path.exists", lambda self: False)
+
+    def _fail_clone(cmd, *a, **kw):
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=128, stdout="",
+            stderr=("fatal: unable to access "
+                    "'https://x-access-token:ghs_sensitive_token@github.com/o/r.git/'"),
+        )
+    monkeypatch.setattr(
+        "agent.workspace_setup.subprocess.run", MagicMock(side_effect=_fail_clone),
+    )
+
+    with pytest.raises(WorkspaceError) as exc_info:
+        ensure_workspace({"repo": "o/r"}, str(tmp_path))
+
+    msg = str(exc_info.value)
+    assert "ghs_sensitive_token" not in msg, "token leaked into WorkspaceError"
+    assert "x-access-token" not in msg
+    assert "github.com/o/r.git" in msg  # the redacted URL is still informative
+
+
 def test_branch_field_is_canonical(tmp_path, monkeypatch):
     """``branch`` is the field the dashboard writes (matches the
     SQLAlchemy ``Project.branch`` column). ``base_branch`` was the


### PR DESCRIPTION
Fifth interlocking bug surfaced by the first end-to-end live triggered run. After #425/#426/#427 the runner spawn reaches \`ensure_workspace\`, which then aborts at \`git clone\`:

\`\`\`
fatal: could not read Username for 'https://github.com':
No such device or address
\`\`\`

## Two contributing failures, both fixed

### 1. Launcher doesn't inject \`GH_TOKEN\` in container mode
\`_spawn_run_manager\` (legacy inline path) fetches the GitHub App installation token from the dashboard and sets \`GH_TOKEN\` in the subprocess env. \`_spawn_runner_container\` (the PR #386 container path) skipped this. Fixed: fetch and inject before \`spawn_runner\`.

### 2. No git credential helper inside the runner
Even with \`GH_TOKEN\` set, git doesn't know to use it unless a credential helper is configured. The image doesn't run \`gh auth setup-git\`. Fixed: \`workspace_setup._clone_url\` embeds the token as the user portion of the HTTPS URL (\`https://x-access-token:\${GH_TOKEN}@github.com/...\`) so git uses it directly.

### Bonus: token redaction
The clone-URL approach means a stderr containing the failed URL would leak the live App token to operator screens. Added a redaction pass before the \`WorkspaceError\` is raised.

## Test plan
- [x] **Full backend suite: 1430 passed, 1 skipped** (was 1424 on dev; +6 regression tests).
- [x] All three failure modes have a specific regression guard.
- [ ] Manual smoke after rebuild: trigger a run; \`git clone\` succeeds; orchestrator proceeds to the issue-fetch phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)