### PR TITLE
fix(orchestrator): double 'run-' prefix on /webhook-tick (#432 follow-up)

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -2845,8 +2845,13 @@ class RunDriver:
 
         try:
             from agent.project_loop import iterate_projects
+            # iterate_projects (and everything downstream — orchestrate_project,
+            # post_webhook callers) builds wire-format run ids by prepending
+            # ``run-`` to its input. Pass the BARE id so we don't end up with
+            # ``run-run-<ts>`` query params on /webhook-tick, which 404 at the
+            # launcher and let the reaper kill the run at 120s.
             exit_code, last_state = iterate_projects(
-                self.run_id, self.config_path, self.workspaces_dir,
+                self._clean_id, self.config_path, self.workspaces_dir,
             )
             if exit_code == 130:
                 status = "interrupted"

--- a/dashboard/backend/tests/test_run_driver.py
+++ b/dashboard/backend/tests/test_run_driver.py
@@ -55,3 +55,43 @@ def test_run_driver_emits_run_complete_with_completed_status_on_success():
     complete_call = next(c for c in mock_emit.call_args_list
                          if c.args[0] == "run_complete")
     assert complete_call.kwargs.get("payload", {}).get("status") == "completed"
+
+
+def test_run_driver_passes_bare_run_id_to_iterate_projects():
+    """Regression: iterate_projects (and everything downstream — post_webhook,
+    the launcher /webhook-tick payload, write_digest, verdict files) builds
+    wire-format ids by prepending ``run-`` to its input. The driver receives
+    ``--run-id run-<ts>`` from the dashboard's pre-allocated trigger flow,
+    so passing self.run_id raw produces ``run-run-<ts>`` everywhere, the
+    launcher 404s the tick, and the reaper kills the runner at 120s. See
+    live run-20260515T234700Z post-mortem.
+    """
+    from agent.station_orchestrator import RunDriver
+    with patch("agent.station_orchestrator.emit"), \
+         patch("agent.project_loop.iterate_projects",
+               return_value=(0, None)) as mock_iter:
+        driver = RunDriver(run_id="run-20260515T234700Z",
+                           config_path="/tmp/cfg.json",
+                           workspaces_dir="/tmp/ws")
+        driver.run()
+    args, _ = mock_iter.call_args
+    assert args[0] == "20260515T234700Z", (
+        f"iterate_projects must receive the BARE run_id (no 'run-' prefix); "
+        f"got {args[0]!r}. Without this, post_webhook payloads carry "
+        f"'run-run-<ts>' run_ids and the launcher rejects every tick."
+    )
+
+
+def test_run_driver_bare_run_id_passes_through_unchanged():
+    """Legacy callers (bash systemd shim) pass the bare timestamp without
+    the ``run-`` prefix. iterate_projects must still receive that bare form."""
+    from agent.station_orchestrator import RunDriver
+    with patch("agent.station_orchestrator.emit"), \
+         patch("agent.project_loop.iterate_projects",
+               return_value=(0, None)) as mock_iter:
+        driver = RunDriver(run_id="20260515T234700Z",
+                           config_path="/tmp/cfg.json",
+                           workspaces_dir="/tmp/ws")
+        driver.run()
+    args, _ = mock_iter.call_args
+    assert args[0] == "20260515T234700Z"


### PR DESCRIPTION
## Summary
PRs #431 and #432 plumbed `run_id` through both tick paths but missed the **actual** reason ticks were 404ing: every payload had a **double** `run-` prefix.

## Why
The dashboard's `/api/runs/trigger` pre-allocates the run_id with `run-` already attached (`run-20260515T234700Z`) and passes it to the launcher as `--run-id`. `RunDriver` stored it verbatim and passed it to `iterate_projects`, which prepends `run-` again at >20 f-string sites. Wire result: `run_id=run-run-20260515T234700Z` → 404 at launcher → reaper kills at 120s.

Live evidence (post-#432):
```
POST /webhook-tick?run_id=run-20260515T234700Z 200 OK         # emit() — fine
POST /webhook-tick?run_id=run-run-20260515T234700Z 404        # post_webhook
... (hundreds of 404s) ...
reaper: cas-runner-20260515T234700Z idle 128s, stopping
```

## Change
`RunDriver` already maintains `self._clean_id` (bare timestamp, used for log file naming). Pass that — not `self.run_id` — to `iterate_projects`. Downstream f-strings now build the correct single-prefix wire id.

## Test plan
- [x] Backend suite green: 1438 passed (was 1436)
- [x] `test_run_driver_passes_bare_run_id_to_iterate_projects` (prefixed input)
- [x] `test_run_driver_bare_run_id_passes_through_unchanged` (legacy systemd path)
- [ ] Rebuild agent image and trigger a run; confirm runner survives past 120s and tick logs show single-prefix `run_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)