### PR TITLE
docs(architecture): document manager paths sidecar contract (#411)

### DIFF
--- a/agent/agents/manager.md
+++ b/agent/agents/manager.md
@@ -15,7 +15,7 @@ model: claude-sonnet-4-6
 # meaningfully reducing blast radius.
 permissionMode: bypassPermissions
 # maxTurns is the SDK-side enforcement ceiling. Keep in lockstep with
-# ``config.limits.max_manager_turns`` (default 60); the prompt-side
+# ``config.limits.max_manager_turns`` (default 30); the prompt-side
 # budget is injected dynamically by ``build_team_prompt``.
 maxTurns: 60
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,6 +313,36 @@ review-criteria branching.
 - **`triage`** — issue classification and labeling without implementation (legacy).
 - **`review`** — security or code review mode for pull requests (legacy).
 
+#### Manager paths sidecar (`.claude-manager-paths.json`, #411)
+
+The orchestrator writes a structured JSON sidecar to the per-project
+workspace root **before** the lead's first turn. The manager sibling
+`Read`s this file on its first turn to discover its review-package and
+verdicts-file paths instead of parsing them out of the lead's spawn-prompt
+markdown — eliminating the path-drift failure mode that previously could
+send the manager's verdicts write to a wrong path and silently lose every
+teammate's work for the run.
+
+| Field | Type | Source |
+|---|---|---|
+| `review_package` | absolute path string | `<log_dir>/run-<id>-review.md` (orchestrator-owned) |
+| `verdicts_file` | absolute path string | `<log_dir>/run-<id>-verdicts.json` (orchestrator-owned) |
+| `hard_deadline_turns` | int | `config.limits.max_manager_turns` (default 60) |
+| `soft_deadline_turns` | int | `max(1, hard_deadline_turns // 2)` |
+
+The sidecar is workspace-scoped because the manager sibling's CWD inside
+the SDK session is the workspace. The lead's spawn-prompt instructs the
+manager to `Read .claude-manager-paths.json` first and does **not**
+interpolate the paths into the prose; `agent/agents/manager.md` `<context>`
+mirrors the contract on the manager side. If the sidecar is missing or
+unparseable the manager refuses to guess paths — the orchestrator's
+`manager_no_verdicts` webhook + `exit_code=6` path then fires and surfaces
+the failure for triage.
+
+See `_write_manager_paths_sidecar` in `agent/station_orchestrator.py` and
+the `# --- #411` test block in
+`dashboard/backend/tests/test_manager_sibling.py`.
+
 ### Plan-review gate
 
 The `plan_only` mode adds a manual checkpoint between plan-writing and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -327,7 +327,7 @@ teammate's work for the run.
 |---|---|---|
 | `review_package` | absolute path string | `<log_dir>/run-<id>-review.md` (orchestrator-owned) |
 | `verdicts_file` | absolute path string | `<log_dir>/run-<id>-verdicts.json` (orchestrator-owned) |
-| `hard_deadline_turns` | int | `config.limits.max_manager_turns` (default 60) |
+| `hard_deadline_turns` | int | `config.limits.max_manager_turns` (default 30; SDK frontmatter ceiling is 60) |
 | `soft_deadline_turns` | int | `max(1, hard_deadline_turns // 2)` |
 
 The sidecar is workspace-scoped because the manager sibling's CWD inside


### PR DESCRIPTION
## Summary

Issue #411 — replacing the markdown-prompt path injection with a structured sidecar mechanism — was already implemented on `origin/dev` via commit `6a3ef29` ("feat(orchestrator): structured sidecar replaces markdown-prompt path injection") and follow-up `1d38281`. The code, agent definition, and 5 dedicated tests are in place and passing (21/21 in `dashboard/backend/tests/test_manager_sibling.py`). The issue remained OPEN on GitHub because the original commit was pushed direct rather than via a PR with a `Closes #411` footer.

This PR adds the missing piece: documentation of the new on-disk contract in `docs/architecture.md`. Project rule: drifted docs are a defect.

## What changed

- **`docs/architecture.md`** — new "Manager paths sidecar (`.claude-manager-paths.json`, #411)" subsection under Run-level run kinds covering:
  - The full schema (`review_package`, `verdicts_file`, `hard_deadline_turns`, `soft_deadline_turns`) as a table.
  - Where the orchestrator writes it (workspace root, before the lead's first turn).
  - Why it is workspace-scoped (manager sibling's CWD inside the SDK session is the workspace).
  - How the manager Reads it (per `agent/agents/manager.md` `<context>`) instead of parsing the spawn-prompt markdown.
  - The failure mode if the sidecar is missing or unparseable: `manager_no_verdicts` webhook + `exit_code=6` for triage — no silent guessing.
  - Cross-references to `_write_manager_paths_sidecar` in `agent/station_orchestrator.py` and the `# --- #411` test block.

## Sidecar schema (for reference)

```json
{
  "review_package": "/var/log/.../run-<id>-review.md",
  "verdicts_file":  "/var/log/.../run-<id>-verdicts.json",
  "hard_deadline_turns": 60,
  "soft_deadline_turns": 30
}
```

## Test plan

- [x] `python -m pytest dashboard/backend/tests/test_manager_sibling.py` — 21 passed (including the 5 `#411` tests:
  - `test_write_manager_paths_sidecar_writes_complete_payload`
  - `test_write_manager_paths_sidecar_lands_in_workspace`
  - `test_write_manager_paths_sidecar_clamps_soft_deadline_floor`
  - `test_lead_prompt_does_not_interpolate_verdicts_path_into_spawn_block`
  - `test_manager_md_instructs_sibling_to_read_sidecar`)
- [x] No code changes — docs-only PR.
- [ ] Render `docs/architecture.md` in a Markdown viewer to confirm the new subsection sits cleanly between the run-kinds list and the Plan-review gate section (table renders, anchor `manager-paths-sidecar-claude-manager-paths-json-411` resolves).

Closes #411
Refs #390 #409