### PR TITLE
fix(runner): pass run_id on /webhook-tick — reaper killing live runs (#386 follow-up)

### DIFF
--- a/agent/webhook_emitter.py
+++ b/agent/webhook_emitter.py
@@ -41,24 +41,37 @@ BACKOFF_BASE = 0.5  # 0.5s, 1s, 2s
 LAUNCHER_URL_ENV = "STATION_AGENT_LAUNCHER_URL"
 
 
-def _ping_launcher(timeout: float = 1.0) -> None:
-    """Best-effort heartbeat to the launcher's /webhook-tick. Silently
-    swallows all errors — the launcher may not be reachable (the bash
-    might be running outside compose mode) and that's fine.
+def _ping_launcher(run_id: str | None = None, timeout: float = 1.0) -> None:
+    """Best-effort heartbeat to the launcher's /webhook-tick.
 
+    ``run_id`` MUST be passed in container mode (#386) so the launcher
+    updates the per-run ``handle.last_webhook_at`` in its ``_runners``
+    map. Without it, the launcher's handler falls through to the
+    legacy global ``_last_webhook_at``, the container-aware reaper
+    sees the runner handle's timestamp stuck at spawn time, and
+    SIGTERMs the runner at the 120s mark even while it's doing useful
+    work. Discovered after PRs #426/#429/#430 got the spawn working:
+    each subsequent live run died at exactly 133s with
+    ``reaper: cas-runner-... idle 133s, stopping``.
+
+    Silently swallows all errors — the launcher may not be reachable
+    (e.g. orchestrator running outside compose mode) and that's fine.
     Defaults to ``http://localhost:8421`` because the emitter runs
-    inside the agent container alongside the launcher. The env var is
-    only the override (e.g. for tests).
+    inside the same container as the launcher in inline mode; the env
+    var ``STATION_AGENT_LAUNCHER_URL`` is the container-mode override
+    that points at ``http://agent:8421``.
     """
     base = os.environ.get(LAUNCHER_URL_ENV) or "http://localhost:8421"
     token = os.environ.get("STATION_LAUNCHER_TOKEN", "")
     headers: dict[str, str] = {}
     if token:
         headers["X-Launcher-Token"] = token
+    params: dict[str, str] = {"run_id": run_id} if run_id else {}
     try:
         httpx.post(
             f"{base.rstrip('/')}/webhook-tick",
             headers=headers,
+            params=params,
             timeout=timeout,
         )
     except Exception:
@@ -99,13 +112,13 @@ def emit(event: str, *, run_id: str, payload: dict[str, Any] | None = None) -> N
         try:
             resp = httpx.post(_url(), json=body, headers=_headers(), timeout=10.0)
             if 200 <= resp.status_code < 300:
-                _ping_launcher()
+                _ping_launcher(run_id=run_id)
                 return
             last_err = f"HTTP {resp.status_code}: {resp.text[:200]}"
             if 400 <= resp.status_code < 500:
                 logger.error("webhook_emitter: non-retryable %s for %s",
                              last_err, event)
-                _ping_launcher()
+                _ping_launcher(run_id=run_id)
                 return
         except httpx.HTTPError as exc:
             last_err = f"transport error: {exc}"
@@ -113,7 +126,7 @@ def emit(event: str, *, run_id: str, payload: dict[str, Any] | None = None) -> N
             time.sleep(BACKOFF_BASE * (2 ** attempt))
     logger.error("webhook_emitter: gave up after %d attempts (%s) for %s",
                  RETRIES, last_err, event)
-    _ping_launcher()
+    _ping_launcher(run_id=run_id)
 
 
 def _cli() -> int:

--- a/dashboard/backend/tests/test_webhook_emitter.py
+++ b/dashboard/backend/tests/test_webhook_emitter.py
@@ -19,6 +19,16 @@ def _dashboard_call(mock_post):
     raise AssertionError(f"no dashboard webhook call seen; saw: {[c.args for c in mock_post.call_args_list]}")
 
 
+def _launcher_call(mock_post):
+    """Pick out the launcher /webhook-tick call. Counterpart of
+    :func:`_dashboard_call`."""
+    for call in mock_post.call_args_list:
+        url = call.args[0] if call.args else ""
+        if "/webhook-tick" in url:
+            return call
+    raise AssertionError(f"no launcher tick call seen; saw: {[c.args for c in mock_post.call_args_list]}")
+
+
 def test_emit_run_start_posts_to_webhook():
     from agent.webhook_emitter import emit
     with patch("agent.webhook_emitter.httpx.post") as mock_post:
@@ -173,3 +183,39 @@ def test_old_pythonpath_fails_from_arbitrary_cwd():
         "Expected import to fail with pre-fix PYTHONPATH but it succeeded; "
         "the test environment may have agent/ on sys.path via other means."
     )
+
+
+def test_launcher_tick_includes_run_id_query_param():
+    """Container-mode runners MUST pass ``run_id`` to /webhook-tick so
+    the launcher updates the per-run ``handle.last_webhook_at`` in its
+    ``_runners`` map. Without the param the launcher falls through to
+    the legacy global timestamp and the container reaper SIGTERMs the
+    runner at the 120s idle mark. Regression guard for the
+    post-#386/#430 reaper-killing-active-runs bug.
+    """
+    from agent.webhook_emitter import emit
+
+    with patch("agent.webhook_emitter.httpx.post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=200, text="ok")
+        emit("run_start", run_id="run-tick-1", payload={})
+
+    tick = _launcher_call(mock_post)
+    assert tick.kwargs.get("params") == {"run_id": "run-tick-1"}, (
+        "params={run_id=...} must be on the tick POST so the launcher's "
+        "per-run handle gets updated"
+    )
+
+
+def test_launcher_tick_omits_run_id_param_when_not_supplied():
+    """``_ping_launcher`` called without a ``run_id`` (e.g. from a
+    bare-systemd inline runner) must send an empty params dict, not
+    ``{"run_id": "None"}`` or similar — the launcher's handler
+    interprets the absence of the param as legacy inline-mode and
+    bumps the global timestamp instead.
+    """
+    from agent.webhook_emitter import _ping_launcher
+
+    with patch("agent.webhook_emitter.httpx.post") as mock_post:
+        _ping_launcher()
+
+    assert mock_post.call_args.kwargs.get("params") == {}


### PR DESCRIPTION
## Summary
- `_ping_launcher()` now accepts and forwards `run_id` as a query param so the launcher updates `handle.last_webhook_at` in its `_runners` map instead of falling through to the legacy global timestamp.
- Without this, the container-aware reaper saw the handle's timestamp stuck at spawn time and SIGTERM'd active runs at the 120s idle mark even while they were emitting successful heartbeats (HTTP 200 OK).
- Two regression tests: presence of `params={run_id=...}` on the tick POST, and explicit empty-params for the legacy inline call shape.

## Why
Observed live, post-#426/#429/#430:
```
reaper: cas-runner-20260515T204232Z idle 133s, stopping
```
Every long-running container died at ~120-133s despite ticks succeeding — the launcher's handler interprets a missing `run_id` param as legacy inline mode and only bumps the global timestamp.

## Test plan
- [x] Backend suite green: 1434 passed (was 1432)
- [x] New `test_launcher_tick_includes_run_id_query_param` and `test_launcher_tick_omits_run_id_param_when_not_supplied`
- [ ] Rebuild agent image and trigger a fresh run; confirm it survives past 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)