### PR TITLE
fix(runner): db on agent-net + override launcher URL for runners

### DIFF
--- a/agent/launcher.py
+++ b/agent/launcher.py
@@ -354,6 +354,17 @@ async def _spawn_runner_container(hint_run_id: str, project_repo: str | None) ->
     client = _get_docker_client()
     quotas = await _resolve_quotas(project_repo)
     env = _env_passthrough()
+    # Override the launcher URL for the runner's view. Inside the
+    # launcher's own process ``http://localhost:8421`` reaches the
+    # FastAPI app via loopback, but inside a spawned runner container
+    # ``localhost`` is the runner itself — webhook-tick POSTs would
+    # silently fail with connection-refused, the zombie reaper would
+    # see no heartbeats, and the runner would be SIGTERM'd after
+    # ZOMBIE_TIMEOUT_SECONDS. ``http://agent:8421`` resolves to the
+    # launcher's container via compose's DNS on ``agent-net``.
+    env["STATION_AGENT_LAUNCHER_URL"] = os.environ.get(
+        "STATION_RUNNER_LAUNCHER_URL", "http://agent:8421",
+    )
     # Fetch a fresh GitHub App installation token for the runner — the
     # legacy ``_spawn_run_manager`` (inline mode) does the same and the
     # original PR #386 port forgot to carry it over. Without

--- a/compose.yml
+++ b/compose.yml
@@ -21,6 +21,14 @@ services:
       - db_password
     volumes:
       - station-pgdata:/var/lib/postgresql/data
+    # Join the agent-net bridge alongside the default network so runner
+    # containers (which join only ``agent-net``) can resolve ``db`` to
+    # open Postgres connections. Without this membership the runner
+    # aborts with ``socket.gaierror: Name or service not known`` the
+    # first time SQLAlchemy tries to dial the DB. See #386 follow-up.
+    networks:
+      - default
+      - agent-net
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "station"]
       interval: 5s

--- a/dashboard/backend/tests/test_compose_runner.py
+++ b/dashboard/backend/tests/test_compose_runner.py
@@ -40,6 +40,19 @@ def test_agent_net_has_explicit_name_to_avoid_project_prefix():
     )
 
 
+def test_db_service_is_on_agent_net():
+    """Runner containers join only ``agent-net``; if ``db`` is not also
+    on that network, every runner aborts the first time it dials
+    Postgres with ``socket.gaierror: Name or service not known``.
+    See #386 follow-up.
+    """
+    c = _compose()
+    nets = c["services"]["db"].get("networks") or []
+    assert "agent-net" in nets, (
+        "db service must join agent-net so runner containers can reach it"
+    )
+
+
 def test_station_volumes_have_explicit_name_to_avoid_project_prefix():
     """Same project-prefix gotcha as ``agent-net``: ``runner_spawn.py``
     mounts ``station-data`` / ``station-logs`` by bare name, but compose

--- a/dashboard/backend/tests/test_launcher_spawn.py
+++ b/dashboard/backend/tests/test_launcher_spawn.py
@@ -247,6 +247,42 @@ def test_spawn_runner_container_injects_gh_token(monkeypatch):
     assert env["GH_TOKEN"] == "ghs_app_token"
 
 
+def test_spawn_runner_container_overrides_launcher_url(monkeypatch):
+    """The launcher's own ``STATION_AGENT_LAUNCHER_URL`` is
+    ``http://localhost:8421`` (loopback inside its own container).
+    Spawned runners MUST get ``http://agent:8421`` instead — inside
+    the runner ``localhost`` is the runner itself, and webhook-tick
+    POSTs would silently fail with connection-refused.
+    """
+    monkeypatch.setenv("STATION_RUNNER_MODE", "container")
+    monkeypatch.setenv("STATION_LAUNCHER_TOKEN", "")
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://localhost:8421")
+    import importlib
+    from fastapi.testclient import TestClient
+    from agent.runner_spawn import RunnerHandle
+    from datetime import datetime, timezone
+    import agent.launcher as launcher
+    importlib.reload(launcher)
+
+    with patch("agent.launcher._fetch_gh_token", return_value=None), \
+         patch("agent.launcher._get_docker_client") as get_client, \
+         patch("agent.launcher._get_inherited_mounts", return_value=[]), \
+         patch("agent.launcher.spawn_runner") as spawn:
+        spawn.return_value = RunnerHandle(
+            run_id="run-url", container_name="cas-runner-url",
+            started_at=datetime.now(timezone.utc),
+            last_webhook_at=datetime.now(timezone.utc),
+            project_repo=None,
+        )
+        get_client.return_value = MagicMock()
+        TestClient(launcher.app).post("/run", json={"hint_run_id": "run-url"})
+
+    env = spawn.call_args.kwargs["env_passthrough"]
+    assert env["STATION_AGENT_LAUNCHER_URL"] == "http://agent:8421", (
+        "launcher URL must be overridden — runners can't reach themselves on localhost:8421"
+    )
+
+
 def test_spawn_runner_container_tolerates_missing_gh_token(monkeypatch):
     """When the dashboard's GitHub App isn't installed (or unreachable),
     ``_fetch_gh_token`` returns ``None``. The runner spawn must still


### PR DESCRIPTION
Sixth runner-spawn bug surfaced live: orchestrator aborts with `socket.gaierror: Name or service not known` because (1) Postgres `db` service is only on the default network and runners join only `agent-net`, and (2) the launcher's own `STATION_AGENT_LAUNCHER_URL=http://localhost:8421` propagates to runners where localhost is the runner itself. Fixes both. Suite: 1430 → 1432 passing.