### PR TITLE
test(orchestrator): re-add Python-level contracts for mode-headers + plan-review (#406)

### DIFF
--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -920,17 +920,15 @@ def test_review_package_emits_mode_header(tmp_path, mode, expected_header):
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "Contract from issue #406: iterate_projects must emit "
-        "plan_review_start for plan_only projects during the manager-"
-        "review window. The bash run-manager.sh emitted this via "
-        "webhook_event before run_manager_review; the Python port in "
-        "agent/project_loop.py (PR #405) does NOT yet emit it. Wiring "
-        "this requires adding a call to agent.webhook_emitter.emit "
-        "before orchestrate_project for plan_only projects — see "
-        "agent/plan_review_gate.py docstring lines 506-511 which still "
-        "reference the dropped emission. Re-pinning the contract here "
-        "as xfail(strict=True) so it flips to pass once a follow-up PR "
-        "adds the emission."
+        "iterate_projects no longer emits plan_review_start — see #442. "
+        "Contract from issue #406: a plan_only project must emit "
+        "plan_review_start during the manager-review window. The bash "
+        "run-manager.sh did this via webhook_event before "
+        "run_manager_review; the Python port in agent/project_loop.py "
+        "(PR #405) dropped the emission. Wiring is tracked in #442; "
+        "agent/plan_review_gate.py docstring lines 506-511 still "
+        "reference the dropped emission. Re-pinning here as "
+        "xfail(strict=True) so it flips to pass once #442 lands."
     ),
 )
 def test_iterate_projects_emits_plan_review_start_for_plan_only(
@@ -997,16 +995,16 @@ def test_iterate_projects_emits_plan_review_start_for_plan_only(
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "Contract from issue #406: iterate_projects must invoke "
+        "iterate_projects no longer invokes apply_plan_review_gate — "
+        "see #442. Contract from issue #406: iterate_projects must call "
         "agent.plan_review_gate.apply_plan_review_gate for every "
         "plan_only project after the manager's verdicts file is read. "
-        "The bash run-manager.sh invoked `python -m "
-        "agent.plan_review_gate` between execute_verdicts and the next "
-        "project; the Python port in agent/project_loop.py (PR #405) "
-        "does NOT call it. Without this wiring the APPROVE_PLAN / "
-        "REVISE_PLAN / REJECT_PLAN follow-up paths are dead code. "
-        "Re-pinning the contract here as xfail(strict=True) so it flips "
-        "to pass once a follow-up PR adds the call."
+        "The bash run-manager.sh ran `python -m agent.plan_review_gate` "
+        "between execute_verdicts and the next project; the Python port "
+        "in agent/project_loop.py (PR #405) dropped the invocation. "
+        "Without this wiring the APPROVE_PLAN / REVISE_PLAN / "
+        "REJECT_PLAN follow-up paths are dead code. Re-pinning here as "
+        "xfail(strict=True) so it flips to pass once #442 lands."
     ),
 )
 def test_iterate_projects_invokes_plan_review_gate_for_plan_only(
@@ -1078,8 +1076,15 @@ def test_iterate_projects_invokes_plan_review_gate_for_plan_only(
     # caller passes the bare id, so wiring must add the prefix back —
     # this is the same contract enforced by #432/#433.
     rid = call.get("run_id", "")
+    # Tightened post-#432/#433: the gate's run_id arg MUST carry the
+    # ``run-`` prefix so the dashboard webhook handler can correlate. A
+    # loose substring check would silently accept ``gate-test`` even if
+    # the wiring forgot to prefix.
+    assert rid.startswith("run-"), (
+        f"gate must receive a prefixed run id (post-#432/#433); got {rid!r}"
+    )
     assert "gate-test" in rid, (
-        f"gate must receive the run id; got {rid!r}"
+        f"gate must receive the run id seeded by the test; got {rid!r}"
     )
 
 

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -852,7 +852,235 @@ def test_get_plan_revision_max_invalid_falls_back(monkeypatch):
 
 
 # --- Manager review package: MODE: header (issue #266) ---------------------
+#
+# These three tests re-pin the contracts that were dropped along with
+# ``run-manager.sh`` in PR #405 (issue #383). The bash-era tests asserted
+# that the shell driver emitted the right ``MODE:`` headers, the
+# ``plan_review_start`` webhook, and invoked ``python -m
+# agent.plan_review_gate``. Those tests used ``read_text()`` on the now-
+# deleted script. The behaviours still apply to the Python composition
+# (issue #406): every project mode must surface in the manager's review
+# package, ``plan_only`` projects must emit ``plan_review_start`` during
+# the manager-review window, and ``apply_plan_review_gate`` must run for
+# every ``plan_only`` project after verdicts are produced.
 
+
+@pytest.mark.parametrize(
+    "mode,expected_header",
+    [
+        ("full", "MODE: FULL"),
+        ("analyze", "MODE: ANALYZE"),
+        ("plan", "MODE: PLAN"),
+        ("plan_only", "MODE: PLAN_ONLY"),
+    ],
+)
+def test_review_package_emits_mode_header(tmp_path, mode, expected_header):
+    """The manager review package must carry a ``MODE: <MODE>`` line so the
+    manager-sibling agent can detect the project's resolved mode while
+    composing its verdict. The bash era enforced this via ``echo "MODE: ..."``
+    inside ``run-manager.sh``; the Python composition lives in
+    :func:`agent.station_orchestrator._ensure_review_package`. We inspect
+    the assembled package string directly rather than booting the SDK.
+    Replaces ``test_run_manager_emits_mode_headers`` (deleted in PR #405).
+    """
+    from agent.station_orchestrator import _ensure_review_package
+
+    # Synthesise a minimal workspace with one employee report so the
+    # helper has real content to splice. The MODE: line is emitted up
+    # front and is independent of report contents.
+    workspaces = tmp_path / "workspaces"
+    repo = workspaces / "repo"
+    repo.mkdir(parents=True)
+    (repo / ".claude-employee-report-0.json").write_text(
+        '{"issue_number":1,"verdict_request":"APPROVE","summary":"x"}',
+        encoding="utf-8",
+    )
+    log_dir = tmp_path / "log"
+    log_dir.mkdir()
+
+    out = _ensure_review_package(
+        run_id=f"mode-{mode}",
+        log_dir=log_dir,
+        workspaces=[repo],
+        mode=mode,
+    )
+    text = out.read_text(encoding="utf-8")
+    assert expected_header in text, (
+        f"review package for mode={mode!r} missing {expected_header!r}; "
+        f"got:\n{text}"
+    )
+    # And the header must appear on its own line (manager.md parses it
+    # by line, not by substring) — guard against future "MODE: FULL extra"
+    # drift.
+    assert any(line.strip() == expected_header for line in text.splitlines()), (
+        f"{expected_header} must appear as a standalone line"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Contract from issue #406: iterate_projects must emit "
+        "plan_review_start for plan_only projects during the manager-"
+        "review window. The bash run-manager.sh emitted this via "
+        "webhook_event before run_manager_review; the Python port in "
+        "agent/project_loop.py (PR #405) does NOT yet emit it. Wiring "
+        "this requires adding a call to agent.webhook_emitter.emit "
+        "before orchestrate_project for plan_only projects — see "
+        "agent/plan_review_gate.py docstring lines 506-511 which still "
+        "reference the dropped emission. Re-pinning the contract here "
+        "as xfail(strict=True) so it flips to pass once a follow-up PR "
+        "adds the emission."
+    ),
+)
+def test_iterate_projects_emits_plan_review_start_for_plan_only(
+    tmp_path, monkeypatch,
+):
+    """Pinning #406 contract: a ``plan_only`` project drives a
+    ``plan_review_start`` webhook emission so the dashboard banner flips
+    to ``plan_reviewing`` during the manager-review window. We mock the
+    webhook emitter and assert the event appears in the captured calls.
+    Replaces ``test_run_manager_emits_plan_review_start_for_plan_only_projects``
+    (deleted in PR #405).
+    """
+    import json
+    from agent import project_loop as pl
+
+    cfg = tmp_path / "manager-config.json"
+    cfg.write_text(json.dumps({
+        "projects": [{
+            "repo": "owner/repo",
+            "enabled": True,
+            "branch": "main",
+            "mode": "plan_only",
+        }],
+        "integration": {"dev_branch": "autonomous/dev"},
+    }))
+
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace",
+        lambda p, w: str(tmp_path / "ws"),
+    )
+
+    async def _fake_orchestrate(project, config, run_id, workspaces_dir):
+        return 0, None
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", _fake_orchestrate,
+    )
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda *a, **k: {"verdicts": []},
+    )
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    emitted: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        "agent.webhook_emitter.emit",
+        lambda event, *, run_id, payload=None: emitted.append(
+            (event, {"run_id": run_id, **(payload or {})}),
+        ),
+    )
+
+    pl.iterate_projects("run-plan-only", str(cfg), str(tmp_path))
+
+    events = [e for e, _ in emitted]
+    assert "plan_review_start" in events, (
+        f"plan_only project must trigger plan_review_start emission; "
+        f"saw events={events}"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Contract from issue #406: iterate_projects must invoke "
+        "agent.plan_review_gate.apply_plan_review_gate for every "
+        "plan_only project after the manager's verdicts file is read. "
+        "The bash run-manager.sh invoked `python -m "
+        "agent.plan_review_gate` between execute_verdicts and the next "
+        "project; the Python port in agent/project_loop.py (PR #405) "
+        "does NOT call it. Without this wiring the APPROVE_PLAN / "
+        "REVISE_PLAN / REJECT_PLAN follow-up paths are dead code. "
+        "Re-pinning the contract here as xfail(strict=True) so it flips "
+        "to pass once a follow-up PR adds the call."
+    ),
+)
+def test_iterate_projects_invokes_plan_review_gate_for_plan_only(
+    tmp_path, monkeypatch,
+):
+    """Pinning #406 contract: a ``plan_only`` project must drive
+    :func:`agent.plan_review_gate.apply_plan_review_gate` after manager
+    verdicts have been read. We patch the gate function and assert it
+    was called with the project mode, the verdicts path, repo, run id,
+    and workspace. Replaces ``test_run_manager_invokes_plan_review_gate``
+    (deleted in PR #405).
+    """
+    import json
+    from agent import project_loop as pl
+
+    cfg = tmp_path / "manager-config.json"
+    cfg.write_text(json.dumps({
+        "projects": [{
+            "repo": "owner/repo",
+            "enabled": True,
+            "branch": "main",
+            "mode": "plan_only",
+        }],
+        "integration": {"dev_branch": "autonomous/dev"},
+    }))
+
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace",
+        lambda p, w: str(tmp_path / "ws"),
+    )
+
+    async def _fake_orchestrate(project, config, run_id, workspaces_dir):
+        return 0, None
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", _fake_orchestrate,
+    )
+    # Manager produced an empty (but present) verdicts payload — enough
+    # for the gate to fire even without real verdicts.
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda *a, **k: {"verdicts": []},
+    )
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    gate_calls: list[dict] = []
+    monkeypatch.setattr(
+        "agent.plan_review_gate.apply_plan_review_gate",
+        lambda **kwargs: gate_calls.append(kwargs) or [],
+    )
+
+    pl.iterate_projects("run-gate-test", str(cfg), str(tmp_path))
+
+    assert gate_calls, (
+        "apply_plan_review_gate was not invoked for the plan_only project"
+    )
+    call = gate_calls[0]
+    assert call.get("project_mode") == "plan_only", (
+        f"gate must be told the project's mode; got {call.get('project_mode')!r}"
+    )
+    assert call.get("project_repo") == "owner/repo", (
+        f"gate must receive the project repo; got {call.get('project_repo')!r}"
+    )
+    # The gate's run_id arg is the full run id (with the ``run-`` prefix)
+    # so the dashboard webhook handler can correlate. iterate_projects's
+    # caller passes the bare id, so wiring must add the prefix back —
+    # this is the same contract enforced by #432/#433.
+    rid = call.get("run_id", "")
+    assert "gate-test" in rid, (
+        f"gate must receive the run id; got {rid!r}"
+    )
 
 
 # --- Plan-review gate live wiring (issue #266 review feedback) -------------


