### PR TITLE
fix(runner): whitelist STATION_LAUNCHER_TOKEN — reaper killing live runs

### DIFF
--- a/agent/launcher.py
+++ b/agent/launcher.py
@@ -150,14 +150,18 @@ def _get_docker_client():
 # webhook the runner emitted and the orchestrator aborted before doing
 # anything useful. See post-#386 PR-3 end-to-end repro.
 #
-# What we still NEVER copy:
-#   - ``STATION_LAUNCHER_TOKEN`` — that token authenticates the
-#     dashboard → launcher hop; the runner has no reason to call its own
-#     launcher endpoint, so propagating it would expand the blast
-#     radius of a runner compromise without enabling any feature.
-#   - Anything outside the ``STATION_*`` namespace, with the documented
-#     exception of ``IS_SANDBOX`` (Claude CLI requires it under root —
-#     see compose.yml's agent service for the rationale).
+# The "exclude STATION_LAUNCHER_TOKEN" reasoning was wrong too: the
+# runner POSTs to ``/webhook-tick`` on the launcher every few seconds
+# to update ``handle.last_webhook_at``, and that endpoint requires
+# ``X-Launcher-Token``. Without the token in the runner's env every
+# tick 401s, the heartbeat stays stuck at spawn time, and the
+# container-aware reaper SIGTERMs the active runner at the 120s idle
+# mark. First live run that progressed past clone (post-#429) was
+# killed exactly this way after 127s of useful work.
+#
+# Anything outside the ``STATION_*`` namespace stays excluded, with
+# the documented exception of ``IS_SANDBOX`` (Claude CLI requires it
+# under root — see compose.yml's agent service for the rationale).
 _RUNNER_ENV_WHITELIST: frozenset[str] = frozenset({
     "STATION_DB_URL",
     "STATION_DB_PASSWORD_FILE",
@@ -173,6 +177,9 @@ _RUNNER_ENV_WHITELIST: frozenset[str] = frozenset({
     "STATION_WEBHOOK_SECRET",
     "STATION_API_KEY",
     "STATION_GITHUB_WEBHOOK_SECRET",
+    # Runner → launcher auth for /webhook-tick heartbeat. Without this
+    # the reaper kills working runs at the 120s idle mark.
+    "STATION_LAUNCHER_TOKEN",
     # Not STATION_-prefixed but required: Claude CLI refuses
     # ``--dangerously-skip-permissions`` under root unless this is set.
     "IS_SANDBOX",

--- a/dashboard/backend/tests/test_launcher_spawn.py
+++ b/dashboard/backend/tests/test_launcher_spawn.py
@@ -171,13 +171,15 @@ def test_post_run_falls_back_to_inline_when_mode_inline(monkeypatch):
 
 def test_env_passthrough_whitelist_runner_needs(monkeypatch):
     """The runner is the orchestrator process — it MUST receive the
-    auth secrets it uses to call back to the dashboard. The earlier
-    too-strict whitelist (PR #419 review) blocked the webhook secret
-    and the runner 401'd on every event, aborting in preflight.
+    auth secrets it uses to call back to the dashboard AND the
+    launcher token for its own heartbeat POSTs. The earlier
+    too-strict whitelist (PR #419/#426 reviews) blocked some of these
+    and runs were either 401'd at preflight or SIGTERMed by the
+    reaper at the 120s idle mark.
 
     What we still refuse to copy:
-    - ``STATION_LAUNCHER_TOKEN`` (dashboard → launcher hop only)
-    - Everything outside the whitelist
+    - Everything outside the whitelist (including unrelated env vars
+      like PATH/HOME that happen to be in the launcher's environ).
     """
     monkeypatch.setenv("STATION_API_KEY", "secret-api")
     monkeypatch.setenv("STATION_WEBHOOK_SECRET", "secret-webhook")
@@ -198,14 +200,15 @@ def test_env_passthrough_whitelist_runner_needs(monkeypatch):
     assert env["STATION_API_KEY"] == "secret-api"
     assert env["STATION_WEBHOOK_SECRET"] == "secret-webhook"
     assert env["STATION_GITHUB_WEBHOOK_SECRET"] == "secret-gh-wh"
+    # Required for runner → launcher /webhook-tick heartbeat (without
+    # it the reaper kills the runner at the 120s idle mark even when
+    # it's doing useful work).
+    assert env["STATION_LAUNCHER_TOKEN"] == "secret-launcher-token"
     # Required for Claude CLI under root.
     assert env["IS_SANDBOX"] == "1"
     # Whitelisted entries must flow through unchanged.
     assert env["STATION_DB_URL"].startswith("postgresql+asyncpg://")
     assert env["STATION_CONFIG"] == "/tmp/cfg.json"
-    # Launcher token still excluded — runner has no reason to call the
-    # launcher's own endpoints.
-    assert "STATION_LAUNCHER_TOKEN" not in env
     # Random non-whitelisted env vars don't leak.
     assert "PATH" not in env
     assert "HOME" not in env


### PR DESCRIPTION
Seventh runner-spawn bug: live runs were being SIGTERMed at exactly the 120s mark even while actively executing tool calls. The runner's /webhook-tick POSTs to the launcher 401'd because STATION_LAUNCHER_TOKEN was whitelist-excluded, so handle.last_webhook_at stayed stuck at spawn time, and the container-aware reaper marked the active runner 'idle' and stopped it.

Same mistake class as PR #426's webhook-secret exclusion: the runner is the trusted orchestrator process, not an untrusted subprocess. The whitelist comment is corrected to match.

Suite: 1432 passing (unchanged count — one test ASSERTION flipped, not a new test).