### PR TITLE
fix(run_lifecycle): make progress_update telemetry monotonic (#434)

### DIFF
--- a/dashboard/backend/app/services/run_lifecycle.py
+++ b/dashboard/backend/app/services/run_lifecycle.py
@@ -322,15 +322,26 @@ async def handle_plan_review_done(
 
 
 async def handle_progress_update(run: Run, event: WebhookRunEvent) -> None:
-    """Update token/turn counts without changing run status."""
+    """Update token/turn counts without changing run status.
+
+    Telemetry is **monotonic**: we only ever ratchet these counters upward.
+    Two distinct emitters write ``progress_update`` against the same ``runs``
+    row — the orchestrator's outer cumulative counters and per-teammate
+    ``teammate_progress`` events scoped to a single task_id. The teammate
+    stream can legitimately carry 0 at the start of a fresh teammate cycle,
+    which would otherwise clobber the cumulative value and produce the
+    0↔N oscillation described in issue #434. Taking ``max(existing, incoming)``
+    mirrors what ``coordinator_service`` already does for ``CoordinatorTask``
+    and ensures the dashboard never regresses while a run is alive.
+    """
     if event.tokens_input is not None:
-        run.tokens_input = event.tokens_input
+        run.tokens_input = max(run.tokens_input or 0, event.tokens_input)
     if event.tokens_output is not None:
-        run.tokens_output = event.tokens_output
+        run.tokens_output = max(run.tokens_output or 0, event.tokens_output)
     if event.tokens_total is not None:
-        run.tokens_total = event.tokens_total
+        run.tokens_total = max(run.tokens_total or 0, event.tokens_total)
     if event.turns is not None:
-        run.turns = event.turns
+        run.turns = max(run.turns or 0, event.turns)
 
 
 async def handle_teammate_completed(run: Run, event: WebhookRunEvent) -> None:

--- a/dashboard/backend/tests/test_run_lifecycle_progress_monotonic.py
+++ b/dashboard/backend/tests/test_run_lifecycle_progress_monotonic.py
@@ -1,0 +1,131 @@
+"""Regression tests for issue #434 — telemetry oscillation.
+
+Two distinct emitters write ``progress_update`` against the same ``runs`` row:
+
+1. The orchestrator's outer counters, cumulative across all teammates.
+2. ``teammate_progress`` events, scoped to a single ``task_id`` — these can
+   legitimately carry 0 at the start of a new teammate cycle.
+
+Both flow through ``handle_progress_update``. Before the fix, whichever event
+fired last overwrote the row, so ``runs.turns`` (and the token fields) would
+oscillate between a high value and 0 on every webhook tick.
+
+The fix makes ``handle_progress_update`` monotonic — it only ever ratchets
+counters upward, mirroring what ``coordinator_service`` does for
+``CoordinatorTask`` rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models import Run
+from app.schemas import WebhookRunEvent
+from app.services.run_lifecycle import handle_progress_update
+
+
+def _make_event(**kwargs) -> WebhookRunEvent:
+    """Build a minimal progress_update event with optional telemetry fields."""
+    base = {
+        "run_id": "run-monotonic-test",
+        "event": "progress_update",
+    }
+    base.update(kwargs)
+    return WebhookRunEvent(**base)
+
+
+@pytest.mark.asyncio
+async def test_progress_update_does_not_regress_turns() -> None:
+    """A low turns value must not clobber an already-recorded high value."""
+    run = Run(run_id="run-monotonic-test", status="running")
+
+    await handle_progress_update(run, _make_event(turns=42))
+    assert run.turns == 42
+
+    # Per-teammate event arrives carrying turns=0 (fresh cycle start).
+    await handle_progress_update(run, _make_event(turns=0))
+    assert run.turns == 42, "turns regressed — telemetry should be monotonic"
+
+
+@pytest.mark.asyncio
+async def test_progress_update_does_not_regress_tokens() -> None:
+    """All three token fields must also be monotonic."""
+    run = Run(run_id="run-monotonic-test", status="running")
+
+    await handle_progress_update(
+        run,
+        _make_event(
+            tokens_input=1000,
+            tokens_output=500,
+            tokens_total=1500,
+            turns=10,
+        ),
+    )
+    assert run.tokens_input == 1000
+    assert run.tokens_output == 500
+    assert run.tokens_total == 1500
+    assert run.turns == 10
+
+    # Lower-valued progress_update (e.g. from a freshly-spawned teammate).
+    await handle_progress_update(
+        run,
+        _make_event(
+            tokens_input=0,
+            tokens_output=0,
+            tokens_total=0,
+            turns=0,
+        ),
+    )
+    assert run.tokens_input == 1000
+    assert run.tokens_output == 500
+    assert run.tokens_total == 1500
+    assert run.turns == 10
+
+
+@pytest.mark.asyncio
+async def test_progress_update_advances_on_higher_values() -> None:
+    """The monotonic guard must still let counters move forward."""
+    run = Run(run_id="run-monotonic-test", status="running")
+
+    await handle_progress_update(run, _make_event(turns=5, tokens_total=100))
+    assert run.turns == 5
+    assert run.tokens_total == 100
+
+    await handle_progress_update(run, _make_event(turns=12, tokens_total=750))
+    assert run.turns == 12
+    assert run.tokens_total == 750
+
+
+@pytest.mark.asyncio
+async def test_progress_update_with_none_existing_handles_fresh_run() -> None:
+    """First event against a brand-new run (all counters are NULL) populates them."""
+    run = Run(run_id="run-monotonic-test", status="running")
+    # Sanity: SQLAlchemy hasn't materialised defaults — fields are None.
+    assert run.turns is None
+    assert run.tokens_total is None
+
+    await handle_progress_update(
+        run,
+        _make_event(turns=7, tokens_input=300, tokens_output=200, tokens_total=500),
+    )
+    assert run.turns == 7
+    assert run.tokens_input == 300
+    assert run.tokens_output == 200
+    assert run.tokens_total == 500
+
+
+@pytest.mark.asyncio
+async def test_progress_update_ignores_absent_fields() -> None:
+    """Events that omit a field entirely must not touch the existing value."""
+    run = Run(
+        run_id="run-monotonic-test",
+        status="running",
+        turns=20,
+        tokens_total=999,
+    )
+
+    # Event only carries tokens_input — turns/tokens_total must stay put.
+    await handle_progress_update(run, _make_event(tokens_input=50))
+    assert run.turns == 20
+    assert run.tokens_total == 999
+    assert run.tokens_input == 50


### PR DESCRIPTION
## Summary

Fix the `runs.turns` 0↔N oscillation reported in #434 by making `handle_progress_update` monotonic — counters can only ratchet upward while a run is alive.

## Regression mechanism

`dashboard/backend/app/services/run_lifecycle.py:handle_progress_update` is fed by two distinct emitters that share one `runs` row:

1. **Orchestrator outer counters** — cumulative across all teammates (real `turns` value).
2. **`teammate_progress` events** — per-teammate, scoped to one `task_id`; legitimately carry `0` at the start of a fresh teammate's cycle.

The previous code did a direct assignment guarded only by `is not None`, so whichever event fired last won. A teammate event carrying `turns=0` would clobber the cumulative value, the next outer-counter event would restore it, and so on every webhook tick — visible in the dashboard as `turns` flipping between a high value and 0.

The fix replaces direct assignment with `max(run.<field> or 0, event.<field>)` for `turns`, `tokens_input`, `tokens_output`, and `tokens_total`. This mirrors what `services/coordinator_service.py` already does for `CoordinatorTask` rows and makes telemetry monotonic.

If a downstream code path ever needs to *reset* these counters (e.g. on retry), it must do so explicitly — `handle_progress_update` is no longer a viable channel for regression. No other call site currently depends on that behaviour.

Closes #434

## Test plan

- [x] New test file `dashboard/backend/tests/test_run_lifecycle_progress_monotonic.py` with 5 cases:
  - [x] `turns=42` then `turns=0` → row keeps `42`
  - [x] high token+turn values then all-zero event → row keeps the highs
  - [x] monotonic guard still lets higher values advance the counters
  - [x] fresh run (NULL counters) is populated correctly on first event
  - [x] events that omit a field leave the existing value untouched
- [x] `pytest tests/test_run_lifecycle_progress_monotonic.py tests/test_run_lifecycle_safe_repo.py` → 19 passed
- [x] `pytest tests/test_webhook.py tests/test_webhook_contracts.py` → 74 passed, 41 skipped (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)