### PR TITLE
fix(project_loop): use kwargs for manager_no_verdicts emit (#444)

### DIFF
--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -250,13 +250,16 @@ def iterate_projects(
             )
             try:
                 from agent.webhook_emitter import emit as _emit
-                _emit("manager_no_verdicts", {
-                    "run_id": f"run-{run_id}",
-                    "project": project.get("repo", ""),
-                    "verdicts_path": str(verdicts_path),
-                })
+                _emit(
+                    "manager_no_verdicts",
+                    run_id=f"run-{run_id}",
+                    payload={
+                        "project": project.get("repo", ""),
+                        "verdicts_path": str(verdicts_path),
+                    },
+                )
             except Exception:  # noqa: BLE001 — best-effort signal
-                logger.warning("manager_no_verdicts webhook emit failed")
+                logger.exception("manager_no_verdicts webhook emit failed")
             exit_code = max(exit_code, 6)
             results.append({
                 "project": project.get("repo", ""),

--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -208,7 +208,12 @@ def iterate_projects(
                     },
                 )
             except Exception:  # noqa: BLE001 — best-effort signal
-                logger.warning("plan_review_start webhook emit failed")
+                # Use logger.exception (with traceback) rather than
+                # logger.warning so any future signature drift surfaces
+                # loudly in logs instead of vanishing into a one-liner.
+                # See PR #445 / issue #444 for the manager_no_verdicts
+                # variant of this bug.
+                logger.exception("plan_review_start webhook emit failed")
 
         try:
             proj_rc, proj_state = asyncio.run(
@@ -266,6 +271,15 @@ def iterate_projects(
                 "decision": "ERROR",
                 "error": f"manager produced no verdicts file at {verdicts_path}",
             })
+            # Bail out of this project entirely. There are no verdicts to
+            # iterate, no plan-review fan-out to attempt, and no digest to
+            # write meaningfully. Falling through to the rest of the loop
+            # body is harmless today (raw_verdicts becomes []), but the
+            # intent here is "this project failed, move on" — make that
+            # explicit so a future downstream phase that assumes
+            # verdicts_payload is non-None cannot trip over a half-failed
+            # iteration. See PR #445 / issue #444 follow-up.
+            continue
         raw_verdicts = (verdicts_payload or {}).get("verdicts", [])
 
         # #442: plan_only projects fan out into APPROVE_PLAN /

--- a/dashboard/backend/tests/test_iterate_projects_python.py
+++ b/dashboard/backend/tests/test_iterate_projects_python.py
@@ -287,6 +287,150 @@ def test_iterate_projects_emits_manager_no_verdicts_with_kwargs(
     )
 
 
+def test_iterate_projects_skips_downstream_phases_when_no_verdicts(
+    tmp_path, monkeypatch,
+):
+    """Issue #444 follow-up: when the manager produces no verdicts file,
+    project_loop must bail out of the per-project loop body with an
+    explicit ``continue`` — not fall through to plan_review_gate /
+    verdict_execution with an empty list.
+
+    Pre-fix the failure path fell through, which was harmless today
+    (raw_verdicts became []) but masked the failure intent. A future
+    downstream phase that assumed ``verdicts_payload`` was non-None
+    would trip on the half-failed iteration. This test pins the
+    "fail this project, move on" contract by driving a ``plan_only``
+    project with no verdicts file and asserting that
+    ``apply_plan_review_gate`` is never invoked.
+    """
+    from agent import project_loop as pl
+
+    cfg = tmp_path / "manager-config.json"
+    cfg.write_text(json.dumps({
+        "projects": [{
+            "repo": "owner/repo",
+            "enabled": True,
+            "branch": "main",
+            "mode": "plan_only",
+        }],
+    }))
+
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda p, w: str(tmp_path / "ws"),
+    )
+
+    async def _fake_orchestrate(*a, **k):
+        return 0, None
+
+    monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
+    # No verdicts file → no-verdicts branch must fire.
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file", lambda *a, **k: None,
+    )
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **k: None)
+
+    gate_calls: list[dict] = []
+
+    def _spy_gate(**kwargs):
+        gate_calls.append(kwargs)
+
+    monkeypatch.setattr("agent.plan_review_gate.apply_plan_review_gate", _spy_gate)
+
+    exec_calls: list = []
+
+    def _spy_execute(verdict, **kwargs):
+        exec_calls.append(verdict)
+        from agent.verdict_execution import ExecutionResult
+        return ExecutionResult(verdict=verdict.verdict, project=verdict.project,
+                               issue_number=verdict.issue_number, success=True)
+
+    monkeypatch.setattr("agent.verdict_execution.execute", _spy_execute)
+
+    rc, _ = pl.iterate_projects("run-skip", str(cfg), str(tmp_path))
+
+    assert rc == 6, "missing verdicts file must bump exit_code to 6"
+    assert gate_calls == [], (
+        "plan_review_gate must NOT run when the manager produced no "
+        f"verdicts file; got {len(gate_calls)} call(s): {gate_calls!r}"
+    )
+    assert exec_calls == [], (
+        "verdict_execution must NOT run when there are no verdicts; "
+        f"got {len(exec_calls)} call(s)"
+    )
+
+
+def test_iterate_projects_emits_plan_review_start_with_kwargs(
+    tmp_path, monkeypatch,
+):
+    """Issue #444 audit: the ``plan_review_start`` emit site in
+    iterate_projects shares the same call shape as ``manager_no_verdicts``
+    and could regress in the same way. Pin its signature too.
+
+    Note: the call site uses ``logger.exception`` (post-#444) — so a
+    signature regression here would at least leave a traceback, but the
+    webhook would still not fire. This test enforces the wire contract.
+    """
+    from agent import project_loop as pl
+
+    cfg = tmp_path / "manager-config.json"
+    cfg.write_text(json.dumps({
+        "projects": [{
+            "repo": "owner/repo",
+            "enabled": True,
+            "branch": "main",
+            "mode": "plan_only",
+        }],
+    }))
+
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda p, w: str(tmp_path / "ws"),
+    )
+
+    async def _fake_orchestrate(*a, **k):
+        return 0, None
+
+    monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda *a, **k: {"verdicts": []},
+    )
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+    monkeypatch.setattr(
+        "agent.plan_review_gate.apply_plan_review_gate", lambda **kw: None,
+    )
+
+    captured: list[dict] = []
+
+    def _fake_emit(event, *args, **kwargs):
+        captured.append({"event": event, "args": args, "kwargs": kwargs})
+
+    monkeypatch.setattr("agent.webhook_emitter.emit", _fake_emit)
+
+    pl.iterate_projects("plan-run", str(cfg), str(tmp_path))
+
+    plan_starts = [c for c in captured if c["event"] == "plan_review_start"]
+    assert plan_starts, (
+        f"plan_review_start was never emitted; observed events: "
+        f"{[c['event'] for c in captured]!r}"
+    )
+    call = plan_starts[0]
+    assert call["args"] == (), (
+        f"plan_review_start payload must be a kwarg, not positional; "
+        f"got positional args: {call['args']!r}"
+    )
+    assert call["kwargs"].get("run_id") == "run-plan-run"
+    payload = call["kwargs"].get("payload")
+    assert payload is not None and payload.get("project") == "owner/repo"
+    assert payload.get("mode") == "plan_only"
+
+
 def test_iterate_projects_swallows_executor_exceptions_per_verdict(
     tmp_path, monkeypatch,
 ):

