### PR TITLE
fix(orchestrator): pass workspace + dev_branch to execute_verdict — integrations were silently dropped

### DIFF
--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -170,9 +170,14 @@ def iterate_projects(
     last_state = None
     log_dir = _os.environ.get("STATION_LOG_DIR", "/var/log/claude-agent")
 
+    # APPROVE_INTEGRATION / APPROVE / PR executors require ``workspace`` and
+    # ``dev_branch`` kwargs (kw-only, no default for workspace). ``dev_branch``
+    # is global to the run; capture it once.
+    dev_branch = config.get("integration", {}).get("dev_branch", "autonomous/dev")
+
     for project in enabled:
         try:
-            ensure_workspace(project, workspaces_dir)
+            workspace_path = ensure_workspace(project, workspaces_dir)
         except WorkspaceError as exc:
             logger.error("workspace: %s", exc)
             exit_code = 3
@@ -238,11 +243,40 @@ def iterate_projects(
         verdicts = [_Verdict.from_dict(v) for v in raw_verdicts]
 
         for verdict in verdicts:
-            execute_verdict(verdict, run_id=run_id)
+            # APPROVE_INTEGRATION / APPROVE / PR executors require
+            # ``workspace`` (kw-only, no default) and use ``dev_branch``
+            # for non-degraded behavior. Missing kwargs raise TypeError
+            # that propagates out and gets caught at the RunDriver level,
+            # silently failing every integration even when the manager
+            # approved. (Discovered after live run-20260515T235612Z:
+            # verdict file written with 5x APPROVE_INTEGRATION, no PRs
+            # opened, run marked failed.) Catch per-verdict so one bad
+            # executor invocation doesn't cancel the whole queue.
+            try:
+                execute_verdict(
+                    verdict,
+                    workspace=Path(workspace_path),
+                    run_id=run_id,
+                    env=_os.environ.copy(),
+                    dev_branch=dev_branch,
+                )
+            except Exception as exc:  # noqa: BLE001 — must not crash loop
+                logger.exception(
+                    "verdict_execution: %s#%s failed (%s)",
+                    verdict.project, verdict.issue_number, verdict.verdict,
+                )
+                exit_code = max(exit_code, 7)
+                results.append({
+                    "project": verdict.project,
+                    "issue_number": verdict.issue_number,
+                    "decision": "ERROR",
+                    "error": f"execute_verdict: {type(exc).__name__}: {exc}",
+                })
+                continue
             results.append({
                 "project": verdict.project,
                 "issue_number": verdict.issue_number,
-                "decision": verdict.decision,
+                "decision": verdict.verdict,
                 "branch": getattr(verdict, "branch", ""),
                 "reasoning": getattr(verdict, "reasoning", ""),
             })

--- a/dashboard/backend/tests/test_iterate_projects_python.py
+++ b/dashboard/backend/tests/test_iterate_projects_python.py
@@ -115,3 +115,150 @@ def test_run_manager_sh_is_deleted():
     assert not (repo_root / "agent" / "scripts" / "run-manager.sh").exists(), (
         "agent/scripts/run-manager.sh must be deleted (issue #383)"
     )
+
+
+def test_iterate_projects_passes_workspace_and_dev_branch_to_executor(
+    tmp_path, monkeypatch,
+):
+    """Regression: ``execute_approve_integration`` (and APPROVE / PR)
+    require ``workspace`` as a keyword-only arg with no default. Before
+    this fix, ``project_loop.execute_verdict`` was called with only
+    ``run_id``, so every APPROVE_INTEGRATION verdict raised TypeError
+    inside the iterate_projects loop. The TypeError propagated to
+    RunDriver's catch-all, which marked the run failed and clobbered
+    telemetry — silently, with no PR opened despite the manager having
+    approved integration.
+
+    Live evidence: run-20260515T235612Z generated 5x APPROVE_INTEGRATION
+    verdicts in the verdicts file, but zero PRs appeared on the target
+    repo, and the runs row ended with ``status=failed`` after the
+    container exited at 30 minutes (well past the verdict step at
+    ~22 minutes).
+    """
+    from pathlib import Path
+    from agent import project_loop as pl
+
+    cfg = tmp_path / "manager-config.json"
+    cfg.write_text(json.dumps({
+        "projects": [{"repo": "owner/repo", "enabled": True, "branch": "main"}],
+        "limits": {"max_concurrent_employees": 1},
+        "integration": {"dev_branch": "autonomous/dev"},
+    }))
+
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace",
+        lambda p, w: str(tmp_path / "ws"),
+    )
+
+    async def _fake_orchestrate(project, config, run_id, workspaces_dir):
+        return 0, None
+
+    monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda *a, **k: {
+            "verdicts": [
+                {
+                    "project": "owner/repo",
+                    "issue_number": 17,
+                    "verdict": "APPROVE_INTEGRATION",
+                    "branch": "autonomous/issue-17",
+                    "base_branch": "main",
+                    "reasoning": "tests pass",
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    captured: dict = {}
+
+    def _fake_execute(verdict, **kwargs):
+        captured["verdict"] = verdict
+        captured["kwargs"] = kwargs
+        from agent.verdict_execution import ExecutionResult
+        return ExecutionResult(
+            verdict=verdict.verdict, project=verdict.project,
+            issue_number=verdict.issue_number, success=True,
+        )
+
+    monkeypatch.setattr("agent.verdict_execution.execute", _fake_execute)
+
+    rc, _ = pl.iterate_projects("run-tested", str(cfg), str(tmp_path))
+
+    assert rc == 0, "happy-path verdict execution must not bump exit_code"
+    assert captured, "execute_verdict was never invoked"
+    kwargs = captured["kwargs"]
+    assert "workspace" in kwargs, (
+        f"execute_verdict must receive workspace=Path(...); got {list(kwargs)}"
+    )
+    assert isinstance(kwargs["workspace"], Path), (
+        f"workspace must be a Path; got {type(kwargs['workspace'])}"
+    )
+    assert kwargs.get("dev_branch") == "autonomous/dev", (
+        f"dev_branch must flow from config['integration']['dev_branch']; "
+        f"got {kwargs.get('dev_branch')!r}"
+    )
+    assert kwargs.get("run_id") == "run-tested"
+
+
+def test_iterate_projects_swallows_executor_exceptions_per_verdict(
+    tmp_path, monkeypatch,
+):
+    """One executor blowing up MUST NOT cancel the rest of the verdict
+    queue or kill the run. The pre-fix behavior let a TypeError on the
+    first APPROVE_INTEGRATION verdict propagate all the way out of
+    iterate_projects, marking the entire run failed and skipping every
+    remaining verdict. Per-verdict try/except keeps the queue draining.
+    """
+    from agent import project_loop as pl
+
+    cfg = tmp_path / "manager-config.json"
+    cfg.write_text(json.dumps({
+        "projects": [{"repo": "owner/repo", "enabled": True, "branch": "main"}],
+        "integration": {"dev_branch": "autonomous/dev"},
+    }))
+
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda p, w: str(tmp_path / "ws"),
+    )
+
+    async def _fake_orchestrate(*a, **k):
+        return 0, None
+
+    monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda *a, **k: {
+            "verdicts": [
+                {"project": "owner/repo", "issue_number": 1, "verdict": "APPROVE_INTEGRATION", "branch": "b1"},
+                {"project": "owner/repo", "issue_number": 2, "verdict": "APPROVE_INTEGRATION", "branch": "b2"},
+            ],
+        },
+    )
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    seen: list[int] = []
+
+    def _flaky_execute(verdict, **kwargs):
+        seen.append(verdict.issue_number)
+        if verdict.issue_number == 1:
+            raise RuntimeError("simulated executor crash")
+        from agent.verdict_execution import ExecutionResult
+        return ExecutionResult(verdict=verdict.verdict, project=verdict.project,
+                               issue_number=verdict.issue_number, success=True)
+
+    monkeypatch.setattr("agent.verdict_execution.execute", _flaky_execute)
+
+    rc, _ = pl.iterate_projects("run-flaky", str(cfg), str(tmp_path))
+
+    assert seen == [1, 2], (
+        f"loop must continue past the crash; saw issue numbers {seen}"
+    )
+    assert rc != 0, "executor failure should bump exit_code"


### PR DESCRIPTION
## Summary
Every `APPROVE_INTEGRATION` verdict (and `APPROVE` / `PR`) was silently failing because `project_loop` called the executor with **only** `run_id` — missing the `workspace` kwarg the executors require. Python raised `TypeError`, RunDriver's catch-all swallowed it, and the run was marked failed. **No PRs were ever being opened, even when the manager approved.**

## Live evidence
- `run-20260515T235612Z`: manager wrote 5× `APPROVE_INTEGRATION` to `/var/log/claude-agent/run-20260515T235612Z-verdicts.json`.
- Zero PRs appeared on `laboef1900/next-itsm` (latest PR there was 3 days old, well before this run).
- Final `runs` row: `status=failed`, telemetry zeroed by the error-path overwrite.
- Run survived 30 minutes (reaper bug from PRs #431/#432/#433 is fixed), reached the verdict step at ~22 minutes, then crashed silently on the very next line.

## Root cause
`agent/project_loop.py:241` was:
```python
execute_verdict(verdict, run_id=run_id)
```
`execute_approve_integration` (and APPROVE, PR) require `workspace: Path` as keyword-only with no default. → `TypeError: missing 1 required keyword-only argument: 'workspace'` → propagates → RunDriver catches → `status=error` → row marked `failed`.

The pre-existing test `test_execute_dispatcher_routes_approve_integration` already calls the executor correctly: `execute(verdict, workspace=workspace, dev_branch=\"dev\")`. So the executor side has always known the contract — `project_loop` just wasn't honoring it.

## Change
1. Capture `workspace_path` from `ensure_workspace()` return value (was being discarded).
2. Resolve `dev_branch` once per run from `config['integration']['dev_branch']` (consistent with `station_orchestrator`).
3. Pass `workspace=`, `env=os.environ.copy()`, `dev_branch=` to `execute_verdict`.
4. Wrap each call in `try/except` so one bad executor invocation can't cancel the rest of the verdict queue. Bumps `exit_code` to 7 (slot above 6 = no-verdicts).

Also fixes a latent secondary bug the TypeError mask was hiding: `Verdict.decision` doesn't exist — the field is `.verdict`. Changed `results.append({'decision': verdict.decision, ...})` to use `verdict.verdict`.

## Test plan
- [x] Backend suite green: 1440 passed (was 1438)
- [x] `test_iterate_projects_passes_workspace_and_dev_branch_to_executor`
- [x] `test_iterate_projects_swallows_executor_exceptions_per_verdict`
- [ ] Rebuild agent image, trigger a run, confirm a non-draft PR appears on `laboef1900/next-itsm` with `--auto --squash` armed

🤖 Generated with [Claude Code](https://claude.com/claude-code)