### PR TITLE
fix(verdict_execution): accept dev_branch in every executor — APPROVE was failing silently

### DIFF
--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -127,8 +127,15 @@ def execute_approve(
     workspace: Path,
     run_id: str | None = None,
     env: dict[str, str] | None = None,
+    dev_branch: str | None = None,  # noqa: ARG001 — kept for dispatcher symmetry
 ) -> ExecutionResult:
     """Push the branch, open a PR, comment on the issue.
+
+    ``dev_branch`` is accepted but ignored — the dispatcher passes the
+    same kwargs to every executor, and only ``execute_approve_integration``
+    consumes it. Without the parameter here, the dispatcher's blind
+    ``**kwargs`` passthrough raises TypeError and every APPROVE silently
+    failed before this fix.
 
     Does NOT auto-merge, does NOT close the issue — those decisions live
     in the bash path that consumes this module (deferred follow-up).
@@ -183,6 +190,7 @@ def execute_pr(
     run_id: str | None = None,
     env: dict[str, str] | None = None,
     draft: bool = True,
+    dev_branch: str | None = None,  # noqa: ARG001 — dispatcher symmetry; see execute_approve
 ) -> ExecutionResult:
     """Open a draft PR (or marked-ready) for manual review. Same path as
     APPROVE but with ``--draft`` and a different issue comment.
@@ -236,6 +244,7 @@ def execute_reject(
     workspace: Path | None = None,  # noqa: ARG001 — unused, kept for caller symmetry
     run_id: str | None = None,
     env: dict[str, str] | None = None,
+    dev_branch: str | None = None,  # noqa: ARG001 — dispatcher symmetry; see execute_approve
 ) -> ExecutionResult:
     """Comment on the issue and apply the reject label. No branch
     operations — the feature branch stays local for the operator to
@@ -278,6 +287,7 @@ def execute_skip(
     workspace: Path | None = None,  # noqa: ARG001 — kept for symmetry
     run_id: str | None = None,
     env: dict[str, str] | None = None,
+    dev_branch: str | None = None,  # noqa: ARG001 — dispatcher symmetry; see execute_approve
 ) -> ExecutionResult:
     """SKIP is observably similar to REJECT but with a kinder message
     (the manager chose not to act this cycle, not that the work was bad).

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -12,6 +12,8 @@ integration branch with auto-merge armed, CI gates the merge.
 
 from __future__ import annotations
 
+import pytest
+
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -505,5 +507,49 @@ def test_execute_dispatcher_forwards_dev_branch_kwarg(tmp_path):
         execute(verdict, workspace=workspace, dev_branch="dev")
     _, kwargs = mock_fn.call_args
     assert kwargs.get("dev_branch") == "dev"
+
+
+@pytest.mark.parametrize("verdict_kind", ["APPROVE", "PR", "REJECT", "SKIP"])
+def test_every_executor_accepts_dev_branch_kwarg(verdict_kind, tmp_path, monkeypatch):
+    """Regression: ``execute()`` dispatches via blind ``**kwargs``, so
+    EVERY executor must accept ``dev_branch`` (only execute_approve_integration
+    actually consumes it). Without this, an APPROVE verdict raises
+    TypeError('execute_approve() got an unexpected keyword argument
+    "dev_branch"'), the verdict-execution wrapper catches and bumps
+    exit_code, the run is marked failed, and no PR ever opens.
+
+    Live evidence: run-20260516T090429Z, digest line:
+        execute_verdict: TypeError: execute_approve() got an
+        unexpected keyword argument 'dev_branch'
+
+    Caller (agent/project_loop.py) passes dev_branch to every verdict
+    uniformly because the dispatcher demands it for APPROVE_INTEGRATION;
+    making every executor accept-and-ignore is the kw-symmetry approach.
+    """
+    from unittest.mock import patch
+    from agent.verdict_execution import execute, Verdict
+    # Stub out the per-executor side effects so we just exercise signatures.
+    monkeypatch.setattr("agent.verdict_execution.subprocess.run",
+                        lambda *a, **kw: type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})())
+    monkeypatch.setattr("agent.verdict_execution.gh_run",
+                        lambda *a, **kw: type("R", (), {"ok": True, "stdout": "", "stderr": ""})())
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    verdict = Verdict(
+        project="owner/repo",
+        issue_number=42,
+        verdict=verdict_kind,
+        branch="autonomous/issue-42",
+    )
+    # MUST NOT raise TypeError
+    result = execute(
+        verdict,
+        workspace=workspace,
+        run_id="run-test",
+        env={"GH_TOKEN": "test"},
+        dev_branch="autonomous/dev",
+    )
+    # Whatever the executor returns, the call itself was valid.
+    assert result is not None, f"{verdict_kind} executor returned None"
 
 


### PR DESCRIPTION
## Summary
PR #435 made `project_loop` pass `dev_branch` uniformly to every `execute_verdict` call. But the dispatcher passes `**kwargs` through blindly, and `execute_approve` / `execute_pr` / `execute_reject` / `execute_skip` never declared `dev_branch`. Result: every APPROVE / PR / REJECT / SKIP verdict raised `TypeError: unexpected keyword argument 'dev_branch'`, the project_loop try/except caught it, exit_code went to 7, the run was marked `failed`, and no PR was opened.

## Live evidence
`run-20260516T090429Z` digest:
```
### laboef1900/next-itsm
- #27 — ERROR — execute_verdict: TypeError: execute_approve() got an unexpected keyword argument 'dev_branch'
- #27 — ERROR — execute_verdict: TypeError: execute_approve() got an unexpected keyword argument 'dev_branch'
- #27 — ERROR — execute_verdict: TypeError: execute_approve() got an unexpected keyword argument 'dev_branch'
```
Verdict file held a valid `APPROVE` with `push_approved: true`, but zero PRs landed on `laboef1900/next-itsm`.

## Change
Every non-INTEGRATION executor now accepts `dev_branch: str | None = None` and ignores it (`noqa: ARG001`). Dispatcher symmetry: the alternative — filtering kwargs at the call site — would couple `project_loop` to per-executor signatures, and a fourth executor adding a new kwarg would break the abstraction again.

## Test plan
- [x] Backend suite green: 1444 passed (was 1440)
- [x] Parametrized regression `test_every_executor_accepts_dev_branch_kwarg` over `APPROVE / PR / REJECT / SKIP`
- [ ] Rebuild agent + trigger; confirm an APPROVE verdict produces a real PR on the target repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)