### PR TITLE
fix(reaper): anchor pgrep pattern and patch flaky tie-breaker tests (#407)

### DIFF
--- a/dashboard/backend/app/services/stale_run_reaper.py
+++ b/dashboard/backend/app/services/stale_run_reaper.py
@@ -96,11 +96,35 @@ async def _heartbeat_subscriber() -> None:
             logger.warning("heartbeat rebroadcast failed for %s", run_id)
 
 
+_ORCHESTRATOR_PGREP_PATTERN = (
+    # Anchored to start of cmdline: any python interpreter (with optional path
+    # prefix and version suffix), followed by either:
+    #   - `-m agent.station_orchestrator ...`  (the launcher / systemd path)
+    #   - any path ending in `station_orchestrator.py` as an argument
+    #
+    # An UNANCHORED `station_orchestrator` substring (the original pattern)
+    # falsely matched any host process whose argv happened to contain the
+    # word: shell sessions with the file in cwd, `gh pr create --body "...
+    # station_orchestrator.py..."`, other Claude Code agents, `grep -rn
+    # station_orchestrator`, etc. That suppressed legitimate reaps in
+    # production and made tests flaky (issue #407).
+    r"^(\S*/)?python[0-9.]*[[:space:]].*([[:space:]]|/)station_orchestrator\.py"
+    r"|^(\S*/)?python[0-9.]*[[:space:]]+-m[[:space:]]+agent\.station_orchestrator"
+)
+
+
 def _is_orchestrator_process_alive() -> bool:
-    """Check if a station_orchestrator process is running (manual/test runs)."""
+    """Check if a station_orchestrator process is running (manual/test runs).
+
+    Uses an anchored pgrep pattern that matches only ``python … -m
+    agent.station_orchestrator …`` or ``python … …/station_orchestrator.py
+    …`` invocations — see :data:`_ORCHESTRATOR_PGREP_PATTERN`. The previous
+    unanchored ``station_orchestrator`` substring matched unrelated host
+    processes (issue #407).
+    """
     try:
         result = subprocess.run(
-            ["pgrep", "-f", "station_orchestrator"],
+            ["pgrep", "-f", _ORCHESTRATOR_PGREP_PATTERN],
             capture_output=True, timeout=3,
         )
         return result.returncode == 0

--- a/dashboard/backend/tests/test_queue.py
+++ b/dashboard/backend/tests/test_queue.py
@@ -89,8 +89,16 @@ class TestStaleRunReaperQueueRecovery:
         _make_queue_item(db, state="completed", run_id="run-DEAD", assigned_to=1)
         await db.commit()
 
+        # Patch ``_is_orchestrator_process_alive`` to False — the production
+        # implementation calls ``pgrep -f station_orchestrator`` which matches
+        # ANY host process whose cmdline contains that substring (other
+        # Claude Code agents, IDEs, build scripts, etc.). Without this patch
+        # the test is flaky: when pgrep finds a stray match the reaper short-
+        # circuits and returns 0. See issue #407.
         with patch("app.services.stale_run_reaper.get_agent_status",
                     new_callable=AsyncMock, return_value={"service_active": False}), \
+             patch("app.services.stale_run_reaper._is_orchestrator_process_alive",
+                    return_value=False), \
              patch("app.services.stale_run_reaper.event_bus_publish",
                     new_callable=AsyncMock), \
              patch("app.services.stale_run_reaper.send_notification",

--- a/dashboard/backend/tests/test_stale_run_reaper.py
+++ b/dashboard/backend/tests/test_stale_run_reaper.py
@@ -124,3 +124,55 @@ async def test_reap_stale_heartbeat_runs_when_launcher_alive(setup_db):
             select(Run).where(Run.run_id == "run-silent-death")
         )).scalar_one()
         assert row.status == "interrupted"
