### PR TITLE
fix: periodic heartbeat events so the dashboard stale-run reaper sees liveness

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1276,6 +1276,20 @@ def _apply_controls(
             logger.warning("Mission Control: unknown action %r (id=%d)", action, row.id)
 
 
+# Interval between heartbeat webhook events. The dashboard's stale-run
+# reaper marks a ``running`` row ``interrupted`` if ``last_event_at`` is
+# older than 120s (services/stale_run_reaper.py). Agent Teams runs
+# legitimately go quiet for 2+ minutes during deep manager-review turns
+# on Sonnet 4.6; without an out-of-band heartbeat, those quiet windows
+# trip the reaper and the run is incorrectly marked interrupted even
+# though the container is healthy and emitting launcher ticks. Sending
+# a ``heartbeat`` webhook every ``HEARTBEAT_INTERVAL_SECONDS`` from the
+# control poll loop bumps ``last_event_at`` on the dashboard side so
+# the reaper only fires when the orchestrator is actually dead. Chosen
+# value gives us ~4 heartbeats per reaper window for fault tolerance.
+HEARTBEAT_INTERVAL_SECONDS = 30
+
+
 async def _control_poll_loop(
     full_run_id: str,
     config: dict,
@@ -1289,6 +1303,16 @@ async def _control_poll_loop(
     stream loop so operator interventions are picked up even when no SDK
     messages are flowing (long tool calls, idle waits, API stalls).
 
+    Also doubles as the heartbeat source: every
+    :data:`HEARTBEAT_INTERVAL_SECONDS` seconds the loop emits a
+    ``heartbeat`` webhook event so the dashboard's stale-run reaper
+    sees liveness during long quiet windows (long Sonnet manager-review
+    turns, in-flight tool calls, API stalls). Without this, the
+    dashboard reaper SIGTERM-equivalents the run by marking it
+    interrupted at the 120s ``last_event_at`` threshold even though
+    the container is fine. Sibling of the launcher's per-runner tick
+    heartbeat (#386) — same idea, different watchdog.
+
     Cancellation is the only way this coroutine exits — the caller cancels
     it in a ``finally:`` block when the run ends. We swallow CancelledError
     so the cleanup path doesn't log a traceback.
@@ -1299,14 +1323,30 @@ async def _control_poll_loop(
     more latency than it saves. If drain latency ever becomes a problem,
     switch to ``asyncio.to_thread``.
     """
-    logger.info("Mission Control: control poll task started for %s (interval=%.1fs)",
-                full_run_id, interval)
+    logger.info("Mission Control: control poll task started for %s (interval=%.1fs, heartbeat=%ds)",
+                full_run_id, interval, HEARTBEAT_INTERVAL_SECONDS)
+    last_heartbeat = 0.0
     try:
         while True:
             try:
                 _apply_controls(full_run_id, config, pending_messages, flags)
             except Exception as exc:  # pragma: no cover — never crash the poll loop
                 logger.warning("Mission Control: control poll tick failed: %s", exc)
+
+            # Heartbeat: best-effort, never raises, never blocks the
+            # control poll. Uses the event-loop clock (monotonic via
+            # ``asyncio.get_event_loop().time()``) so we don't drift if
+            # the system wall clock jumps.
+            now = asyncio.get_event_loop().time()
+            if now - last_heartbeat >= HEARTBEAT_INTERVAL_SECONDS:
+                try:
+                    await asyncio.to_thread(
+                        post_webhook, config, "heartbeat", {"run_id": full_run_id},
+                    )
+                except Exception as exc:  # pragma: no cover — best-effort
+                    logger.debug("heartbeat post failed (non-fatal): %s", exc)
+                last_heartbeat = now
+
             # Exit fast once stop is latched so the stream loop doesn't have
             # to wait a full tick for the task to notice.
             if flags.get("stop"):

--- a/dashboard/backend/app/routers/webhook.py
+++ b/dashboard/backend/app/routers/webhook.py
@@ -96,7 +96,18 @@ async def receive_run_event(
 
     # ---- Dispatch to appropriate handler ----
 
-    if event_name == "verdict":
+    # ``heartbeat`` is a liveness-only event from the orchestrator's
+    # control poll loop (agent/station_orchestrator.py). Its sole
+    # purpose is to bump ``last_event_at`` above so the dashboard's
+    # stale-run reaper doesn't mark a healthy run as ``interrupted``
+    # during legitimate long-Sonnet-turn quiet windows. No state
+    # transition; explicit branch so future devs don't accidentally
+    # route it through ``handle_unknown`` (which mutates ``run.status``
+    # if the event happens to carry one).
+    if event_name == "heartbeat":
+        pass
+
+    elif event_name == "verdict":
         run, _ = await run_lifecycle.handle_verdict(db, event, project_id, run)
 
     elif event_name in _RUN_HANDLERS:
@@ -305,5 +316,6 @@ def _normalize_event_name(event_name: str) -> str:
         "team_cleanup": "team_cleanup",
         "progress_update": "progress_update",
         "vision_misalignment": "vision_misalignment",
+        "heartbeat": "heartbeat",
     }
     return mapping.get(event_name, event_name)

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -1606,3 +1606,133 @@ def test_launcher_does_not_set_stream_close_timeout_in_run_env():
         "(issue #392). Move the setter into the module that owns the "
         "surviving query() call."
     )
+
+
+@pytest.mark.asyncio
+async def test_control_poll_loop_emits_periodic_heartbeats(tmp_path, monkeypatch):
+    """The control poll loop MUST emit a ``heartbeat`` webhook on its
+    own cadence so the dashboard's stale-run reaper sees liveness
+    during long quiet windows. Without this, the reaper marks any
+    ``running`` row ``interrupted`` after 120s of webhook silence —
+    a window an Agent Teams Sonnet manager-review turn easily exceeds.
+
+    Regression guard for run-20260516T005654Z: the run flipped to
+    ``interrupted`` at t=605s while the container was healthy and
+    still emitting launcher ticks. The dashboard reaper had a
+    different signal (``last_event_at``) that no one was feeding.
+    """
+    import asyncio
+    import sqlite3
+
+    from agent import station_orchestrator
+
+    # Minimal sqlite for the control drain.
+    db = tmp_path / "hb.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE run_controls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          run_id TEXT, action TEXT, payload TEXT, requested_by TEXT,
+          requested_at TEXT, consumed_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    monkeypatch.setenv("STATION_DB_PATH", str(db))
+
+    # Spy on post_webhook so we can count heartbeats.
+    captured: list[tuple[str, dict]] = []
+
+    def _spy(config, event, data=None):
+        captured.append((event, data or {}))
+
+    monkeypatch.setattr(station_orchestrator, "post_webhook", _spy)
+    # Shrink the heartbeat interval so the test runs in fractions of a
+    # second. The default is 30s; we want ~3 heartbeats in 0.4s.
+    monkeypatch.setattr(station_orchestrator, "HEARTBEAT_INTERVAL_SECONDS", 0.1)
+
+    flags = {"stop": False}
+    task = asyncio.create_task(
+        station_orchestrator._control_poll_loop(
+            "run-hb-test", {}, [], flags, interval=0.02,
+        )
+    )
+
+    try:
+        await asyncio.sleep(0.4)
+    finally:
+        flags["stop"] = True
+        try:
+            await asyncio.wait_for(task, timeout=1.0)
+        except asyncio.TimeoutError:
+            task.cancel()
+
+    heartbeats = [d for (ev, d) in captured if ev == "heartbeat"]
+    assert len(heartbeats) >= 3, (
+        f"expected ≥3 heartbeats in 0.4s with interval=0.1s; "
+        f"got {len(heartbeats)}: {captured}"
+    )
+    for d in heartbeats:
+        assert d.get("run_id") == "run-hb-test", (
+            f"heartbeat payload must carry the full_run_id; got {d}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_control_poll_loop_heartbeat_is_best_effort(tmp_path, monkeypatch):
+    """A failing post_webhook (dashboard down, network error) MUST NOT
+    crash the control poll loop. Heartbeats are diagnostic, not
+    load-bearing — losing one is acceptable; killing the loop is not.
+    """
+    import asyncio
+    import sqlite3
+
+    from agent import station_orchestrator
+
+    db = tmp_path / "hb-fail.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        """
+        CREATE TABLE run_controls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          run_id TEXT, action TEXT, payload TEXT, requested_by TEXT,
+          requested_at TEXT, consumed_at TEXT
+        )
+        """
+    )
+    conn.commit()
+    monkeypatch.setenv("STATION_DB_PATH", str(db))
+
+    call_count = {"n": 0}
+
+    def _boom(config, event, data=None):
+        call_count["n"] += 1
+        raise RuntimeError("simulated dashboard outage")
+
+    monkeypatch.setattr(station_orchestrator, "post_webhook", _boom)
+    monkeypatch.setattr(station_orchestrator, "HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+    flags = {"stop": False}
+    task = asyncio.create_task(
+        station_orchestrator._control_poll_loop(
+            "run-hb-fail", {}, [], flags, interval=0.02,
+        )
+    )
+
+    try:
+        await asyncio.sleep(0.25)
+        # Loop must still be running despite repeated post_webhook crashes.
+        assert not task.done(), (
+            f"control poll loop crashed on heartbeat failure; "
+            f"exception: {task.exception() if task.done() else None}"
+        )
+        assert call_count["n"] >= 2, (
+            f"heartbeat must be attempted repeatedly; got {call_count['n']}"
+        )
+    finally:
+        flags["stop"] = True
+        try:
+            await asyncio.wait_for(task, timeout=1.0)
+        except asyncio.TimeoutError:
+            task.cancel()

--- a/dashboard/backend/tests/test_webhook_heartbeat.py
+++ b/dashboard/backend/tests/test_webhook_heartbeat.py
@@ -1,0 +1,129 @@
+"""Tests for the ``heartbeat`` webhook event handler.
+
+Heartbeat events are emitted by the orchestrator's control poll loop
+(agent/station_orchestrator._control_poll_loop) every 30s so the
+dashboard's stale-run reaper sees liveness during long quiet windows.
+
+Without them, an Agent Teams run with a Sonnet 4.6 manager-review turn
+that takes 90-120s would be marked ``interrupted`` even though it's
+healthy. Regression guards for run-20260516T005654Z post-mortem.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from app.database import Base, async_session, engine
+from app.main import app
+from app.models import Run
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+def test_heartbeat_is_recognized_by_normalizer():
+    """``heartbeat`` must be in the recognized event mapping so it
+    doesn't fall through to ``handle_unknown`` (which mutates
+    ``run.status`` if the event carries one)."""
+    from app.routers.webhook import _normalize_event_name
+    assert _normalize_event_name("heartbeat") == "heartbeat"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_bumps_last_event_at(client):
+    """A heartbeat for a known run row must update ``last_event_at`` so
+    the stale-run reaper sees liveness, without changing ``status``."""
+    stale = datetime.now(timezone.utc) - timedelta(seconds=300)
+    async with async_session() as db:
+        db.add(Run(
+            run_id="run-hb-1",
+            status="running",
+            started_at=stale,
+            last_event_at=stale,
+        ))
+        await db.commit()
+
+    response = await client.post(
+        "/api/webhook/run-event",
+        json={"event": "heartbeat", "run_id": "run-hb-1"},
+    )
+    assert response.status_code == 200, response.text
+
+    async with async_session() as db:
+        from sqlalchemy import select
+        row = (await db.execute(select(Run).where(Run.run_id == "run-hb-1"))).scalar_one()
+        assert row.status == "running", (
+            f"heartbeat must not change status; got {row.status!r}"
+        )
+        assert row.last_event_at is not None
+        # SQLite drops tzinfo on round-trip; compare naive-to-naive.
+        row_naive = row.last_event_at.replace(tzinfo=None) if row.last_event_at.tzinfo else row.last_event_at
+        stale_naive = stale.replace(tzinfo=None)
+        assert row_naive > stale_naive, (
+            "heartbeat must bump last_event_at past the stale value"
+        )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_does_not_resurrect_terminal_run(client):
+    """Edge case: a heartbeat arriving after a run has already finished
+    must not bump it back to running. Status preservation: heartbeat
+    only bumps ``last_event_at``, never mutates ``status``."""
+    now = datetime.now(timezone.utc)
+    async with async_session() as db:
+        db.add(Run(
+            run_id="run-hb-done",
+            status="completed",
+            started_at=now - timedelta(minutes=30),
+            finished_at=now - timedelta(minutes=1),
+            last_event_at=now - timedelta(minutes=1),
+        ))
+        await db.commit()
+
+    response = await client.post(
+        "/api/webhook/run-event",
+        json={"event": "heartbeat", "run_id": "run-hb-done"},
+    )
+    assert response.status_code == 200
+
+    async with async_session() as db:
+        from sqlalchemy import select
+        row = (await db.execute(select(Run).where(Run.run_id == "run-hb-done"))).scalar_one()
+        assert row.status == "completed", (
+            f"terminal status must survive a stray heartbeat; got {row.status!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_for_unknown_run_id_is_a_no_op(client):
+    """A heartbeat for a run_id that doesn't exist yet (orchestrator
+    mid-spawn) must not crash and must not create a phantom row."""
+    response = await client.post(
+        "/api/webhook/run-event",
+        json={"event": "heartbeat", "run_id": "run-doesnt-exist"},
+    )
+    assert response.status_code == 200, response.text
+
+    async with async_session() as db:
+        from sqlalchemy import select
+        rows = (await db.execute(select(Run).where(Run.run_id == "run-doesnt-exist"))).all()
+        assert rows == [], (
+            "heartbeat must not create a phantom run row when no row exists yet"
+        )


### PR DESCRIPTION
## Summary
Adds a periodic `heartbeat` webhook event (every 30s) from the orchestrator's control poll loop so the dashboard's stale-run reaper sees liveness during long quiet windows. Mirrors the launcher's `/webhook-tick` heartbeat fixed in PRs #431/#432/#433 — same idea, different watchdog.

## Why
`services/stale_run_reaper.py` marks any `running` row as `interrupted` when `last_event_at` is older than **120s**. An Agent Teams run with a Sonnet 4.6 manager-review turn easily exceeds that during normal operation. Result: healthy runs marked `interrupted` mid-flight.

Live evidence: `run-20260516T005654Z` flipped to `interrupted` at t=605s (10 min in) while the container kept working for another 28 minutes and ultimately reached a `SKIP` verdict.

The launcher container reaper got its heartbeat fix in #431/#432/#433. The dashboard reaper had no equivalent — `last_event_at` is only bumped by full webhook POSTs to `/api/webhook/run-event`, and a multi-minute Sonnet round-trip produces no such posts.

## Change
**Agent side** (`agent/station_orchestrator.py`):
- New constant `HEARTBEAT_INTERVAL_SECONDS = 30`
- `_control_poll_loop` now emits a `heartbeat` event via `post_webhook` every 30s (~4 per reaper window for fault tolerance)
- Failures are best-effort and swallowed — a RuntimeError from `post_webhook` must not crash the poll loop, because operators depend on it for stop/pause

**Dashboard side** (`dashboard/backend/app/routers/webhook.py`):
- `heartbeat` added to the `_normalize_event_name` mapping
- Explicit dispatcher branch: `heartbeat` is a no-op whose sole purpose is to let the unconditional `last_event_at` bump (already there at line 91) fire — no status mutation, no side effects

## Test plan
- [x] Backend suite green: 1446 passed (was 1440)
- [x] `test_control_poll_loop_emits_periodic_heartbeats` (interval=0.1s → ≥3 heartbeats in 0.4s)
- [x] `test_control_poll_loop_heartbeat_is_best_effort` (post_webhook failure doesn't kill the loop)
- [x] `test_heartbeat_is_recognized_by_normalizer`
- [x] `test_heartbeat_bumps_last_event_at` (stale row gets its timestamp advanced)
- [x] `test_heartbeat_does_not_resurrect_terminal_run` (no status mutation)
- [x] `test_heartbeat_for_unknown_run_id_is_a_no_op` (no phantom row when row doesn't exist yet)
- [ ] Rebuild agent image and trigger a run; verify the run no longer flips to `interrupted` during long Sonnet manager-review turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)