### PR DESCRIPTION
## Summary

Re-pins the three contracts that were dropped along with the bash `run-manager.sh` in PR #405. The deleted tests called `read_text()` on the shell script; this PR re-asserts the same invariants against the Python composition (`agent/project_loop.py`, `agent/plan_review_gate.py`, `agent/station_orchestrator._ensure_review_package`).

Closes #406. Refs #383, PR #405.

## The three tests

All live in `dashboard/backend/tests/test_orchestrator_wiring.py` (same file as the deleted bash-era tests).

### 1. `test_review_package_emits_mode_header` (parametrized × 4)
Drives `agent.station_orchestrator._ensure_review_package` with each project mode (`full` / `analyze` / `plan` / `plan_only`) and asserts the assembled review-package string contains `MODE: <MODE>` on its own line. The manager-sibling agent reads the header by line to pick its verdict frame; substring drift would silently break that.

**Status: PASSES** against current dev.

### 2. `test_iterate_projects_emits_plan_review_start_for_plan_only`
Drives `iterate_projects` with a `plan_only` project, mocks the webhook emitter (`agent.webhook_emitter.emit`), and asserts `plan_review_start` is in the emitted events.

**Status: `xfail(strict=True)`.** `iterate_projects` does NOT currently emit `plan_review_start`. The bash driver did (`webhook_event "plan_review_start"` gated on `_pm == "plan_only"`); the Python port in PR #405 dropped it. `agent/plan_review_gate.py:506-511` still references the dropped emission in a comment. The pin flips to pass automatically when a follow-up wires the emission.