+
+
+# ── issue #407 positive coverage: tie-breaker branch ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reaper_skips_when_orchestrator_process_alive(setup_db):
+    """Tie-breaker coverage (issue #407): when ``deploy_mode() == 'systemd'``
+    and the launcher reports ``service_active=False`` but pgrep finds a
+    live ``station_orchestrator`` process, the main sweep must NOT reap.
+
+    Every other test in the suite mocks ``_is_orchestrator_process_alive``
+    to False to neutralise host-process flakiness, so without this test
+    the True branch of the tie-breaker has zero coverage.
+
+    The run is seeded WITHOUT ``last_event_at`` so the heartbeat reap
+    (which runs unconditionally before the tie-breaker) does not pick it
+    up; only the main service-inactive sweep would, and the tie-breaker
+    must skip that sweep.
+    """
+    from app.services.stale_run_reaper import reap_stale_runs
+
+    async with async_session() as db:
+        db.add(Run(
+            run_id="run-orchestrator-alive",
+            status="running",
+            started_at=datetime.now(timezone.utc),
+            # last_event_at left NULL so the heartbeat sweep can't claim it.
+        ))
+        await db.commit()
+
+    with patch("app.services.stale_run_reaper.get_agent_status",
+               new_callable=AsyncMock,
+               return_value={"service_active": False}), \
+         patch("app.services.stale_run_reaper.deploy_mode",
+               return_value="systemd"), \
+         patch("app.services.stale_run_reaper._is_orchestrator_process_alive",
+               return_value=True):
+        async with async_session() as db:
+            reaped = await reap_stale_runs(db)
+
+    assert reaped == 0, "tie-breaker must short-circuit the main sweep"
+
+    async with async_session() as db:
+        row = (await db.execute(
+            select(Run).where(Run.run_id == "run-orchestrator-alive")
+        )).scalar_one()
+        assert row.status == "running", (
+            "seeded run must NOT be marked interrupted while orchestrator "
+            "process is alive"
+        )
+        assert row.finished_at is None

--- a/dashboard/backend/tests/test_stale_run_reaper_compose.py
+++ b/dashboard/backend/tests/test_stale_run_reaper_compose.py
@@ -48,7 +48,14 @@ async def test_reaper_does_nothing_when_agent_active(stale_run):
 @pytest.mark.asyncio
 async def test_reaper_marks_runs_interrupted_when_agent_inactive(stale_run):
     mock_status = AsyncMock(return_value={"service_active": False})
-    with patch("app.services.stale_run_reaper.get_agent_status", mock_status):
+    # Patch ``_is_orchestrator_process_alive`` to False — the production
+    # implementation calls ``pgrep -f station_orchestrator`` which matches
+    # ANY host process whose cmdline contains that substring (other Claude
+    # Code agents, IDEs, build scripts, etc.). Without this patch the test
+    # is flaky on dev workstations. See issue #407.
+    with patch("app.services.stale_run_reaper.get_agent_status", mock_status), \
+         patch("app.services.stale_run_reaper._is_orchestrator_process_alive",
+               return_value=False):
         async with async_session() as s:
             n = await reap_stale_runs(s)
             await s.commit()
@@ -98,7 +105,11 @@ async def test_reaper_marks_old_unknown_runs_interrupted(old_unknown_run):
     """Issue #268 acceptance criterion: the reaper must catch ``unknown``
     rows older than the threshold whose orchestrator process is dead."""
     mock_status = AsyncMock(return_value={"service_active": False})
-    with patch("app.services.stale_run_reaper.get_agent_status", mock_status):
+    # Patch ``_is_orchestrator_process_alive`` to False (see issue #407 —
+    # pgrep -f station_orchestrator can match unrelated host processes).
+    with patch("app.services.stale_run_reaper.get_agent_status", mock_status), \
+         patch("app.services.stale_run_reaper._is_orchestrator_process_alive",
+               return_value=False):
         async with async_session() as s:
             n = await reap_stale_runs(s)
             await s.commit()


### PR DESCRIPTION
## Summary

Originally a test-only fix for the flaky reaper tests in #407. Code review surfaced two warning-level findings that expanded scope to also include a **production fix** and a **new positive coverage test** — both pushed in the follow-up commit.

## Investigation

Reproduced the exact `assert 0 == 1` failure from the issue by running:

```bash
bash -c 'exec -a station_orchestrator_fake sleep 30' &
python3 -m pytest tests/test_queue.py::TestStaleRunReaperQueueRecovery \
                  tests/test_stale_run_reaper_compose.py -xvs
```

With the fake process alive, all three target tests fail with `assert 0 == 1`. Without it (and without other host processes whose cmdline contains "station_orchestrator"), they pass.

## Root cause

**Both fixture drift and a real production code smell.** The reaper's `_is_orchestrator_process_alive()` helper called `pgrep -f station_orchestrator`, where the unanchored substring matches **any** host process whose command line contains that word — including:

- Other Claude Code agents running in this repo (their cmdlines mention `agent/station_orchestrator.py`)
- `gh pr create --body "...station_orchestrator.py..."` invocations
- IDE tabs / build scripts / `grep` invocations referencing the file
- The test runner itself in some configurations

