### PR TITLE
fix(orchestrator): pass run_id on every /webhook-tick (#431 follow-up)

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1363,13 +1363,24 @@ def post_webhook(config: dict, event: str, data: dict | None = None) -> None:
     # traffic flows through this Python path; without this ping the
     # launcher reaped active runs after 120s of "bash silence" (see
     # run-20260512T122255Z post-mortem).
-    _ping_launcher_best_effort()
+    _ping_launcher_best_effort(run_id=(data or {}).get("run_id"))
 
 
-def _ping_launcher_best_effort() -> None:
+def _ping_launcher_best_effort(run_id: str | None = None) -> None:
     """Bump the launcher's heartbeat clock so its _zombie_reaper sees
     that the Python orchestrator is making forward progress. Mirrors
     agent.webhook_emitter._ping_launcher. Silent on all errors.
+
+    ``run_id`` MUST be passed in container mode (#386) so the launcher
+    updates the per-run ``handle.last_webhook_at`` in its ``_runners``
+    map. Without it, the launcher's handler falls through to the
+    legacy global ``_last_webhook_at``, the container-aware reaper
+    sees the runner handle's timestamp stuck at spawn time, and
+    SIGTERMs the runner at the 120s mark even while it's emitting
+    successful heartbeats. Sibling of
+    ``agent.webhook_emitter._ping_launcher``; the orchestrator path
+    needs the same fix because most Agent Teams runtime traffic flows
+    through ``post_webhook()`` rather than ``emit()``.
 
     Defaults to ``http://localhost:8421`` because the orchestrator
     runs inside the agent container and the launcher listens there.
@@ -1379,9 +1390,10 @@ def _ping_launcher_best_effort() -> None:
     base = os.environ.get("STATION_AGENT_LAUNCHER_URL") or "http://localhost:8421"
     token = os.environ.get("STATION_LAUNCHER_TOKEN", "")
     headers = {"X-Launcher-Token": token} if token else {}
+    params: dict[str, str] = {"run_id": run_id} if run_id else {}
     try:
         with httpx.Client(timeout=1.0) as client:
-            client.post(f"{base.rstrip('/')}/webhook-tick", headers=headers)
+            client.post(f"{base.rstrip('/')}/webhook-tick", headers=headers, params=params)
     except Exception:
         pass
 

--- a/dashboard/backend/tests/test_orchestrator_launcher_ping.py
+++ b/dashboard/backend/tests/test_orchestrator_launcher_ping.py
@@ -124,3 +124,85 @@ def test_launcher_ping_swallows_errors(monkeypatch):
             "run_start",
             {"run_id": "run-flaky"},
         )
+
+
+def test_post_webhook_threads_run_id_to_launcher_tick(monkeypatch):
+    """Container-mode runners MUST pass ``run_id`` to /webhook-tick so
+    the launcher updates ``handle.last_webhook_at`` in its ``_runners``
+    map. Without it, the launcher's handler falls through to the
+    legacy global ``_last_webhook_at`` and the container reaper
+    SIGTERMs the runner at the 120s idle mark even while
+    ``post_webhook`` keeps firing. Regression guard for the second
+    half of the #386 reaper bug (the first half — emit() path — was
+    fixed in PR #431). Discovered when live run-20260515T233935Z
+    still died at 134s after PR #431: the first tick had ``?run_id=``
+    but every subsequent ``post_webhook`` ping (the dominant traffic)
+    did not.
+    """
+    from agent import station_orchestrator as so
+
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://agent:8421")
+
+    captured: list[tuple[str, dict]] = []
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            captured.append((url, kwargs))
+
+    with patch("agent.station_orchestrator.httpx.Client", FakeClient):
+        so.post_webhook(
+            {"dashboard": {"webhook_url": "http://dashboard:8420/api/webhook/run-event"}},
+            "teammate_progress",
+            {"run_id": "run-tick-id", "task_id": "t1"},
+        )
+
+    tick_calls = [(u, kw) for (u, kw) in captured if "/webhook-tick" in u]
+    assert len(tick_calls) == 1, f"expected one tick, saw {captured}"
+    _, kwargs = tick_calls[0]
+    assert kwargs.get("params") == {"run_id": "run-tick-id"}, (
+        f"params={{run_id=...}} must be on the tick POST; got {kwargs}"
+    )
+
+
+def test_post_webhook_omits_run_id_param_when_data_missing(monkeypatch):
+    """If a caller invokes ``post_webhook`` without a ``run_id`` in
+    ``data`` (or with ``data=None``), the launcher tick must send
+    empty params, NOT ``{"run_id": "None"}`` or similar. The
+    launcher's handler interprets the absence of the param as legacy
+    inline-mode and bumps the global timestamp instead.
+    """
+    from agent import station_orchestrator as so
+
+    monkeypatch.setenv("STATION_AGENT_LAUNCHER_URL", "http://agent:8421")
+
+    captured: list[tuple[str, dict]] = []
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            captured.append((url, kwargs))
+
+    with patch("agent.station_orchestrator.httpx.Client", FakeClient):
+        so.post_webhook(
+            {"dashboard": {"webhook_url": "http://dashboard:8420/api/webhook/run-event"}},
+            "narration",
+            None,
+        )
+
+    tick_calls = [(u, kw) for (u, kw) in captured if "/webhook-tick" in u]
+    assert len(tick_calls) == 1
+    _, kwargs = tick_calls[0]
+    assert kwargs.get("params") == {}, (
+        f"empty params expected when run_id is missing; got {kwargs}"
+    )


### PR DESCRIPTION
## Summary
PR #431 fixed `webhook_emitter._ping_launcher` but missed the **other** tick caller — `station_orchestrator.post_webhook` → `_ping_launcher_best_effort`. That second path fires the dominant share of `/webhook-tick` traffic during an Agent Teams run (narration, teammate_progress, progress_update — dozens per minute), and it was still sending bare ticks without `run_id`.

## Why
Live verification of #431 with `run-20260515T233935Z` showed the runner **still dying at 134s** with:
```
POST /webhook-tick?run_id=run-20260515T233935Z 200 OK   # one emit() tick (fixed)
POST /webhook-tick 200 OK                               # post_webhook (broken)
POST /webhook-tick 200 OK                               # post_webhook
...
reaper: cas-runner-20260515T233935Z idle 125s, stopping
```
The launcher's handler reads `request.query_params.get("run_id")` and falls through to the legacy global timestamp when absent — so `handle.last_webhook_at` only ever advanced once, at `run_start`.

## Change
`_ping_launcher_best_effort` now accepts `run_id` and forwards it as a query param. `post_webhook` extracts it from `data` (every existing caller passes `data["run_id"]`) and threads it through.

## Test plan
- [x] Backend suite green: 1436 passed (was 1434)
- [x] New `test_post_webhook_threads_run_id_to_launcher_tick` + `test_post_webhook_omits_run_id_param_when_data_missing`
- [ ] Rebuild agent image and trigger a run; confirm it survives past 120s

🤖 Generated with [Claude Code](https://claude.com/claude-code)