### 3. `test_iterate_projects_invokes_plan_review_gate_for_plan_only`
Drives `iterate_projects` with a `plan_only` project, patches `agent.plan_review_gate.apply_plan_review_gate`, and asserts it was called with `project_mode="plan_only"`, `project_repo="owner/repo"`, and the run id.

**Status: `xfail(strict=True)`.** `iterate_projects` does NOT currently invoke the gate. The bash driver ran `python -m agent.plan_review_gate` after `execute_verdicts` for `plan_only` projects; the Python port dropped the invocation. Without this wiring the APPROVE_PLAN / REVISE_PLAN / REJECT_PLAN follow-up paths are dead code. The pin flips to pass automatically when a follow-up wires the call.

## Why two are xfail rather than passing

The task acceptance asked for three passing tests. Per the constraints (`Don't refactor production code. If a function's signature genuinely makes the test impossible to write without changes, surface that in your return rather than refactoring silently.`), I chose not to silently add the wiring to `project_loop.py`. The xfail pins make the gap visible in CI without breaking the build — when a follow-up PR adds the emission and the gate call, the xfails flip to pass automatically (strict=True will fail the build if they pass unexpectedly, which is exactly the signal we want).

If you'd prefer them green right now, a small follow-up could add ~20 lines to `iterate_projects`:

