### PR TITLE
fix(orchestrator): wire plan-review gate + emit plan_review_start for plan_only mode (#442)

### DIFF
--- a/agent/plan_review_gate.py
+++ b/agent/plan_review_gate.py
@@ -13,10 +13,11 @@ inserts a manual gate between plan-writing and implementation:
 This module owns the post-run gate logic: parsing the manager's plan
 verdict, enqueuing follow-up work, and emitting the corresponding run
 state transitions. The actual re-spawn loop for REVISE_PLAN is currently
-implemented as a documented helper that the run-manager shell driver
-calls between iterations — wiring it into the live SDK session is
-deliberately out-of-scope for the initial cut (see TODO in
-``apply_plan_verdict``).
+implemented as a documented helper invoked between project iterations by
+:func:`agent.project_loop.iterate_projects` (issue #442 in-process
+wiring); the CLI :func:`main` is preserved for ad-hoc / triage runs.
+Live re-spawn into the SDK session is deliberately out-of-scope for the
+initial cut (see TODO in ``apply_plan_verdict``).
 
 States added to the run / queue lifecycle (additive — both columns are
 TEXT in SQLite, so old code accepts the new strings without a
@@ -110,8 +111,9 @@ class GateAction:
                                  ``plan_approved``.
     - ``"revise"``             — re-spawn the same teammate with the manager
                                  feedback + prior plan path. The orchestrator
-                                 / run-manager shim drives the loop, bounded
-                                 by ``get_plan_revision_max()``.
+                                 (``agent.project_loop.iterate_projects``)
+                                 drives the loop, bounded by
+                                 ``get_plan_revision_max()``.
     - ``"reject"``             — close the planning thread, no follow-up.
                                  ``next_run_state`` is ``plan_rejected``.
     - ``"halt_revisions_exhausted"`` — REVISE_PLAN was returned but the
@@ -191,9 +193,10 @@ def apply_plan_verdict(
 ) -> GateAction:
     """Resolve a single plan verdict into the next gate action.
 
-    The caller (orchestrator post-run hook OR run-manager shim) is
-    responsible for actually performing the side-effects implied by the
-    returned ``GateAction``:
+    The caller (orchestrator post-run hook in
+    :func:`agent.project_loop.iterate_projects`, or the CLI in
+    :func:`main` for ad-hoc invocations) is responsible for actually
+    performing the side-effects implied by the returned ``GateAction``:
 
     - ``enqueue_full_run``  → POST a new ``QueueItem`` with mode="full",
                               context={"approved_plan_path": ...}, and
@@ -210,8 +213,9 @@ def apply_plan_verdict(
 
     TODO(#266 follow-up): wire ``revise`` into the live SDK session. The
     current iteration implements the verdict mapping + tests; the actual
-    re-spawn-with-feedback loop is driven by the run-manager shell driver
-    between iterations.
+    re-spawn-with-feedback loop is driven by
+    :func:`agent.project_loop.iterate_projects` between iterations
+    (post-#442 in-process wiring).
     """
     if verdict.verdict == "APPROVE_PLAN":
         return GateAction(
@@ -296,12 +300,13 @@ def build_followup_queue_item(action: GateAction) -> dict:
 #   run's status to ``awaiting_plan_review``, ``plan_approved``, or
 #   ``plan_rejected`` (handlers added in run_lifecycle.py).
 # - :func:`apply_plan_review_gate` is the orchestrator-side entry point:
-#   parse → decide → execute. Called by :func:`main` (CLI) which is in
-#   turn invoked from :file:`agent/scripts/run-manager.sh` after the
-#   manager review phase, gated on ``project.mode == "plan_only"``.
+#   parse → decide → execute. Called in-process by
+#   :func:`agent.project_loop.iterate_projects` after the manager-sibling
+#   has written its verdicts (gated on ``project.mode == "plan_only"``),
+#   and also exposed via the :func:`main` CLI for ad-hoc / triage runs.
 #
 # Network failures are logged and converted to non-zero exits so the
-# shell driver can surface them, but they never raise — the gate is a
+# caller can surface them, but they never raise — the gate is a
 # side-effect layer, not a fail-stop in the main flow.
 
 
@@ -310,9 +315,10 @@ def _resolve_dashboard_url(api_url: str | None = None) -> str:
 
     Precedence: explicit arg → ``STATION_DASHBOARD_URL`` env →
     ``STATION_WEBHOOK_URL`` env (stripped of the ``/api/webhook/...``
-    suffix) → ``http://127.0.0.1:8420``. Matches ``run-manager.sh``
-    queue_api/webhook_event resolution so a single deployment env var
-    works for both layers.
+    suffix) → ``http://127.0.0.1:8420``. Matches the orchestrator's
+    queue_api / webhook resolution so a single deployment env var works
+    for both layers (previously aligned with the bash run-manager.sh
+    helpers; now with :mod:`agent.webhook_emitter`).
     """
     if api_url:
         return api_url.rstrip("/")
@@ -457,8 +463,9 @@ def write_revision_feedback(
 class GateOutcome:
     """Aggregated result of running the gate over one verdict.
 
-    Returned to the CLI / shell driver so it can log per-verdict outcomes
-    and decide whether the gate as a whole succeeded.
+    Returned to the in-process caller (or the CLI driver) so it can log
+    per-verdict outcomes and decide whether the gate as a whole
+    succeeded.
     """
     action_kind: str
     verdict_kind: str
@@ -506,9 +513,11 @@ def apply_plan_review_gate(
     # Mark the run as awaiting plan review BEFORE applying any verdicts so
     # operators see the gate engage even if the verdicts file is malformed
     # or the manager produced nothing. The ``plan_reviewing`` window is
-    # the manager-review phase itself (handled by run-manager.sh emitting
-    # plan_review_start for plan_only projects); ``awaiting_plan_review``
-    # is the post-review window where the gate is applying verdicts.
+    # the manager-review phase itself (handled by
+    # :func:`agent.project_loop.iterate_projects` emitting
+    # ``plan_review_start`` for plan_only projects before orchestration);
+    # ``awaiting_plan_review`` is the post-review window where the gate is
+    # applying verdicts.
     post_run_event(
         "awaiting_plan_review",
         run_id,
@@ -661,11 +670,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="python -m agent.plan_review_gate",
         description=(
-            "Plan-review gate driver. Invoked by run-manager.sh after the "
-            "manager review phase for plan_only projects. Reads the manager's "
-            "plan-verdicts JSON, decides per-verdict, and executes the "
-            "follow-up actions (enqueue full run, write revision feedback, "
-            "or close the planning thread)."
+            "Plan-review gate driver. The live orchestrator calls "
+            "apply_plan_review_gate() in-process from "
+            "agent.project_loop.iterate_projects after the manager-sibling "
+            "writes its verdicts; this CLI is retained for ad-hoc / triage "
+            "invocations against an existing verdicts JSON. Reads the "
+            "manager's plan-verdicts JSON, decides per-verdict, and "
+            "executes the follow-up actions (enqueue full run, write "
+            "revision feedback, or close the planning thread)."
         ),
     )
     p.add_argument("--project-mode", required=True,
@@ -704,7 +716,7 @@ def main(argv: list[str] | None = None) -> int:
         api_url=args.api_url,
     )
 
-    # Summary JSON to stdout for the shell driver to capture.
+    # Summary JSON to stdout for the (ad-hoc) caller to capture.
     summary = {
         "outcomes": [
             {

--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -184,6 +184,32 @@ def iterate_projects(
             results.append({"project": project["repo"], "decision": "ERROR", "error": str(exc)})
             continue
 
+        # Resolved project mode (defaults to "full" to match the bash picker).
+        # Captured once here so both the pre-orchestration plan_review_start
+        # emit and the post-verdicts gate call see the same value.
+        project_mode = str(project.get("mode") or "full").strip().lower()
+
+        # #442: plan_only projects flip the dashboard banner to
+        # ``plan_reviewing`` for the manager-review window. The legacy
+        # bash driver emitted this via ``webhook_event plan_review_start``
+        # immediately before invoking the manager review step; the Python
+        # port (PR #405) dropped it. We re-emit here, right before
+        # orchestrate_project (which now hosts the manager as an in-session
+        # sibling agent), so the UI state transition is restored.
+        if project_mode == "plan_only":
+            try:
+                from agent.webhook_emitter import emit as _emit_plan_start
+                _emit_plan_start(
+                    "plan_review_start",
+                    run_id=f"run-{run_id}",
+                    payload={
+                        "project": project.get("repo", ""),
+                        "mode": "plan_only",
+                    },
+                )
+            except Exception:  # noqa: BLE001 — best-effort signal
+                logger.warning("plan_review_start webhook emit failed")
+
         try:
             proj_rc, proj_state = asyncio.run(
                 orchestrate_project(project, config, run_id, workspaces_dir)
@@ -238,6 +264,31 @@ def iterate_projects(
                 "error": f"manager produced no verdicts file at {verdicts_path}",
             })
         raw_verdicts = (verdicts_payload or {}).get("verdicts", [])
+
+        # #442: plan_only projects fan out into APPROVE_PLAN /
+        # REVISE_PLAN / REJECT_PLAN follow-up actions that the manager-sibling
+        # writes alongside (or instead of) the regular ``verdicts`` array.
+        # The gate parses the same verdicts file, enqueues follow-up full
+        # runs, writes revision feedback, and flips the dashboard run
+        # status. The legacy bash driver shelled out to
+        # ``python -m agent.plan_review_gate``; here we call the function
+        # in-process. The CLI entry-point at ``agent.plan_review_gate.main``
+        # is preserved for ad-hoc / triage invocations.
+        if project_mode == "plan_only":
+            try:
+                from agent import plan_review_gate as _prg
+                _prg.apply_plan_review_gate(
+                    project_mode=project_mode,
+                    verdicts_path=verdicts_path,
+                    project_repo=project.get("repo", ""),
+                    run_id=f"run-{run_id}",
+                    workspace=workspace_path,
+                )
+            except Exception:  # noqa: BLE001 — gate is best-effort
+                logger.exception(
+                    "apply_plan_review_gate failed for %s",
+                    project.get("repo", ""),
+                )
 
         from agent.verdict_execution import Verdict as _Verdict
         verdicts = [_Verdict.from_dict(v) for v in raw_verdicts]

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -917,20 +917,6 @@ def test_review_package_emits_mode_header(tmp_path, mode, expected_header):
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "iterate_projects no longer emits plan_review_start — see #442. "
-        "Contract from issue #406: a plan_only project must emit "
-        "plan_review_start during the manager-review window. The bash "
-        "run-manager.sh did this via webhook_event before "
-        "run_manager_review; the Python port in agent/project_loop.py "
-        "(PR #405) dropped the emission. Wiring is tracked in #442; "
-        "agent/plan_review_gate.py docstring lines 506-511 still "
-        "reference the dropped emission. Re-pinning here as "
-        "xfail(strict=True) so it flips to pass once #442 lands."
-    ),
-)
 def test_iterate_projects_emits_plan_review_start_for_plan_only(
     tmp_path, monkeypatch,
 ):
@@ -992,21 +978,6 @@ def test_iterate_projects_emits_plan_review_start_for_plan_only(
     )
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "iterate_projects no longer invokes apply_plan_review_gate — "
-        "see #442. Contract from issue #406: iterate_projects must call "
-        "agent.plan_review_gate.apply_plan_review_gate for every "
-        "plan_only project after the manager's verdicts file is read. "
-        "The bash run-manager.sh ran `python -m agent.plan_review_gate` "
-        "between execute_verdicts and the next project; the Python port "
-        "in agent/project_loop.py (PR #405) dropped the invocation. "
-        "Without this wiring the APPROVE_PLAN / REVISE_PLAN / "
-        "REJECT_PLAN follow-up paths are dead code. Re-pinning here as "
-        "xfail(strict=True) so it flips to pass once #442 lands."
-    ),
-)
 def test_iterate_projects_invokes_plan_review_gate_for_plan_only(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- PR #405 ported the run-manager bash driver to Python but dropped two pieces of behaviour for `plan_only` projects: the `plan_review_start` webhook emission and the `apply_plan_review_gate(...)` call. Without the emission the dashboard's `plan_reviewing` UI state was unreachable; without the gate call the manager's `APPROVE_PLAN` / `REVISE_PLAN` / `REJECT_PLAN` verdicts were silently discarded.
- Both behaviours are now wired into `agent/project_loop.py::iterate_projects`. The `apply_plan_review_gate` CLI entry-point is preserved for ad-hoc / triage use; the live driver simply calls the function in-process.
- Stale `run-manager.sh` references in `agent/plan_review_gate.py` docstrings are rewritten to describe the new in-process invocation.

## xfail markers removed
The following two `@pytest.mark.xfail(strict=True, reason="...see #442...")` markers in `dashboard/backend/tests/test_orchestrator_wiring.py` are removed; both tests now PASS:

- `test_iterate_projects_emits_plan_review_start_for_plan_only` — the test mocks `agent.webhook_emitter.emit` and asserts `plan_review_start` appears in the captured events for a `plan_only` project. It now passes because `iterate_projects` emits the event before invoking `orchestrate_project` whenever the resolved project mode is `plan_only`.
- `test_iterate_projects_invokes_plan_review_gate_for_plan_only` — the test mocks `agent.plan_review_gate.apply_plan_review_gate` and asserts it is called with `project_mode="plan_only"`, `project_repo="owner/repo"`, and a `run_id` that starts with `run-` and contains the test-supplied bare id. It now passes because `iterate_projects` calls the gate in-process after reading the verdicts file, prefixing the run id with `run-` to match the dashboard webhook handler's correlation contract (per #432 / #433).

The third test in the same block, `test_review_package_emits_mode_header`, was already passing and is untouched.

## Where the wiring lives
- `agent/project_loop.py::iterate_projects` — resolves `project_mode` once at the top of the per-project loop, then:
  - **Emit:** right before `orchestrate_project(...)` for `plan_only`, calls `agent.webhook_emitter.emit("plan_review_start", run_id=f"run-{run_id}", payload={"project": project["repo"], "mode": "plan_only"})`. Best-effort — failures are logged, never raised. Placed pre-orchestration because the manager review happens inside the SDK session.
  - **Gate:** after the verdicts payload is read back (and after `manager_no_verdicts` handling), calls `agent.plan_review_gate.apply_plan_review_gate(project_mode=..., verdicts_path=..., project_repo=..., run_id=f"run-{run_id}", workspace=workspace_path)`. Wrapped in `try / except Exception` and logged so a flaky gate cannot crash the project loop.
- `agent/plan_review_gate.py` — docstrings updated (module-level, `GateAction`, `apply_plan_verdict`, `apply_plan_review_gate`, `_resolve_dashboard_url`, `_build_arg_parser`, `GateOutcome`, and the trailing CLI comment) so they describe the in-process invocation while noting that `main()` is still the ad-hoc / triage CLI.

## Call-site contract (per PR #440's tests)
Argument resolution mirrors the CLI's `main()` reference (`agent/plan_review_gate.py` ~line 690): every value passes as a kwarg so the test-mock `lambda **kwargs: ...` captures them. The verdicts path is the same `run-{run_id}-verdicts.json` the manager-sibling writes into `STATION_LOG_DIR` (the orchestrator already builds this path for the regular verdicts read). `run_id` is prefixed with `run-` so the dashboard webhook handler can correlate the gate's run-event POSTs.

Closes #442

## Test plan
- [x] `python3 -m pytest dashboard/backend/tests/test_orchestrator_wiring.py -xvs` — all 92 tests pass, including the two formerly-xfail tests now PASSED.
- [x] `python3 -m pytest dashboard/backend/tests/test_plan_review_override.py tests/test_project_loop_pick_issue.py tests/test_webhook.py tests/test_webhook_contracts.py tests/test_webhook_emitter.py tests/test_webhook_heartbeat.py` — all 108 pass.
- [x] Broader backend suite: `python3 -m pytest dashboard/backend/tests/ -x --ignore=tests/test_database.py --ignore=tests/test_migration_script.py --ignore=tests/test_pubsub.py` — 1438 passed, 1 skipped.
- [ ] (manual) verify a live `plan_only` run flips the dashboard banner through `plan_reviewing` → `awaiting_plan_review` → `plan_approved` / `plan_rejected` and that an APPROVE_PLAN verdict enqueues a follow-up `full` run.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>