--- a/dashboard/backend/tests/test_iterate_projects_python.py
+++ b/dashboard/backend/tests/test_iterate_projects_python.py
@@ -205,6 +205,88 @@ def test_iterate_projects_passes_workspace_and_dev_branch_to_executor(
     assert kwargs.get("run_id") == "run-tested"
 
 
+def test_iterate_projects_emits_manager_no_verdicts_with_kwargs(
+    tmp_path, monkeypatch,
+):
+    """Issue #444: when the manager produces no verdicts file, project_loop
+    emits a ``manager_no_verdicts`` webhook so the dashboard can surface it.
+
+    The emitter signature is::
+
+        emit(event: str, *, run_id: str, payload: dict | None = None)
+
+    where ``run_id`` and ``payload`` are keyword-only. Pre-fix the call
+    passed the payload as a positional second arg → TypeError, swallowed
+    by a bare ``except Exception: logger.warning(...)``, so the webhook
+    was never actually sent and the dashboard never learned about the
+    failure. This test pins the call signature.
+    """
+    from agent import project_loop as pl
+
+    cfg = tmp_path / "manager-config.json"
+    cfg.write_text(json.dumps({
+        "projects": [{"repo": "owner/repo", "enabled": True, "branch": "main"}],
+        "limits": {"max_concurrent_employees": 1},
+    }))
+
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda p, w: str(tmp_path / "ws"),
+    )
+
+    async def _fake_orchestrate(*a, **k):
+        return 0, None
+
+    monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
+    # Missing verdicts file → manager_no_verdicts branch fires.
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file", lambda *a, **k: None,
+    )
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    captured: dict = {}
+
+    def _fake_emit(event, *args, **kwargs):
+        # Record both args + kwargs so we can detect any positional-arg
+        # regression. A correct call has no positional args beyond ``event``.
+        captured["event"] = event
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr("agent.webhook_emitter.emit", _fake_emit)
+
+    rc, _ = pl.iterate_projects("test-run", str(cfg), str(tmp_path))
+
+    assert rc == 6, "missing verdicts file must bump exit_code to 6"
+    assert captured, (
+        "manager_no_verdicts webhook was never emitted — the lazy "
+        "import inside project_loop may have been refactored, or the "
+        "branch is not firing"
+    )
+    assert captured["event"] == "manager_no_verdicts"
+    assert captured["args"] == (), (
+        "payload must be passed as a kwarg, not positional. "
+        f"Got positional args: {captured['args']!r}"
+    )
+    assert captured["kwargs"].get("run_id") == "run-test-run", (
+        f"run_id must be passed as kwarg and prefixed with 'run-'; "
+        f"got {captured['kwargs'].get('run_id')!r}"
+    )
+    payload = captured["kwargs"].get("payload")
+    assert payload is not None, "payload kwarg missing"
+    assert payload.get("project") == "owner/repo"
+    assert "verdicts_path" in payload
+    assert payload["verdicts_path"].endswith("run-test-run-verdicts.json")
+    # run_id must NOT be duplicated inside the payload — the wire body
+    # builder in webhook_emitter.emit adds it at the top level.
+    assert "run_id" not in payload, (
+        "run_id should not be duplicated inside payload; "
+        "webhook_emitter.emit already places it at the top level"
+    )
+
+
 def test_iterate_projects_swallows_executor_exceptions_per_verdict(
     tmp_path, monkeypatch,
 ):