When pgrep finds a match and `deploy_mode()` defaults to `systemd` (no `STATION_DEPLOY_MODE` env var set), `reap_stale_runs()` short-circuits before the main sweep and returns 0. In tests this causes `count == 1` to fail; **in production it would suppress legitimate reaps any time such a process is running on the host**.

The smoking-gun commit is `31d908e` (`fix(reaper): use service_control so compose runs aren't reaped`), which added the pgrep tie-breaker for manual systemd developer invocations. The intent was correct (pgrep is the only liveness signal for manual orchestrator runs outside the systemd unit) — only the pattern was too loose.

## Fix — three changes

### 1. Production: anchor the pgrep pattern (`stale_run_reaper.py`)

Replaced the unanchored `"station_orchestrator"` substring with a new constant `_ORCHESTRATOR_PGREP_PATTERN`:

```
^(\S*/)?python[0-9.]*[[:space:]].*([[:space:]]|/)station_orchestrator\.py
|^(\S*/)?python[0-9.]*[[:space:]]+-m[[:space:]]+agent\.station_orchestrator
```

Verified the pattern **matches** all five legitimate invocation styles:
- `python3 -m agent.station_orchestrator --driver --run-id ...`
- `python agent/station_orchestrator.py --run-id ...`
- `python3 /opt/claude-agent-station/agent/station_orchestrator.py ...`
- `python3.11 -m agent.station_orchestrator --driver`
- `/opt/.../venv/bin/python3 -m agent.station_orchestrator --driver` (the actual launcher invocation, see `agent/launcher.py:662-668`)

Verified the pattern **rejects** all realistic decoys that the old pattern matched:
- `gh pr create --body "...station_orchestrator.py..."`
- `claude code agent working on agent/station_orchestrator.py`
- `grep -rn station_orchestrator .`
- `station_orchestrator_fake` (the original #407 repro process)
- `bash echo station_orchestrator`
- `pytest tests/test_stale_run_reaper_compose.py`
- `my-editor agent/station_orchestrator.py`

(One narrow remaining case still matches: `python3 -c "code that mentions station_orchestrator.py in a string"` — vanishingly rare on the host and not worth a more complex pattern.)

### 2. Tests: patch `_is_orchestrator_process_alive` in the three target tests

Even with the tighter production pattern, tests must not depend on host process state. Added `patch("app.services.stale_run_reaper._is_orchestrator_process_alive", return_value=False)` to:

- `test_queue.py::test_orphaned_items_recovered_when_run_reaped`
- `test_stale_run_reaper_compose.py::test_reaper_marks_runs_interrupted_when_agent_inactive`
- `test_stale_run_reaper_compose.py::test_reaper_marks_old_unknown_runs_interrupted`

Assertions remain `== 1` — no loosening.

### 3. New positive coverage test for the tie-breaker (`test_stale_run_reaper.py`)

With `_is_orchestrator_process_alive` mocked to False everywhere, the True branch of the tie-breaker had zero coverage. Added `test_reaper_skips_when_orchestrator_process_alive`:
- Seeds a stale run that would otherwise be reaped (status=running, no `last_event_at` so the heartbeat sweep can't claim it).
- Mocks `_is_orchestrator_process_alive` → True, `deploy_mode` → "systemd", `get_agent_status` → service_active=False — so we land on the tie-breaker branch.
- Asserts `reap_stale_runs(db) == 0` AND the seeded run still has `status=running`, `finished_at=None`.

## Test plan

- [x] Repro confirmed: with a fake `station_orchestrator`-cmdline process alive, the three target tests fail before the patch and pass after.
- [x] `python3 -m pytest tests/test_queue.py tests/test_stale_run_reaper.py tests/test_stale_run_reaper_compose.py tests/test_stale_run_reaper_pubsub.py` → **20 passed**.
- [x] `python3 -m pytest tests/test_queue.py::TestStaleRunReaperQueueRecovery tests/test_stale_run_reaper_compose.py` with a fake `station_orchestrator_fake` process running → **7 passed** (was 0 of the 3 #407 tests failing before).
- [x] In-situ production check: with `station_orchestrator_fake` running, `_is_orchestrator_process_alive()` now returns False (was True). With a legitimate `python3 -m agent.station_orchestrator --driver` running, it returns True.
- [x] Full backend suite (excluding postgres-container tests that need Docker): 1426 passed, 1 skipped.

Closes #407

## Side observations

- Pre-existing test errors unrelated to this issue: `test_database.py`, `test_migration_script.py`, `test_pubsub.py` all fail with "postgres test container never became ready" — those need a working Docker daemon. Not in scope for #407.