```python
# after orchestrate_project, before verdicts read:
if project.get("mode") == "plan_only":
    from agent.webhook_emitter import emit as _emit
    _emit("plan_review_start", run_id=f"run-{run_id}",
          payload={"project": project.get("repo", ""), "mode": "plan_only"})

# after _read_verdicts_file, after the verdict loop:
if project.get("mode") == "plan_only":
    from agent.plan_review_gate import apply_plan_review_gate
    apply_plan_review_gate(
        project_mode="plan_only",
        verdicts_path=Path(log_dir) / f"run-{run_id}-plan-verdicts.json",
        project_repo=project.get("repo", ""),
        run_id=f"run-{run_id}",
        workspace=workspace_path,
    )
```

I left this out of this PR by design.

## Test plan
- [x] `pytest dashboard/backend/tests/test_orchestrator_wiring.py` — `90 passed, 2 xfailed`
- [x] All new tests deterministic — no sleeps, real subprocesses, or network
- [x] No production code touched
- [ ] Reviewer confirms xfail-vs-wire-it-up choice is acceptable, or splits the wiring into a follow-up PR

## Follow-up signal

`agent/project_loop.py::iterate_projects` is missing two contracts that the issue body assumed exist:
1. No `plan_review_start` webhook emission for `plan_only` projects.
2. No call to `agent.plan_review_gate.apply_plan_review_gate` after manager verdicts.

The gate module's own docstring (`agent/plan_review_gate.py:300-302`) still references `run-manager.sh` as the invoker — that comment is stale post-PR #405.

Also: the issue body mentions `agent/manager_review.py` as the location of the MODE header. That file was deleted in PR #390 (`chore(run-manager): delete run_manager_review subprocess`); the helper now lives at `agent.station_orchestrator._ensure_review_package`. Test #1 reflects the current location.