### PR DESCRIPTION
## Summary

Originally a one-line signature bug; expanded during PR review into a small emit-hygiene pass.

### Original bug (#444)

The `manager_no_verdicts` webhook in `agent/project_loop.py` was silently failing on every invocation because the call did not match the emitter's signature.

`webhook_emitter.emit()` is declared as `emit(event, *, run_id, payload=None)` with `run_id` and `payload` keyword-only. The branch in `iterate_projects` was passing the payload dict as a positional second arg:

```python
_emit("manager_no_verdicts", {
    "run_id": f"run-{run_id}",
    "project": project.get("repo", ""),
    "verdicts_path": str(verdicts_path),
})
```

That raises `TypeError: emit() takes 1 positional argument but 2 were given`. The surrounding `except Exception: logger.warning("...emit failed")` swallowed it — no traceback, no webhook, no signal to the dashboard. Operators triaging "why was my issue not touched?" got nothing on the wire.

## Fixes (folded across two commits)

### Commit 1 — original fix
- Pass `payload` as a kwarg and `run_id` as a kwarg.
- Drop the redundant `run_id` from inside the payload dict (the wire body builder in `webhook_emitter.emit` already adds it at the top level — see `webhook_emitter.py:106`).
- Promote `logger.warning` to `logger.exception` so future similar bugs leave a traceback in the logs.

### Commit 2 — PR-review follow-ups

**Finding 1 — explicit `continue` after `manager_no_verdicts`**
After the no-verdicts branch logs the error, appends an ERROR result, and emits the webhook, control was falling through and iterating an empty `raw_verdicts` list. Harmless today, but the intent is "this project failed, move on" — make it explicit so a future downstream phase that assumes `verdicts_payload` is non-None cannot trip.

**Finding 2 — audit of every `emit` callsite in `agent/`**

| File:Line | Event | Signature | Swallow pattern | Action |
|---|---|---|---|---|
| `project_loop.py:202` | `plan_review_start` | kwargs OK | `except Exception: logger.warning(...)` | Promoted to `logger.exception` |
| `project_loop.py:253` | `manager_no_verdicts` | broken → fixed | `except Exception: logger.warning(...)` | Fixed in commit 1 |
| `station_orchestrator.py:2833` | `run_start` | kwargs OK | none (handled at run level) | No change |
| `station_orchestrator.py:2864` | `run_complete` | kwargs OK | none | No change |

No new signature bugs. Only hygiene change: align `plan_review_start` swallow to `logger.exception`.

**Finding 3 — `_safe_emit` helper: skipped**
Only 2 callsites use the swallow pattern (both in `project_loop.py`). The threshold for the helper to earn its keep was ≥ 3 — below that it's premature abstraction. Left inline try/except in place.

## Regression tests

In `dashboard/backend/tests/test_iterate_projects_python.py`:

1. `test_iterate_projects_emits_manager_no_verdicts_with_kwargs` (original) — patches `agent.webhook_emitter.emit` with a sentinel that captures both `*args` and `**kwargs`, drives `iterate_projects` through the no-verdicts branch, and asserts `event == "manager_no_verdicts"` (positional), `args == ()` (no positional payload), `kwargs["run_id"] == "run-test-run"`, payload contains `project` + `verdicts_path` but NOT a duplicated `run_id`. **Verified the test fails on the pre-fix code** by reverting `project_loop.py` and re-running.

2. `test_iterate_projects_skips_downstream_phases_when_no_verdicts` (finding 1) — drives a `plan_only` project with no verdicts file and asserts `apply_plan_review_gate` and `verdict_execution.execute` are never invoked (proves the `continue` is in effect).

3. `test_iterate_projects_emits_plan_review_start_with_kwargs` (finding 2) — pins the `plan_review_start` emit's call shape so it cannot regress into the same positional-args bug as #444.

Closes #444

## Test plan

- [x] `pytest tests/test_iterate_projects_python.py` → 9 passed
- [x] Pre-fix repro verified for `manager_no_verdicts` (revert + re-run failed at `args == ()` assertion, re-applied)
- [x] Full suite `pytest tests/test_project_loop*.py tests/test_iterate_projects_python.py tests/test_orchestrator_wiring.py tests/test_webhook*.py tests/test_run_lifecycle*.py -xvs` → **277 passed**
- [ ] Manual: trigger a run where the manager produces no verdicts file; confirm webhook lands on the dashboard and the run skips plan-review gate cleanly