### PR TITLE
feat: introduce 'skipped' run status + project_skipped_no_work event (#446 #447)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ api-key
 *.pem
 *.key
 .secrets/
+
+# Local worktrees for parallel task execution
+.worktrees/

--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -216,7 +216,7 @@ def iterate_projects(
                 logger.exception("plan_review_start webhook emit failed")
 
         try:
-            proj_rc, proj_state = asyncio.run(
+            proj_rc, proj_state, _work_attempted = asyncio.run(
                 orchestrate_project(project, config, run_id, workspaces_dir)
             )
             if proj_state is not None:

--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -111,19 +111,27 @@ def pick_issue(
 
 def iterate_projects(
     run_id: str, config_path: str, workspaces_dir: str,
-) -> tuple[int, "Any | None"]:
+) -> "tuple[int, Any | None, str | None]":
     """Drive a full run in-process: preflight → recovery → per-project → digest.
 
     Each former bash phase is a Python module; this function composes them
     (issue #383 bash deletion).
 
-    Returns ``(exit_code, last_stream_state)``. ``last_stream_state`` is the
-    most recent per-project stream state produced by
-    :func:`agent.station_orchestrator.orchestrate_project`, or ``None`` if
-    no project ran successfully far enough to initialise one. RunDriver's
-    ``_finalize_telemetry`` consumes it. Threading state via the return
-    value (rather than a module global) is correct under any concurrent
-    invocation pattern.
+    Returns ``(exit_code, last_stream_state, terminal_status_hint)``.
+
+    - ``exit_code``: process-level exit code (0 = clean, non-zero = failure).
+    - ``last_stream_state``: the most recent per-project stream state produced
+      by :func:`agent.station_orchestrator.orchestrate_project`, or ``None``
+      if no project ran successfully far enough to initialise one. RunDriver's
+      ``_finalize_telemetry`` consumes it. Threading state via the return
+      value (rather than a module global) is correct under any concurrent
+      invocation pattern.
+    - ``terminal_status_hint``: optional string hint for RunDriver. Currently
+      ``"skipped"`` when every enabled project was idle (no eligible issues,
+      ``work_attempted=False`` for all) and nothing failed; ``None`` otherwise.
+      RunDriver maps ``"skipped"`` to ``status="skipped"`` on run_complete so
+      the dashboard can render idle runs distinctly from real failures
+      (issues #446 #447).
 
     Exception policy: ``OrchestratorStopRequested`` and
     ``KeyboardInterrupt`` always propagate up so the driver's finally
@@ -149,7 +157,7 @@ def iterate_projects(
         run_preflight(config_path)
     except PreflightError as exc:
         logger.error("preflight: %s", exc)
-        return 2, None
+        return 2, None, None
 
     # Queue recovery errors are surfaced (dashboard returning 4xx/5xx is a
     # real problem); transient connect failures already degrade to a no-op
@@ -160,7 +168,7 @@ def iterate_projects(
         resume_paused()
     except QueueRecoveryError as exc:
         logger.error("queue_recovery: %s", exc)
-        return 5, None
+        return 5, None, None
 
     config = json.loads(Path(config_path).read_text())
     enabled = [p for p in config.get("projects", []) if p.get("enabled", True)]
@@ -175,12 +183,16 @@ def iterate_projects(
     # is global to the run; capture it once.
     dev_branch = config.get("integration", {}).get("dev_branch", "autonomous/dev")
 
+    any_work_attempted = False
+    any_real_failure = False
+
     for project in enabled:
         try:
             workspace_path = ensure_workspace(project, workspaces_dir)
         except WorkspaceError as exc:
             logger.error("workspace: %s", exc)
             exit_code = 3
+            any_real_failure = True
             results.append({"project": project["repo"], "decision": "ERROR", "error": str(exc)})
             continue
 
@@ -216,13 +228,14 @@ def iterate_projects(
                 logger.exception("plan_review_start webhook emit failed")
 
         try:
-            proj_rc, proj_state, _work_attempted = asyncio.run(
+            proj_rc, proj_state, work_attempted = asyncio.run(
                 orchestrate_project(project, config, run_id, workspaces_dir)
             )
             if proj_state is not None:
                 last_state = proj_state
             if proj_rc != 0:
                 exit_code = proj_rc
+                any_real_failure = True
         except (KeyboardInterrupt, OrchestratorStopRequested):
             # Operator stop / SIGTERM-mapped interrupt — propagate so the
             # RunDriver's finally block can write the interrupted-run
@@ -231,7 +244,37 @@ def iterate_projects(
         except Exception as exc:  # noqa: BLE001
             logger.exception("orchestrate_project failed for %s", project["repo"])
             exit_code = 4
+            any_real_failure = True
             results.append({"project": project["repo"], "decision": "ERROR", "error": str(exc)})
+            continue
+
+        if work_attempted:
+            any_work_attempted = True
+
+        # #446 / #447: idle case — the project had no eligible issues
+        # and the SDK session was never opened. This is NOT a failure;
+        # don't read verdicts, don't emit manager_no_verdicts, don't
+        # bump exit_code. Emit project_skipped_no_work so the dashboard
+        # can render it distinctly from a real failure.
+        if not work_attempted:
+            try:
+                from agent.webhook_emitter import emit as _emit_skip
+                _emit_skip(
+                    "project_skipped_no_work",
+                    run_id=f"run-{run_id}",
+                    payload={
+                        "project": project.get("repo", ""),
+                        "reason": "no_eligible_work",
+                    },
+                )
+            except Exception:  # noqa: BLE001 — best-effort signal
+                logger.exception("project_skipped_no_work webhook emit failed")
+
+            results.append({
+                "project": project.get("repo", ""),
+                "decision": "SKIP",
+                "reason": "no_eligible_work",
+            })
             continue
 
         # #390: the manager is now a sibling agent inside the lead's SDK
@@ -266,6 +309,7 @@ def iterate_projects(
             except Exception:  # noqa: BLE001 — best-effort signal
                 logger.exception("manager_no_verdicts webhook emit failed")
             exit_code = max(exit_code, 6)
+            any_real_failure = True
             results.append({
                 "project": project.get("repo", ""),
                 "decision": "ERROR",
@@ -334,6 +378,7 @@ def iterate_projects(
                     verdict.project, verdict.issue_number, verdict.verdict,
                 )
                 exit_code = max(exit_code, 7)
+                any_real_failure = True
                 results.append({
                     "project": verdict.project,
                     "issue_number": verdict.issue_number,
@@ -368,4 +413,17 @@ def iterate_projects(
                     })
 
     write_digest(run_id=run_id, results=results, log_dir=log_dir)
-    return exit_code, last_state
+
+    # #446 / #447: idle-run terminal status hint for RunDriver.
+    # Only emit "skipped" if EVERY enabled project was idle AND
+    # nothing genuinely failed. Conservative: anything ambiguous
+    # falls through to existing completed/failed mapping in RunDriver.run().
+    # Note: an empty ``enabled`` list (no enabled projects at all) is a
+    # misconfiguration, not an idle run; fall through to "completed" so
+    # the operator sees the run completed rather than masking the config
+    # gap behind a "skipped" status.
+    if enabled and not any_work_attempted and not any_real_failure and exit_code == 0:
+        terminal_status_hint = "skipped"
+    else:
+        terminal_status_hint = None
+    return exit_code, last_state, terminal_status_hint

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -2896,13 +2896,18 @@ class RunDriver:
             # ``run-`` to its input. Pass the BARE id so we don't end up with
             # ``run-run-<ts>`` query params on /webhook-tick, which 404 at the
             # launcher and let the reaper kill the run at 120s.
-            exit_code, last_state = iterate_projects(
+            exit_code, last_state, terminal_status_hint = iterate_projects(
                 self._clean_id, self.config_path, self.workspaces_dir,
             )
             if exit_code == 130:
                 status = "interrupted"
             elif exit_code != 0:
                 status = "failed"
+            elif terminal_status_hint == "skipped":
+                # #446 / #447: idle run — every enabled project was idle
+                # and nothing failed. Distinct terminal status so the
+                # dashboard can render this as "skipped" not "failed".
+                status = "skipped"
         except KeyboardInterrupt:
             logger.warning("RunDriver: KeyboardInterrupt — marking run interrupted")
             status = "interrupted"

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -2010,13 +2010,19 @@ def _read_verdicts_file(path: Path) -> dict | None:
 
 async def orchestrate_project(
     project: dict, config: dict, run_id: str, workspaces_dir: str,
-) -> tuple[int, "_StreamState | None"]:
+) -> tuple[int, "_StreamState | None", bool]:
     """Run the Agent Teams session for a single project.
 
-    Returns ``(exit_code, stream_state)``. ``stream_state`` is ``None`` if
-    the project short-circuited before the orchestrator session began
-    (no eligible issues, workspace error, etc.). Callers use the returned
-    state for telemetry aggregation — see :class:`RunDriver._finalize_telemetry`.
+    Returns ``(exit_code, stream_state, work_attempted)``.
+
+    - ``stream_state`` is ``None`` if the project short-circuited before
+      the SDK session began (no eligible issues).
+    - ``work_attempted`` is ``False`` only when the picker returned no
+      eligible issues and the SDK session was never opened. ``True`` for
+      all other paths (session opened, errored, etc.) so that downstream
+      failure signals (manager_no_verdicts, exit_code bumps) are preserved.
+      Idle-run-semantics discriminator — see #446 / #447 / spec
+      ``docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md``.
 
     Extracted from orchestrate() in #383 so iterate_projects (Python-only)
     can drive per-project work directly without delegating the outer loop
@@ -2162,7 +2168,7 @@ async def orchestrate_project(
             # No issues: clean exit. ``stream_state`` is uninitialised here
             # because the orchestrator session never started — return None so
             # telemetry aggregation in the caller can skip this project.
-            return exit_code, None
+            return exit_code, None, False
 
         # Hook 1: vision-aware prioritisation
         vision = load_vision(workspace)
@@ -2668,7 +2674,7 @@ async def orchestrate_project(
                         repo, exc,
                     )
 
-    return exit_code, stream_state
+    return exit_code, stream_state, True
 
 
 async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
@@ -2695,10 +2701,10 @@ async def orchestrate(config: dict, run_id: str, workspaces_dir: str) -> int:
 
     exit_code = 0
     for project in enabled_projects:
-        # orchestrate_project now returns (exit_code, stream_state); the
-        # legacy `orchestrate()` driver only cares about the exit code,
-        # discards the state.
-        proj_rc, _state = await orchestrate_project(
+        # orchestrate_project now returns (exit_code, stream_state, work_attempted);
+        # the legacy `orchestrate()` driver only cares about the exit code,
+        # discards the state and work_attempted flag.
+        proj_rc, _state, _work_attempted = await orchestrate_project(
             project, config, run_id, workspaces_dir,
         )
         if proj_rc != 0:

--- a/dashboard/backend/app/services/run_lifecycle.py
+++ b/dashboard/backend/app/services/run_lifecycle.py
@@ -158,6 +158,7 @@ async def handle_finished(
         "no_reports": "completed",
         "completed": "completed",
         "rate_limited": "completed",
+        "skipped": "skipped",       # #446 #447: idle runs (no eligible work)
         "error": "failed",
         "interrupted": "interrupted",
     }

--- a/dashboard/backend/tests/test_iterate_projects_python.py
+++ b/dashboard/backend/tests/test_iterate_projects_python.py
@@ -614,3 +614,135 @@ def test_iterate_projects_returns_3tuple_on_preflight_failure(tmp_path, monkeypa
     exit_code, _last_state, terminal_status_hint = result
     assert exit_code == 2
     assert terminal_status_hint is None
+
+
+def test_iterate_projects_returns_skipped_hint_when_all_projects_idle(
+    tmp_path, monkeypatch
+):
+    """Run-level: all projects idle, no failures → terminal_status_hint='skipped'."""
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"projects":['
+        '{"repo":"a/a","enabled":true,"mode":"full"},'
+        '{"repo":"b/b","enabled":true,"mode":"full"}'
+        ']}'
+    )
+
+    async def fake_orchestrate(*a, **kw):
+        return (0, None, False)  # both projects idle
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    # Match the monkeypatch targets used in pre-existing tests in this file
+    # (Task 2 implementer found that the plan's lazy-import targets don't
+    # exist as module attributes; use the canonical module paths instead).
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    exit_code, _last_state, terminal_status_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "workspaces")
+    )
+
+    assert exit_code == 0
+    assert terminal_status_hint == "skipped"
+
+
+def test_iterate_projects_no_skipped_hint_when_any_project_did_work(
+    tmp_path, monkeypatch
+):
+    """Mixed: one idle, one did work → no skipped hint (run is completed)."""
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"projects":['
+        '{"repo":"a/a","enabled":true,"mode":"full"},'
+        '{"repo":"b/b","enabled":true,"mode":"full"}'
+        ']}'
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_orchestrate(*a, **kw):
+        call_count["n"] += 1
+        # First call: idle; second: did work
+        return (0, None, call_count["n"] != 1)
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    # Second project's verdicts file present, empty verdicts (happy minimal).
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda p: {"verdicts": []},
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    exit_code, _last_state, terminal_status_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "workspaces")
+    )
+
+    assert exit_code == 0
+    assert terminal_status_hint is None, (
+        "Mixed idle+work runs must NOT be marked skipped"
+    )
+
+
+def test_iterate_projects_no_skipped_hint_when_any_real_failure(
+    tmp_path, monkeypatch
+):
+    """Mixed: one idle, one fails → no skipped hint (run is failed)."""
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"projects":['
+        '{"repo":"a/a","enabled":true,"mode":"full"},'
+        '{"repo":"b/b","enabled":true,"mode":"full"}'
+        ']}'
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_orchestrate(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return (0, None, False)   # idle
+        raise RuntimeError("simulated project failure")
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    exit_code, _last_state, terminal_status_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "workspaces")
+    )
+
+    assert exit_code != 0
+    assert terminal_status_hint is None, (
+        "Run with a real failure must NOT be marked skipped"
+    )

--- a/dashboard/backend/tests/test_iterate_projects_python.py
+++ b/dashboard/backend/tests/test_iterate_projects_python.py
@@ -28,9 +28,9 @@ def test_iterate_projects_calls_each_phase_when_manager_produces_verdicts(
 
     async def _fake_orchestrate(project, config, run_id, workspaces_dir):
         call_log.append("orchestrate_project")
-        # orchestrate_project returns (exit_code, stream_state) — None state
-        # is the documented value when the orchestrator session never ran.
-        return 0, None
+        # orchestrate_project returns (exit_code, stream_state, work_attempted).
+        # None stream_state is the documented value when the session never ran.
+        return 0, None, True
 
     monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
     # Happy-path mock: manager produced a verdicts file with no verdicts.
@@ -82,7 +82,7 @@ def test_iterate_projects_flags_missing_verdicts_file(tmp_path, monkeypatch):
     monkeypatch.setattr("agent.workspace_setup.ensure_workspace", lambda p, w: str(tmp_path))
 
     async def _fake_orchestrate(project, config, run_id, workspaces_dir):
-        return 0, None
+        return 0, None, True
 
     monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
     # No verdicts file: simulate manager crash / max-turns / never-spawned.
@@ -154,7 +154,7 @@ def test_iterate_projects_passes_workspace_and_dev_branch_to_executor(
     )
 
     async def _fake_orchestrate(project, config, run_id, workspaces_dir):
-        return 0, None
+        return 0, None, True
 
     monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
     monkeypatch.setattr(
@@ -237,7 +237,7 @@ def test_iterate_projects_emits_manager_no_verdicts_with_kwargs(
     )
 
     async def _fake_orchestrate(*a, **k):
-        return 0, None
+        return 0, None, True
 
     monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
     # Missing verdicts file → manager_no_verdicts branch fires.
@@ -323,7 +323,7 @@ def test_iterate_projects_skips_downstream_phases_when_no_verdicts(
     )
 
     async def _fake_orchestrate(*a, **k):
-        return 0, None
+        return 0, None, True
 
     monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
     # No verdicts file → no-verdicts branch must fire.
@@ -394,7 +394,7 @@ def test_iterate_projects_emits_plan_review_start_with_kwargs(
     )
 
     async def _fake_orchestrate(*a, **k):
-        return 0, None
+        return 0, None, True
 
     monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
     monkeypatch.setattr(
@@ -456,7 +456,7 @@ def test_iterate_projects_swallows_executor_exceptions_per_verdict(
     )
 
     async def _fake_orchestrate(*a, **k):
-        return 0, None
+        return 0, None, True
 
     monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
     monkeypatch.setattr(

--- a/dashboard/backend/tests/test_iterate_projects_python.py
+++ b/dashboard/backend/tests/test_iterate_projects_python.py
@@ -43,7 +43,7 @@ def test_iterate_projects_calls_each_phase_when_manager_produces_verdicts(
     )
     monkeypatch.setattr("agent.digest.write_digest", lambda **kw: call_log.append("digest") or "")
 
-    rc, last_state = pl.iterate_projects("run-test", str(cfg), str(tmp_path))
+    rc, last_state, _hint = pl.iterate_projects("run-test", str(cfg), str(tmp_path))
 
     assert rc == 0
     assert last_state is None
@@ -92,7 +92,7 @@ def test_iterate_projects_flags_missing_verdicts_file(tmp_path, monkeypatch):
     )
     monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
 
-    rc, _ = pl.iterate_projects("run-test", str(cfg), str(tmp_path))
+    rc, _, _hint = pl.iterate_projects("run-test", str(cfg), str(tmp_path))
     assert rc == 6, "missing verdicts file must bump exit_code to 6"
 
 
@@ -187,7 +187,7 @@ def test_iterate_projects_passes_workspace_and_dev_branch_to_executor(
 
     monkeypatch.setattr("agent.verdict_execution.execute", _fake_execute)
 
-    rc, _ = pl.iterate_projects("run-tested", str(cfg), str(tmp_path))
+    rc, _, _hint = pl.iterate_projects("run-tested", str(cfg), str(tmp_path))
 
     assert rc == 0, "happy-path verdict execution must not bump exit_code"
     assert captured, "execute_verdict was never invoked"
@@ -257,7 +257,7 @@ def test_iterate_projects_emits_manager_no_verdicts_with_kwargs(
 
     monkeypatch.setattr("agent.webhook_emitter.emit", _fake_emit)
 
-    rc, _ = pl.iterate_projects("test-run", str(cfg), str(tmp_path))
+    rc, _, _hint = pl.iterate_projects("test-run", str(cfg), str(tmp_path))
 
     assert rc == 6, "missing verdicts file must bump exit_code to 6"
     assert captured, (
@@ -350,7 +350,7 @@ def test_iterate_projects_skips_downstream_phases_when_no_verdicts(
 
     monkeypatch.setattr("agent.verdict_execution.execute", _spy_execute)
 
-    rc, _ = pl.iterate_projects("run-skip", str(cfg), str(tmp_path))
+    rc, _, _hint = pl.iterate_projects("run-skip", str(cfg), str(tmp_path))
 
     assert rc == 6, "missing verdicts file must bump exit_code to 6"
     assert gate_calls == [], (
@@ -482,9 +482,135 @@ def test_iterate_projects_swallows_executor_exceptions_per_verdict(
 
     monkeypatch.setattr("agent.verdict_execution.execute", _flaky_execute)
 
-    rc, _ = pl.iterate_projects("run-flaky", str(cfg), str(tmp_path))
+    rc, _, _hint = pl.iterate_projects("run-flaky", str(cfg), str(tmp_path))
 
     assert seen == [1, 2], (
         f"loop must continue past the crash; saw issue numbers {seen}"
     )
     assert rc != 0, "executor failure should bump exit_code"
+
+
+def test_iterate_projects_emits_project_skipped_no_work_when_no_work_attempted(
+    tmp_path, monkeypatch
+):
+    """Idle case: orchestrate_project returns work_attempted=False →
+    iterate_projects emits project_skipped_no_work, NOT
+    manager_no_verdicts, and does not bump exit_code.
+
+    Spec: docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md
+    Issues: #446 #447
+    """
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"projects":[{"repo":"test/repo","enabled":true,"mode":"full"}]}')
+    workspaces_dir = str(tmp_path / "workspaces")
+
+    captured_emits: list[tuple] = []
+
+    def fake_emit(event, *, run_id, payload=None):
+        captured_emits.append((event, run_id, payload))
+
+    async def fake_orchestrate_async(*args, **kwargs):
+        return (0, None, False)
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate_async
+    )
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", fake_emit)
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    exit_code, _last_state, _terminal_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), workspaces_dir
+    )
+
+    emit_names = [e[0] for e in captured_emits]
+    assert "project_skipped_no_work" in emit_names, (
+        f"Expected project_skipped_no_work emit, got: {emit_names}"
+    )
+    assert "manager_no_verdicts" not in emit_names, (
+        f"manager_no_verdicts must NOT fire in idle case, got: {emit_names}"
+    )
+
+    skip_event = next(e for e in captured_emits if e[0] == "project_skipped_no_work")
+    assert skip_event[1] == "run-test-run", f"run_id wrong: {skip_event[1]}"
+    assert skip_event[2] is not None
+    assert skip_event[2].get("project") == "test/repo"
+    assert skip_event[2].get("reason") == "no_eligible_work"
+
+    assert exit_code == 0
+
+
+def test_iterate_projects_still_emits_manager_no_verdicts_for_real_failure(
+    tmp_path, monkeypatch
+):
+    """Regression pin: work_attempted=True + verdicts file missing must
+    still trigger the existing manager_no_verdicts path (exit_code=6).
+    The work_attempted discriminator must not suppress real failures.
+    """
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"projects":[{"repo":"test/repo","enabled":true,"mode":"full"}]}')
+    workspaces_dir = str(tmp_path / "workspaces")
+
+    captured_emits: list[tuple] = []
+
+    def fake_emit(event, *, run_id, payload=None):
+        captured_emits.append((event, run_id, payload))
+
+    async def fake_orchestrate(*a, **kw):
+        return (0, None, True)
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file", lambda p: None
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", fake_emit)
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    exit_code, _last_state, _terminal_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), workspaces_dir
+    )
+
+    emit_names = [e[0] for e in captured_emits]
+    assert "manager_no_verdicts" in emit_names
+    assert "project_skipped_no_work" not in emit_names
+    assert exit_code == 6
+
+
+def test_iterate_projects_returns_3tuple_on_preflight_failure(tmp_path, monkeypatch):
+    """Regression: preflight failure path must return a 3-tuple so
+    RunDriver.run's unpack doesn't crash. #446 #447."""
+    from agent import project_loop
+    from agent.preflight import PreflightError
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"projects":[{"repo":"x/x","enabled":true}]}')
+
+    def boom(*a, **kw):
+        raise PreflightError("simulated")
+
+    monkeypatch.setattr("agent.preflight.run_preflight", boom)
+
+    result = project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "ws")
+    )
+    assert len(result) == 3, f"expected 3-tuple, got {len(result)}-tuple"
+    exit_code, _last_state, terminal_status_hint = result
+    assert exit_code == 2
+    assert terminal_status_hint is None

--- a/dashboard/backend/tests/test_orchestrate_project_work_attempted.py
+++ b/dashboard/backend/tests/test_orchestrate_project_work_attempted.py
@@ -1,0 +1,134 @@
+"""Tests for the work_attempted bool in orchestrate_project's return.
+
+Spec: docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md
+Issues: #446, #447
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# These tests verify the new return contract introduced by Task 1 of the
+# idle-run-semantics plan. They mock the picker so the function returns
+# from its early-exit branch (no eligible issues) without booting the
+# SDK session, OR from a path that did open the session.
+
+
+async def test_orchestrate_project_returns_work_attempted_false_when_no_eligible_issues(
+    tmp_path,
+):
+    """When the picker finds no eligible issues, orchestrate_project must
+    return (exit_code, None, False) — no SDK session was opened."""
+    from agent import station_orchestrator as so
+
+    project = {"repo": "test/repo", "id": 1, "mode": "full"}
+    config = {
+        "projects": [project],
+        "logging": {"log_dir": str(tmp_path)},
+    }
+
+    # Force the no-eligible-issues short-circuit:
+    # fetch_eligible_issues returns [] AND claim_pending_queue_items returns []
+    # → handle_empty_backlog runs → function returns at the early-exit point.
+    # orchestrate_project ignores handle_empty_backlog's return value, so a
+    # ``lambda: None`` patch reflects the real contract — see review of
+    # commit 93d8ddd, Finding 3.
+    with patch.object(so, "fetch_eligible_issues", return_value=[]), \
+         patch.object(so, "claim_pending_queue_items", AsyncMock(return_value=[])), \
+         patch.object(so, "handle_empty_backlog", lambda *a, **kw: None), \
+         patch.object(so, "_ensure_workspace", return_value=None):
+        result = await so.orchestrate_project(project, config, "test-run", str(tmp_path))
+
+    assert len(result) == 3, f"Expected 3-tuple, got {len(result)}-tuple"
+    exit_code, stream_state, work_attempted = result
+    assert work_attempted is False, (
+        "work_attempted must be False when no eligible issues found"
+    )
+    assert stream_state is None
+    assert exit_code == 0
+
+
+async def test_orchestrate_project_returns_work_attempted_true_when_session_opened(
+    monkeypatch, tmp_path,
+):
+    """When the SDK session opens (eligible issues found), work_attempted
+    must be True even if the session later errors out."""
+    from agent import station_orchestrator as so
+
+    project = {"repo": "owner/repo", "id": 1, "mode": "full"}
+    config = {
+        "projects": [project],
+        "limits": {"max_concurrent_employees": 1},
+        "models": {},
+        "logging": {"log_dir": str(tmp_path)},
+    }
+    fake_issue = {"number": 1, "title": "test", "body": "", "labels": []}
+
+    # Build a minimal fake ClaudeSDKClient that enters/exits without error
+    # and yields a result message so the session completes cleanly.
+    init_msg = MagicMock(spec=so.SystemMessage)
+    init_msg.subtype = "init"
+    init_msg.session_id = "sess-1"
+
+    result_msg = MagicMock(spec=so.ResultMessage)
+    result_msg.session_id = "sess-1"
+    result_msg.result = "All teammates have completed. Final summary."
+    result_msg.is_error = False
+    result_msg.duration_ms = 100
+    result_msg.num_turns = 1
+
+    class _FakeClient:
+        def __init__(self, *, options=None):
+            self.options = options
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def query(self, prompt: str):
+            pass
+
+        async def receive_response(self):
+            for msg in [init_msg, result_msg]:
+                yield msg
+
+        async def interrupt(self):
+            pass
+
+    # Picker returns one issue → session opens. Mock everything downstream
+    # to a no-op success so we just verify the work_attempted=True signal.
+    # Explicit patches for every side-effect inside the session body
+    # (build_run_complete_server, _ensure_review_package,
+    # _synthesize_employee_report) prevent this test from depending on the
+    # ``except Exception`` guards that wrap them — see review of commit
+    # 93d8ddd, Finding 2.
+    monkeypatch.setattr(so, "ClaudeSDKClient", lambda options=None: _FakeClient(options=options))
+    monkeypatch.setattr(so, "_ensure_workspace", lambda *a, **k: None)
+    monkeypatch.setattr(so, "post_webhook", lambda *a, **k: None)
+    monkeypatch.setattr(so, "fetch_eligible_issues", lambda *a, **k: [fake_issue])
+    monkeypatch.setattr(so, "claim_pending_queue_items", AsyncMock(return_value=[]))
+    monkeypatch.setattr(so, "load_vision", lambda *a, **k: None)
+    monkeypatch.setattr(so, "_combined_rank_issues", lambda issues, **k: issues)
+    monkeypatch.setattr(so, "build_team_prompt", lambda *a, **k: "test prompt")
+    monkeypatch.setattr(so, "build_followup_prompt", lambda *a, **k: "followup prompt")
+    monkeypatch.setattr(so, "handle_stream_event", AsyncMock())
+    monkeypatch.setattr(so, "_control_poll_loop", AsyncMock())
+    monkeypatch.setattr(so, "build_run_complete_server", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(so, "_ensure_review_package", lambda *a, **k: None)
+    monkeypatch.setattr(so, "_synthesize_employee_report", lambda *a, **k: None)
+    monkeypatch.setattr(so.asyncio, "sleep", AsyncMock())
+    import subprocess as _sp
+    monkeypatch.setattr(_sp, "run", lambda *a, **k: MagicMock(returncode=0, stderr=""))
+
+    result = await so.orchestrate_project(project, config, "test-run", str(tmp_path))
+
+    assert len(result) == 3
+    _exit_code, _stream_state, work_attempted = result
+    assert work_attempted is True, (
+        "work_attempted must be True once the SDK session is opened"
+    )

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -950,7 +950,7 @@ def test_iterate_projects_emits_plan_review_start_for_plan_only(
     )
 
     async def _fake_orchestrate(project, config, run_id, workspaces_dir):
-        return 0, None
+        return 0, None, True
 
     monkeypatch.setattr(
         "agent.station_orchestrator.orchestrate_project", _fake_orchestrate,
@@ -1011,7 +1011,7 @@ def test_iterate_projects_invokes_plan_review_gate_for_plan_only(
     )
 
     async def _fake_orchestrate(project, config, run_id, workspaces_dir):
-        return 0, None
+        return 0, None, True
 
     monkeypatch.setattr(
         "agent.station_orchestrator.orchestrate_project", _fake_orchestrate,

--- a/dashboard/backend/tests/test_run_driver.py
+++ b/dashboard/backend/tests/test_run_driver.py
@@ -10,7 +10,7 @@ def test_run_driver_emits_run_start_then_run_complete_on_success():
     via webhook_emitter, replacing the bash EXIT-trap construct."""
     from agent.station_orchestrator import RunDriver
     with patch("agent.station_orchestrator.emit") as mock_emit, \
-         patch("agent.project_loop.iterate_projects", return_value=(0, None)):
+         patch("agent.project_loop.iterate_projects", return_value=(0, None, None)):
         driver = RunDriver(run_id="run-driver-1",
                            config_path="/tmp/cfg.json",
                            workspaces_dir="/tmp/ws")
@@ -47,7 +47,7 @@ def test_run_driver_emits_run_complete_even_on_exception():
 def test_run_driver_emits_run_complete_with_completed_status_on_success():
     from agent.station_orchestrator import RunDriver
     with patch("agent.station_orchestrator.emit") as mock_emit, \
-         patch("agent.project_loop.iterate_projects", return_value=(0, None)):
+         patch("agent.project_loop.iterate_projects", return_value=(0, None, None)):
         driver = RunDriver(run_id="run-driver-3",
                            config_path="/tmp/cfg.json",
                            workspaces_dir="/tmp/ws")
@@ -69,7 +69,7 @@ def test_run_driver_passes_bare_run_id_to_iterate_projects():
     from agent.station_orchestrator import RunDriver
     with patch("agent.station_orchestrator.emit"), \
          patch("agent.project_loop.iterate_projects",
-               return_value=(0, None)) as mock_iter:
+               return_value=(0, None, None)) as mock_iter:
         driver = RunDriver(run_id="run-20260515T234700Z",
                            config_path="/tmp/cfg.json",
                            workspaces_dir="/tmp/ws")
@@ -88,7 +88,7 @@ def test_run_driver_bare_run_id_passes_through_unchanged():
     from agent.station_orchestrator import RunDriver
     with patch("agent.station_orchestrator.emit"), \
          patch("agent.project_loop.iterate_projects",
-               return_value=(0, None)) as mock_iter:
+               return_value=(0, None, None)) as mock_iter:
         driver = RunDriver(run_id="20260515T234700Z",
                            config_path="/tmp/cfg.json",
                            workspaces_dir="/tmp/ws")

--- a/dashboard/backend/tests/test_run_driver_payload.py
+++ b/dashboard/backend/tests/test_run_driver_payload.py
@@ -44,7 +44,7 @@ def test_run_start_payload_carries_full_bash_field_set(tmp_path):
 
     cfg_path = _write_config(tmp_path)
     with patch("agent.station_orchestrator.emit") as mock_emit, \
-         patch("agent.project_loop.iterate_projects", return_value=(0, None)), \
+         patch("agent.project_loop.iterate_projects", return_value=(0, None, None)), \
          patch.dict("os.environ", {"STATION_LOG_DIR": str(tmp_path)}):
         driver = RunDriver(run_id="run-test-1",
                            config_path=str(cfg_path),
@@ -70,7 +70,7 @@ def test_run_complete_falls_back_to_zero_telemetry_when_dump_missing(tmp_path):
 
     cfg_path = _write_config(tmp_path)
     with patch("agent.station_orchestrator.emit") as mock_emit, \
-         patch("agent.project_loop.iterate_projects", return_value=(0, None)), \
+         patch("agent.project_loop.iterate_projects", return_value=(0, None, None)), \
          patch.dict("os.environ", {"STATION_LOG_DIR": str(tmp_path)}):
         driver = RunDriver(run_id="run-test-3",
                            config_path=str(cfg_path),
@@ -114,7 +114,7 @@ def test_run_complete_status_interrupted_on_child_exit_130(tmp_path):
 
     cfg_path = _write_config(tmp_path)
     with patch("agent.station_orchestrator.emit") as mock_emit, \
-         patch("agent.project_loop.iterate_projects", return_value=(130, None)), \
+         patch("agent.project_loop.iterate_projects", return_value=(130, None, None)), \
          patch.dict("os.environ", {"STATION_LOG_DIR": str(tmp_path)}):
         driver = RunDriver(run_id="run-test-5",
                            config_path=str(cfg_path),
@@ -135,7 +135,7 @@ def test_run_id_is_normalized_to_run_prefix_on_the_wire(tmp_path):
     cfg_path = _write_config(tmp_path)
     # Caller passes without the prefix.
     with patch("agent.station_orchestrator.emit") as mock_emit, \
-         patch("agent.project_loop.iterate_projects", return_value=(0, None)), \
+         patch("agent.project_loop.iterate_projects", return_value=(0, None, None)), \
          patch.dict("os.environ", {"STATION_LOG_DIR": str(tmp_path)}):
         driver = RunDriver(run_id="bareid-1",
                            config_path=str(cfg_path),
@@ -154,7 +154,7 @@ def test_run_complete_status_failed_on_nonzero_non_130_exit(tmp_path):
 
     cfg_path = _write_config(tmp_path)
     with patch("agent.station_orchestrator.emit") as mock_emit, \
-         patch("agent.project_loop.iterate_projects", return_value=(1, None)), \
+         patch("agent.project_loop.iterate_projects", return_value=(1, None, None)), \
          patch.dict("os.environ", {"STATION_LOG_DIR": str(tmp_path)}):
         driver = RunDriver(run_id="run-test-6",
                            config_path=str(cfg_path),
@@ -175,7 +175,7 @@ def test_telemetry_init_handles_missing_or_invalid_config(tmp_path):
     from agent.station_orchestrator import RunDriver
 
     with patch("agent.station_orchestrator.emit"), \
-         patch("agent.project_loop.iterate_projects", return_value=(0, None)), \
+         patch("agent.project_loop.iterate_projects", return_value=(0, None, None)), \
          patch.dict("os.environ", {"STATION_LOG_DIR": str(tmp_path)}):
         driver = RunDriver(run_id="run-test-7",
                            config_path=str(tmp_path / "nonexistent.json"),

--- a/dashboard/backend/tests/test_run_lifecycle.py
+++ b/dashboard/backend/tests/test_run_lifecycle.py
@@ -88,3 +88,46 @@ async def test_handle_finished_orphans_running_coordinator_tasks(setup_db):
         assert by_id["t-zombie-claim"].status == "orphaned"
         assert by_id["t-zombie-claim"].claimed_at is None
         assert by_id["t-other-run"].status == "running"
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_maps_skipped_to_skipped(setup_db):
+    """Agent-side status='skipped' must persist as row status='skipped',
+    not fall through to default mapping. #446 #447."""
+    event = WebhookRunEvent(
+        event="finished",
+        event_id="evt-test-skipped",
+        run_id="run-test-skipped",
+        status="skipped",
+    )
+
+    async with async_session() as db:
+        run = await handle_finished(db, event, project_id=None, run=None)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.status == "skipped", (
+        f"Expected status='skipped', got '{run.status}'. "
+        "If 'skipped' is missing from the status_map, this regresses."
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_does_not_remap_skipped_to_failed(setup_db):
+    """Regression pin: future map changes must not collapse skipped → failed."""
+    event = WebhookRunEvent(
+        event="finished",
+        event_id="evt-test-skipped-2",
+        run_id="run-test-skipped-2",
+        status="skipped",
+    )
+
+    async with async_session() as db:
+        run = await handle_finished(db, event, project_id=None, run=None)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.status != "failed", (
+        "Map drift: 'skipped' must not be remapped to 'failed'. "
+        "See spec docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md"
+    )

--- a/dashboard/frontend/src/app.css
+++ b/dashboard/frontend/src/app.css
@@ -361,6 +361,7 @@ code, .font-mono {
 .badge-pending { background: rgba(176,96,48,0.10); color: #B06030; }
 .badge-completed { background: rgba(46,125,50,0.12); color: #2E7D32; }
 .badge-failed { background: rgba(208,96,80,0.12); color: #D06050; }
+.badge-skipped { background: rgba(92,84,74,0.10); color: #5C544A; }
 
 /* Mode badges */
 .badge-full { background: rgba(176,96,48,0.10); color: #B06030; }
@@ -784,6 +785,7 @@ code, .font-mono {
 [data-theme="cyberpunk"] .badge-plan,
 [data-theme="cyberpunk"] .badge-triage,
 [data-theme="cyberpunk"] .badge-vision-bootstrap { color: #FCEE0A; }
+[data-theme="cyberpunk"] .badge-skipped { color: #8FB7C8; }
 
 /* --- Buttons --- */
 [data-theme="cyberpunk"] .btn {

--- a/dashboard/frontend/src/components/dag/DAGNode.svelte
+++ b/dashboard/frontend/src/components/dag/DAGNode.svelte
@@ -26,6 +26,7 @@
     running: { bg: 'color-mix(in oklch, var(--color-warning) 15%, var(--color-surface))', border: 'var(--color-warning)', text: 'var(--color-warning)' },
     completed: { bg: 'color-mix(in oklch, var(--color-approve) 15%, var(--color-surface))', border: 'var(--color-approve)', text: 'var(--color-approve)' },
     failed: { bg: 'color-mix(in oklch, var(--color-reject) 15%, var(--color-surface))', border: 'var(--color-reject)', text: 'var(--color-reject)' },
+    skipped: { bg: 'var(--color-surface)', border: 'var(--color-text-muted)', text: 'var(--color-text-muted)' },
     blocked: { bg: 'var(--color-surface)', border: 'var(--color-text-muted)', text: 'var(--color-text-muted)' },
   };
 

--- a/dashboard/frontend/src/lib/types.ts
+++ b/dashboard/frontend/src/lib/types.ts
@@ -19,7 +19,9 @@ export type ProviderName = 'openai' | 'gemini';
 
 // --- Enums ---
 export type AgentMode = 'full' | 'analyze' | 'plan' | 'plan_only' | 'triage' | 'review' | 'fix';
-export type RunStatus = 'started' | 'employee_done' | 'reviewing' | 'finished' | 'verdict' | 'plan_reviewing' | 'plan_review_done' | 'awaiting_plan_review' | 'plan_approved' | 'plan_rejected' | string;
+export type RunStatus = 'started' | 'employee_done' | 'reviewing' | 'finished' | 'verdict' | 'plan_reviewing' | 'plan_review_done' | 'awaiting_plan_review' | 'plan_approved' | 'plan_rejected'
+  | 'skipped' // #446 #447: idle runs (no eligible work)
+  | string;
 export type Verdict = 'APPROVE' | 'APPROVE_INTEGRATION' | 'PR' | 'REJECT';
 export type QueueState = 'pending' | 'assigned' | 'claimed' | 'planning' | 'in_progress' | 'review' | 'verifying' | 'approved' | 'rejected' | 'escalated' | 'paused' | 'failed' | 'cancelled' | 'completed';
 export type PlanStatus = 'draft' | 'approved' | 'implementing' | 'completed' | 'rejected';

--- a/dashboard/frontend/src/pages/CommandCenter.svelte
+++ b/dashboard/frontend/src/pages/CommandCenter.svelte
@@ -136,6 +136,7 @@
     if (s === 'interrupted') return { label: 'STOP', cls: 'stop', tick: false };
     if (s === 'failed' || s === 'error') return { label: 'FAIL', cls: 'planx', tick: false };
     if (s === 'completed' || s === 'finished' || s === 'success') return { label: 'DONE', cls: 'done', tick: false };
+    if (s === 'skipped') return { label: 'SKIP', cls: 'idle', tick: false };
     if (!r.status && !r.finished_at) return { label: 'IDLE', cls: 'idle', tick: false };
     return { label: (r.status ?? 'IDLE').toUpperCase().slice(0, 6), cls: 'idle', tick: false };
   }

--- a/dashboard/frontend/src/pages/ProjectDetail.svelte
+++ b/dashboard/frontend/src/pages/ProjectDetail.svelte
@@ -89,6 +89,7 @@
     if (s === 'interrupted') return { label: 'STOP', cls: 'stop', tick: false };
     if (s === 'failed' || s === 'error') return { label: 'FAIL', cls: 'planx', tick: false };
     if (s === 'completed' || s === 'finished' || s === 'success') return { label: 'DONE', cls: 'done', tick: false };
+    if (s === 'skipped') return { label: 'SKIP', cls: 'idle', tick: false };
     if (!r.status && !r.finished_at) return { label: 'IDLE', cls: 'idle', tick: false };
     return { label: (r.status ?? 'IDLE').toUpperCase().slice(0, 6), cls: 'idle', tick: false };
   }

--- a/dashboard/frontend/src/pages/RunDetail.svelte
+++ b/dashboard/frontend/src/pages/RunDetail.svelte
@@ -713,7 +713,7 @@
               <div class="key-row"><span class="k">Autonomy</span><span class="v">{run.autonomy_level ?? 'assisted'}</span></div>
               <div class="key-row">
                 <span class="k">Status</span>
-                <span class="v" style="color: {isLive ? 'var(--go)' : run.status === 'failed' ? 'var(--abort)' : 'var(--ink)'}">{run.status}</span>
+                <span class="v" style="color: {isLive ? 'var(--go)' : run.status === 'failed' ? 'var(--abort)' : run.status === 'skipped' ? 'var(--graphite)' : 'var(--ink)'}">{run.status}</span>
               </div>
               <div class="key-row">
                 <span class="k">Verdict</span>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -384,6 +384,49 @@ surfaces every gate state via banners on Mission Control and the Agent
 Teams canvas. See `docs/configuration.md#plan-review-gate-plan_only-only`
 for the full env-var matrix and verdict-action table.
 
+### Run status values (`runs.status`)
+
+Terminal states written to the `runs` table and mapped by `app/services/run_lifecycle.py`:
+
+| Status | Meaning |
+|---|---|
+| `running` | Run is active; orchestrator in progress. |
+| `completed` | Run finished with work attempted and all projects resolved (agent-side values `success`, `finished`, `no_reports`, `completed`, `rate_limited` all map here). |
+| `skipped` | Run finished cleanly with no eligible work to do in any configured project. Distinct from `failed`. Introduced 2026-05-17 (#446 / #447). |
+| `failed` | Run encountered a genuine error (e.g. manager produced no verdicts after work was attempted, orchestrator exception). |
+| `interrupted` | Run was stopped externally via a `run_controls` signal. |
+| `plan_reviewing` | `plan_only` run: manager is reviewing the plan. |
+| `awaiting_plan_review` | `plan_only` run: gate is open, waiting for human approval. |
+| `plan_approved` | `plan_only` run: plan approved; follow-up `full` run enqueued. Terminal. |
+| `plan_rejected` | `plan_only` run: plan rejected or revision budget exhausted. Terminal. |
+
+### Webhook events (agent → dashboard)
+
+Events posted to `POST /api/webhook` by `agent/webhook_emitter.py` and routed in `dashboard/backend/app/routers/webhook.py`:
+
+| Event | Description |
+|---|---|
+| `run_start` | Run has begun; creates or reactivates the `runs` row. |
+| `run_complete` | Run has finished; sets terminal status and `finished_at`. |
+| `manager_no_verdicts` | Manager was spawned but produced no verdicts file (genuine failure). Payload includes `exit_code=6`. Distinct from `project_skipped_no_work`. |
+| `project_skipped_no_work` | Emitted per-project when the orchestrator found no eligible work and did not open the SDK session. Payload: `{project, reason}` where `reason` is `"no_eligible_work"`. Run-level analogue: `runs.status="skipped"`. Introduced 2026-05-17 (#447). |
+| `plan_review_start` | `plan_only`: teammates have written a plan; manager review begins. |
+| `awaiting_plan_review` | `plan_only`: gate is open; waiting for human decision. |
+| `plan_approved` | `plan_only`: human approved the plan. |
+| `plan_rejected` | `plan_only`: plan rejected or revision budget exhausted. |
+
+### Per-project digest decision values
+
+Each project entry in the run digest carries a `decision` field written by `iterate_projects`:
+
+| Decision | Meaning |
+|---|---|
+| `APPROVE` | Manager approved the implementation; branch ready for merge. |
+| `PR` | Manager opened a pull request. |
+| `REJECT` | Manager rejected the implementation; no PR opened. |
+| `SKIP` | Project had no eligible work; no SDK session was opened. Paired with the `project_skipped_no_work` webhook. |
+| `ERROR` | Orchestrator or manager encountered an error while processing the project. |
+
 ---
 
 ## Deployment Model

--- a/docs/superpowers/plans/2026-05-17-idle-run-semantics.md
+++ b/docs/superpowers/plans/2026-05-17-idle-run-semantics.md
@@ -1,0 +1,1191 @@
+# Idle-Run Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce `status="skipped"` and `project_skipped_no_work` so idle runs (no eligible work) are visually and semantically distinct from genuine failures.
+
+**Architecture:** Thread a `work_attempted: bool` from `orchestrate_project` through `iterate_projects` to `RunDriver`. Idle per-project: emit new `project_skipped_no_work`, append `SKIP` digest entry, do NOT bump exit_code, do NOT touch verdicts file. Idle run-level: `RunDriver` emits `run_complete` with `status="skipped"` iff every project was idle and no real failure occurred. `run_lifecycle.handle_finished` adds `"skipped" → "skipped"` to its status map. Frontend gets a neutral-grey badge variant.
+
+**Tech Stack:** Python 3.11 / FastAPI / SQLite / pytest / Svelte 5 / TypeScript
+
+**Spec:** `docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md`
+**Issues:** Closes #446, Closes #447
+**Target branch:** PR `--base dev` (per project policy)
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `agent/station_orchestrator.py` | Change `orchestrate_project` return to 3-tuple `(rc, state, work_attempted)`; `RunDriver.run` unpacks new bool from `iterate_projects`'s return and chooses `status="skipped"` when applicable |
+| `agent/project_loop.py` | Unpack 3-tuple from `orchestrate_project`; per-project: emit `project_skipped_no_work` for the idle case, skip verdicts read, `continue`; track `any_work_attempted` / `any_real_failure`; return new 3-tuple `(exit_code, last_state, terminal_status_hint)` to `RunDriver` |
+| `dashboard/backend/app/services/run_lifecycle.py` | Add `"skipped": "skipped"` to `handle_finished`'s `status_map` (line ~155) |
+| `dashboard/frontend/src/lib/types.ts` | Add `"skipped"` to run-status union; add `"project_skipped_no_work"` to event-name union |
+| `dashboard/frontend/src/lib/run-status.ts` (or wherever badge mapping lives — verify during Task 8) | Add `skipped` → neutral-grey badge variant |
+| `docs/architecture.md` | Document new status + new event |
+| `dashboard/backend/tests/test_iterate_projects_python.py` | New tests: idle emission, real-failure still emits manager_no_verdicts, run-level skipped, mixed-status precedence |
+| `dashboard/backend/tests/test_run_lifecycle.py` (or appropriate existing file — verify during Task 7) | New tests: `handle_finished` maps `skipped` → `skipped`; regression that `skipped` is NOT remapped to `failed` |
+| `agent/tests/test_orchestrate_project_work_attempted.py` (or `dashboard/backend/tests/` if that's the convention — verify) | New tests: `orchestrate_project` returns `work_attempted=False` for no-eligible-issues, `True` for happy path |
+
+---
+
+## Task 1: Add `work_attempted` to `orchestrate_project` return contract
+
+**Files:**
+- Modify: `agent/station_orchestrator.py:2011-2165` (signature + the no-eligible-issues early return at line 2165) and `:2671` (the happy-path return)
+- Test: `dashboard/backend/tests/test_orchestrate_project_work_attempted.py` (create)
+
+The signature change is contagious — `iterate_projects` is the only caller. Tasks 2-3 unpack the new tuple; this task just defines and tests the new return contract.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `dashboard/backend/tests/test_orchestrate_project_work_attempted.py`:
+
+```python
+"""Tests for the work_attempted bool in orchestrate_project's return.
+
+Spec: docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md
+Issues: #446, #447
+"""
+
+from unittest.mock import patch, MagicMock
+import pytest
+
+# These tests verify the new return contract introduced by Task 1 of the
+# idle-run-semantics plan. They mock the picker so the function returns
+# from its early-exit branch (no eligible issues) without booting the
+# SDK session, OR from a path that did open the session.
+
+
+@pytest.mark.asyncio
+async def test_orchestrate_project_returns_work_attempted_false_when_no_eligible_issues():
+    """When the picker finds no eligible issues, orchestrate_project must
+    return (exit_code, None, False) — no SDK session was opened."""
+    from agent import station_orchestrator as so
+
+    project = {"repo": "test/repo", "id": 1, "mode": "full"}
+    config = {"projects": [project]}
+
+    # Force the no-eligible-issues short-circuit:
+    # _pick_eligible_issues returns [] → handle_empty_backlog runs →
+    # function returns at line 2165.
+    with patch.object(so, "_pick_eligible_issues", return_value=[]), \
+         patch.object(so, "handle_empty_backlog", return_value="no-eligible-issues-no-vision"), \
+         patch.object(so, "ensure_workspace", return_value="/tmp/test-ws"):
+        result = await so.orchestrate_project(project, config, "test-run", "/tmp")
+
+    assert len(result) == 3, f"Expected 3-tuple, got {len(result)}-tuple"
+    exit_code, stream_state, work_attempted = result
+    assert work_attempted is False, (
+        "work_attempted must be False when no eligible issues found"
+    )
+    assert stream_state is None
+    assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_orchestrate_project_returns_work_attempted_true_when_session_opened():
+    """When the SDK session opens (eligible issues found), work_attempted
+    must be True even if the session later errors out."""
+    from agent import station_orchestrator as so
+
+    project = {"repo": "test/repo", "id": 1, "mode": "full"}
+    config = {"projects": [project]}
+    fake_issue = {"number": 1, "title": "test", "body": "", "labels": []}
+
+    # Picker returns one issue → session opens. Mock everything downstream
+    # to a no-op success so we just verify the work_attempted=True signal.
+    with patch.object(so, "_pick_eligible_issues", return_value=[fake_issue]), \
+         patch.object(so, "ensure_workspace", return_value="/tmp/test-ws"), \
+         patch.object(so, "_run_agent_session", new_callable=MagicMock,
+                      return_value=(0, None)):
+        result = await so.orchestrate_project(project, config, "test-run", "/tmp")
+
+    assert len(result) == 3
+    _exit_code, _stream_state, work_attempted = result
+    assert work_attempted is True, (
+        "work_attempted must be True once the SDK session is opened"
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_orchestrate_project_work_attempted.py -xvs`
+Expected: FAIL — `ValueError: not enough values to unpack (expected 3, got 2)` or `AttributeError` depending on which mock surface drifted. Both tests must fail.
+
+- [ ] **Step 3: Modify `orchestrate_project` signature + early-return**
+
+Edit `agent/station_orchestrator.py:2011-2013`. Change signature from:
+
+```python
+async def orchestrate_project(
+    project: dict, config: dict, run_id: str, workspaces_dir: str,
+) -> tuple[int, "_StreamState | None"]:
+    """Run the Agent Teams session for a single project.
+
+    Returns ``(exit_code, stream_state)``. ``stream_state`` is ``None`` if
+    the project short-circuited before the orchestrator session began
+    (no eligible issues, workspace error, etc.). Callers use the returned
+    state for telemetry aggregation — see :class:`RunDriver._finalize_telemetry`.
+```
+
+to:
+
+```python
+async def orchestrate_project(
+    project: dict, config: dict, run_id: str, workspaces_dir: str,
+) -> tuple[int, "_StreamState | None", bool]:
+    """Run the Agent Teams session for a single project.
+
+    Returns ``(exit_code, stream_state, work_attempted)``.
+
+    - ``stream_state`` is ``None`` if the project short-circuited before
+      the SDK session began (no eligible issues, workspace error, etc.).
+    - ``work_attempted`` is ``False`` only when the picker returned no
+      eligible issues and the SDK session was never opened. ``True`` for
+      all other paths (session opened, errored, etc.) so that downstream
+      failure signals (manager_no_verdicts, exit_code bumps) are preserved.
+      Idle-run-semantics discriminator — see #446 / #447 / spec
+      ``docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md``.
+```
+
+Also fix the no-eligible-issues early return at line 2165. Change from:
+
+```python
+            return exit_code, None
+```
+
+to:
+
+```python
+            return exit_code, None, False
+```
+
+And the happy-path return at line 2671. Change from:
+
+```python
+    return exit_code, stream_state
+```
+
+to:
+
+```python
+    return exit_code, stream_state, True
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_orchestrate_project_work_attempted.py -xvs`
+Expected: PASS — both tests green.
+
+- [ ] **Step 5: Update `iterate_projects`'s call site to unpack 3-tuple (compat-only — full logic in Task 2)**
+
+`iterate_projects` will break at runtime until it unpacks the new tuple. Make a minimal compat edit now so the existing test suite isn't red between tasks.
+
+Edit `agent/project_loop.py:219-221`. Change from:
+
+```python
+            proj_rc, proj_state = asyncio.run(
+                orchestrate_project(project, config, run_id, workspaces_dir)
+            )
+```
+
+to:
+
+```python
+            proj_rc, proj_state, _work_attempted = asyncio.run(
+                orchestrate_project(project, config, run_id, workspaces_dir)
+            )
+```
+
+The `_` prefix signals "we'll use this in Task 2." Don't add logic on it yet.
+
+- [ ] **Step 6: Run the broader suite to confirm no regressions**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_iterate_projects_python.py tests/test_project_loop*.py tests/test_orchestrator_wiring.py -x`
+Expected: All previously-passing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/station_orchestrator.py agent/project_loop.py dashboard/backend/tests/test_orchestrate_project_work_attempted.py
+git commit -m "$(cat <<'EOF'
+feat(orchestrator): return work_attempted bool from orchestrate_project (#446 #447)
+
+Foundation for distinguishing idle runs (no eligible work) from
+genuine failures. orchestrate_project now returns a 3-tuple
+(exit_code, stream_state, work_attempted); the bool is False only
+on the no-eligible-issues early-exit path. iterate_projects unpacks
+the new value but does not yet branch on it (next task).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Per-project idle branch in `iterate_projects`
+
+**Files:**
+- Modify: `agent/project_loop.py:219-282` (the per-project loop body — branch on `work_attempted` before verdicts read)
+- Test: `dashboard/backend/tests/test_iterate_projects_python.py` (extend)
+
+This task moves the idle case off the `manager_no_verdicts` code path and onto the new `project_skipped_no_work` event. The "real failure" path (work_attempted=True + verdicts missing) is untouched.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `dashboard/backend/tests/test_iterate_projects_python.py` (at the end, with the other tests):
+
+```python
+def test_iterate_projects_emits_project_skipped_no_work_when_no_work_attempted(
+    tmp_path, monkeypatch
+):
+    """Idle case: orchestrate_project returns work_attempted=False →
+    iterate_projects emits project_skipped_no_work, NOT
+    manager_no_verdicts, and does not bump exit_code.
+
+    Spec: docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md
+    Issues: #446 #447
+    """
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"projects":[{"repo":"test/repo","enabled":true,"mode":"full"}]}')
+    workspaces_dir = str(tmp_path / "workspaces")
+
+    # Mock orchestrate_project to return the idle signal.
+    captured_emits: list[tuple] = []
+
+    def fake_emit(event, *, run_id, payload=None):
+        captured_emits.append((event, run_id, payload))
+
+    def fake_orchestrate(*args, **kwargs):
+        # (exit_code, stream_state, work_attempted=False)
+        return (0, None, False)
+
+    async def fake_orchestrate_async(*args, **kwargs):
+        return fake_orchestrate(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate_async
+    )
+    monkeypatch.setattr(
+        "agent.project_loop.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", fake_emit)
+
+    # Make purge/recover/preflight no-ops so we reach the loop.
+    monkeypatch.setattr("agent.project_loop.preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.resume_paused", lambda: None)
+
+    exit_code, _last_state, _terminal_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), workspaces_dir
+    )
+
+    # Assertions on emits
+    emit_names = [e[0] for e in captured_emits]
+    assert "project_skipped_no_work" in emit_names, (
+        f"Expected project_skipped_no_work emit, got: {emit_names}"
+    )
+    assert "manager_no_verdicts" not in emit_names, (
+        f"manager_no_verdicts must NOT fire in idle case, got: {emit_names}"
+    )
+
+    skip_event = next(e for e in captured_emits if e[0] == "project_skipped_no_work")
+    assert skip_event[1] == "run-test-run", f"run_id wrong: {skip_event[1]}"
+    assert skip_event[2] is not None
+    assert skip_event[2].get("project") == "test/repo"
+    assert skip_event[2].get("reason") == "no_eligible_work"
+
+    # Exit code must NOT be bumped — idle is not a failure.
+    assert exit_code == 0
+
+
+def test_iterate_projects_still_emits_manager_no_verdicts_for_real_failure(
+    tmp_path, monkeypatch
+):
+    """Regression pin: work_attempted=True + verdicts file missing must
+    still trigger the existing manager_no_verdicts path (exit_code=6).
+    The work_attempted discriminator must not suppress real failures.
+    """
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text('{"projects":[{"repo":"test/repo","enabled":true,"mode":"full"}]}')
+    workspaces_dir = str(tmp_path / "workspaces")
+
+    captured_emits: list[tuple] = []
+
+    def fake_emit(event, *, run_id, payload=None):
+        captured_emits.append((event, run_id, payload))
+
+    async def fake_orchestrate(*a, **kw):
+        return (0, None, True)  # work was attempted
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.project_loop.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    # _read_verdicts_file returns None → real failure branch
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file", lambda p: None
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", fake_emit)
+    monkeypatch.setattr("agent.project_loop.preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.resume_paused", lambda: None)
+
+    exit_code, _last_state, _terminal_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), workspaces_dir
+    )
+
+    emit_names = [e[0] for e in captured_emits]
+    assert "manager_no_verdicts" in emit_names, (
+        "manager_no_verdicts must still fire when work was attempted but verdicts missing"
+    )
+    assert "project_skipped_no_work" not in emit_names, (
+        "project_skipped_no_work must NOT fire when work was attempted"
+    )
+    assert exit_code == 6, f"exit_code must be 6 on real failure, got {exit_code}"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_iterate_projects_python.py::test_iterate_projects_emits_project_skipped_no_work_when_no_work_attempted tests/test_iterate_projects_python.py::test_iterate_projects_still_emits_manager_no_verdicts_for_real_failure -xvs`
+Expected: FAIL on the idle test (the new event is not yet emitted; either `project_skipped_no_work` missing or `manager_no_verdicts` present). The real-failure test may pass already (since `work_attempted` is unused) — that's fine; it just becomes a regression pin.
+
+Also: `iterate_projects` does not yet return a 3-tuple. The test `_terminal_hint` unpack will fail with `ValueError`. Both tests will fail at unpack.
+
+- [ ] **Step 3: Implement the idle branch + return 3-tuple**
+
+Edit `agent/project_loop.py`. Three changes in the same edit:
+
+**3a.** At the call site (lines 218-238, after the `try/except` around `orchestrate_project`), rename `_work_attempted` → `work_attempted` (drop underscore so we use it) and insert the idle branch BEFORE the existing `verdicts_path = ...` block:
+
+```python
+        try:
+            proj_rc, proj_state, work_attempted = asyncio.run(
+                orchestrate_project(project, config, run_id, workspaces_dir)
+            )
+            if proj_state is not None:
+                last_state = proj_state
+            if proj_rc != 0:
+                exit_code = proj_rc
+        except (KeyboardInterrupt, OrchestratorStopRequested):
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("orchestrate_project failed for %s", project["repo"])
+            exit_code = 4
+            results.append({"project": project["repo"], "decision": "ERROR", "error": str(exc)})
+            continue
+
+        # #446 / #447: idle case — the project had no eligible issues
+        # and the SDK session was never opened. This is NOT a failure;
+        # don't read verdicts, don't emit manager_no_verdicts, don't
+        # bump exit_code. Emit project_skipped_no_work so the dashboard
+        # can render it distinctly from a real failure.
+        if not work_attempted:
+            try:
+                from agent.webhook_emitter import emit as _emit_skip
+                _emit_skip(
+                    "project_skipped_no_work",
+                    run_id=f"run-{run_id}",
+                    payload={
+                        "project": project.get("repo", ""),
+                        "reason": "no_eligible_work",
+                    },
+                )
+            except Exception:  # noqa: BLE001 — best-effort signal
+                # Same hygiene rule as the other emits in this module:
+                # logger.exception so any future signature drift surfaces
+                # with a traceback instead of vanishing into a one-liner.
+                logger.exception("project_skipped_no_work webhook emit failed")
+
+            results.append({
+                "project": project.get("repo", ""),
+                "decision": "SKIP",
+                "reason": "no_eligible_work",
+            })
+            continue
+
+        # #390: the manager is now a sibling agent inside the lead's SDK
+        # session. It writes verdicts to this path during the run; we just
+        # confirm the file exists and hand each verdict to the executor.
+        verdicts_path = Path(log_dir) / f"run-{run_id}-verdicts.json"
+        # ... (rest unchanged)
+```
+
+**3b.** Track run-level flags. Right before the `for project in enabled:` loop (around line 178), add:
+
+```python
+    any_work_attempted = False
+    any_real_failure = False
+```
+
+In the per-project `except Exception` clause (line 232) and the verdicts-missing real-failure branch (around line 244), and the verdict-execution failure path (line 336 — `exit_code = max(exit_code, 7)`), set `any_real_failure = True`. In the `if not work_attempted:` branch above, do NOT set either flag. In the happy path (after work_attempted was True), set `any_work_attempted = True` right after the unpack:
+
+```python
+            if proj_rc != 0:
+                exit_code = proj_rc
+                any_real_failure = True
+            if work_attempted:
+                any_work_attempted = True
+```
+
+(Place `any_work_attempted = True` BEFORE the `if not work_attempted: continue` block at the spot in 3a so it captures the True case.)
+
+**3c.** Change `iterate_projects`'s return at line 371 from:
+
+```python
+    write_digest(run_id=run_id, results=results, log_dir=log_dir)
+    return exit_code, last_state
+```
+
+to:
+
+```python
+    write_digest(run_id=run_id, results=results, log_dir=log_dir)
+
+    # #446 / #447: idle-run terminal status hint for RunDriver.
+    # Only emit "skipped" if EVERY enabled project was idle AND
+    # nothing genuinely failed. Conservative: anything ambiguous
+    # falls through to the existing completed/failed mapping in
+    # RunDriver.run().
+    if enabled and not any_work_attempted and not any_real_failure and exit_code == 0:
+        terminal_status_hint = "skipped"
+    else:
+        terminal_status_hint = None
+    return exit_code, last_state, terminal_status_hint
+```
+
+**3d.** Update `iterate_projects`'s docstring (the function header around line 112) — find the `Returns` section and update it to reflect the new 3-tuple shape and the `terminal_status_hint` semantics.
+
+- [ ] **Step 4: Update `RunDriver.run` to unpack the 3-tuple**
+
+Edit `agent/station_orchestrator.py:2893-2899`. Change from:
+
+```python
+            exit_code, last_state = iterate_projects(
+                self._clean_id, self.config_path, self.workspaces_dir,
+            )
+            if exit_code == 130:
+                status = "interrupted"
+            elif exit_code != 0:
+                status = "failed"
+```
+
+to:
+
+```python
+            exit_code, last_state, terminal_status_hint = iterate_projects(
+                self._clean_id, self.config_path, self.workspaces_dir,
+            )
+            if exit_code == 130:
+                status = "interrupted"
+            elif exit_code != 0:
+                status = "failed"
+            elif terminal_status_hint == "skipped":
+                # #446 / #447: idle run — every enabled project was idle
+                # and nothing failed. Distinct terminal status so the
+                # dashboard can render this as "skipped" not "failed".
+                status = "skipped"
+```
+
+- [ ] **Step 5: Run the two new tests to verify they pass**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_iterate_projects_python.py::test_iterate_projects_emits_project_skipped_no_work_when_no_work_attempted tests/test_iterate_projects_python.py::test_iterate_projects_still_emits_manager_no_verdicts_for_real_failure -xvs`
+Expected: PASS — both.
+
+- [ ] **Step 6: Run the broader suite to confirm no regressions**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_iterate_projects_python.py tests/test_project_loop*.py tests/test_orchestrator_wiring.py tests/test_run_lifecycle*.py -x`
+Expected: All previously-passing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/project_loop.py agent/station_orchestrator.py dashboard/backend/tests/test_iterate_projects_python.py
+git commit -m "$(cat <<'EOF'
+feat(project_loop): idle projects emit project_skipped_no_work, not manager_no_verdicts (#446 #447)
+
+When orchestrate_project returns work_attempted=False (no eligible
+issues, SDK session never opened), iterate_projects now emits a
+project_skipped_no_work webhook event and appends a SKIP digest
+entry instead of routing through the manager_no_verdicts path.
+Exit code is not bumped; the run is not a failure.
+
+iterate_projects now returns a 3-tuple including a terminal_status_hint
+"skipped" when every enabled project was idle and nothing failed.
+RunDriver maps the hint to status="skipped" on run_complete.
+
+Regression test pins that manager_no_verdicts still fires for the
+real-failure case (work_attempted=True + verdicts missing).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Run-level `skipped` status — additional coverage
+
+**Files:**
+- Test: `dashboard/backend/tests/test_iterate_projects_python.py` (extend)
+
+Task 2's commit makes the run-level skipped status work. This task adds three more tests pinning the precedence rules.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `dashboard/backend/tests/test_iterate_projects_python.py`:
+
+```python
+def test_iterate_projects_returns_skipped_hint_when_all_projects_idle(
+    tmp_path, monkeypatch
+):
+    """Run-level: all projects idle, no failures → terminal_status_hint='skipped'."""
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"projects":['
+        '{"repo":"a/a","enabled":true,"mode":"full"},'
+        '{"repo":"b/b","enabled":true,"mode":"full"}'
+        ']}'
+    )
+
+    async def fake_orchestrate(*a, **kw):
+        return (0, None, False)  # both projects idle
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.project_loop.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.resume_paused", lambda: None)
+
+    exit_code, _last_state, terminal_status_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "workspaces")
+    )
+
+    assert exit_code == 0
+    assert terminal_status_hint == "skipped"
+
+
+def test_iterate_projects_no_skipped_hint_when_any_project_did_work(
+    tmp_path, monkeypatch
+):
+    """Mixed: one idle, one did work → no skipped hint (run is completed)."""
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"projects":['
+        '{"repo":"a/a","enabled":true,"mode":"full"},'
+        '{"repo":"b/b","enabled":true,"mode":"full"}'
+        ']}'
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_orchestrate(*a, **kw):
+        call_count["n"] += 1
+        # First call: idle; second: did work
+        return (0, None, call_count["n"] != 1)
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.project_loop.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    # Second project's verdicts file present, empty verdicts (happy minimal).
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda p: {"verdicts": []},
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.resume_paused", lambda: None)
+
+    exit_code, _last_state, terminal_status_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "workspaces")
+    )
+
+    assert exit_code == 0
+    assert terminal_status_hint is None, (
+        "Mixed idle+work runs must NOT be marked skipped"
+    )
+
+
+def test_iterate_projects_no_skipped_hint_when_any_real_failure(
+    tmp_path, monkeypatch
+):
+    """Mixed: one idle, one fails → no skipped hint (run is failed)."""
+    from agent import project_loop
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"projects":['
+        '{"repo":"a/a","enabled":true,"mode":"full"},'
+        '{"repo":"b/b","enabled":true,"mode":"full"}'
+        ']}'
+    )
+
+    call_count = {"n": 0}
+
+    async def fake_orchestrate(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return (0, None, False)   # idle
+        raise RuntimeError("simulated project failure")
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.project_loop.ensure_workspace", lambda *a, **kw: str(tmp_path / "ws")
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.project_loop.resume_paused", lambda: None)
+
+    exit_code, _last_state, terminal_status_hint = project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "workspaces")
+    )
+
+    assert exit_code != 0
+    assert terminal_status_hint is None, (
+        "Run with a real failure must NOT be marked skipped"
+    )
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_iterate_projects_python.py::test_iterate_projects_returns_skipped_hint_when_all_projects_idle tests/test_iterate_projects_python.py::test_iterate_projects_no_skipped_hint_when_any_project_did_work tests/test_iterate_projects_python.py::test_iterate_projects_no_skipped_hint_when_any_real_failure -xvs`
+Expected: All PASS (Task 2's implementation already handles these).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add dashboard/backend/tests/test_iterate_projects_python.py
+git commit -m "$(cat <<'EOF'
+test(project_loop): pin run-level skipped precedence rules (#446 #447)
+
+Three regression tests covering: all-idle → skipped, mixed
+idle+work → completed (not skipped), idle+failure → failed
+(not skipped). Verifies the conservative-default rule from
+the design spec: ambiguous cases fall through to existing logic.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `"skipped"` to `run_lifecycle.handle_finished` status map
+
+**Files:**
+- Modify: `dashboard/backend/app/services/run_lifecycle.py:155-163` (the `status_map` dict in `handle_finished`)
+- Test: `dashboard/backend/tests/test_run_lifecycle_safe_repo.py` (extend — verify file exists) or create a new test file `test_run_lifecycle_skipped_status.py`
+
+Without this map entry, the agent-side `status="skipped"` from Task 2 falls through to `status_map.get(raw_status, raw_status)` and lands as the literal `"skipped"` in the DB — which would actually work. But pinning it explicitly defends against drift and makes the map self-documenting.
+
+- [ ] **Step 1: Identify the appropriate test file**
+
+Run: `cd dashboard/backend && grep -l "handle_finished\|EVENT_STATUS_MAP\|status_map" tests/*.py | head -5`
+Expected output: list of files that already test `handle_finished`. Pick the most apt one (likely `test_run_lifecycle_safe_repo.py`). If none is obviously right, create `tests/test_run_lifecycle_skipped_status.py`.
+
+- [ ] **Step 2: Write the failing tests**
+
+Add to the chosen test file (using the existing imports and fixtures as templates — read the file first if creating fresh, mimic the pattern):
+
+```python
+@pytest.mark.asyncio
+async def test_handle_finished_maps_skipped_to_skipped(db_session):
+    """Agent-side status='skipped' must persist as row status='skipped',
+    not fall through to default mapping. #446 #447."""
+    from app.services import run_lifecycle
+    from app.schemas import WebhookRunEvent
+
+    event = WebhookRunEvent(
+        event="finished",
+        event_id="evt-test-skipped",
+        run_id="run-test-skipped",
+        status="skipped",
+    )
+
+    run = await run_lifecycle.handle_finished(
+        db_session, event, project_id=None, run=None
+    )
+
+    assert run.status == "skipped", (
+        f"Expected status='skipped', got '{run.status}'. "
+        "If 'skipped' is missing from the status_map, this regresses."
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_does_not_remap_skipped_to_failed(db_session):
+    """Regression pin: future map changes must not collapse skipped → failed."""
+    from app.services import run_lifecycle
+    from app.schemas import WebhookRunEvent
+
+    event = WebhookRunEvent(
+        event="finished",
+        event_id="evt-test-skipped-2",
+        run_id="run-test-skipped-2",
+        status="skipped",
+    )
+
+    run = await run_lifecycle.handle_finished(
+        db_session, event, project_id=None, run=None
+    )
+
+    assert run.status != "failed", (
+        "Map drift: 'skipped' must not be remapped to 'failed'. "
+        "See spec docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md"
+    )
+```
+
+(If `db_session` fixture name differs in the file you chose, use whatever the surrounding tests use. If `WebhookRunEvent` requires different fields, mimic the closest existing test.)
+
+- [ ] **Step 3: Run tests to verify they fail (or already pass via fall-through)**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/<chosen_file>.py::test_handle_finished_maps_skipped_to_skipped tests/<chosen_file>.py::test_handle_finished_does_not_remap_skipped_to_failed -xvs`
+Expected: The first may PASS via fall-through (`status_map.get("skipped", "skipped")` → `"skipped"`); the second will PASS for the same reason. Either way, proceed — Task 4 makes the mapping explicit so future drift is caught.
+
+- [ ] **Step 4: Add explicit map entry**
+
+Edit `dashboard/backend/app/services/run_lifecycle.py:155-163`. Change from:
+
+```python
+    status_map = {
+        "success": "completed",
+        "finished": "completed",
+        "no_reports": "completed",
+        "completed": "completed",
+        "rate_limited": "completed",
+        "error": "failed",
+        "interrupted": "interrupted",
+    }
+```
+
+to:
+
+```python
+    status_map = {
+        "success": "completed",
+        "finished": "completed",
+        "no_reports": "completed",
+        "completed": "completed",
+        "rate_limited": "completed",
+        "skipped": "skipped",       # #446 #447: idle runs (no eligible work)
+        "error": "failed",
+        "interrupted": "interrupted",
+    }
+```
+
+- [ ] **Step 5: Run tests to confirm they still pass**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/<chosen_file>.py -xvs -k "skipped"`
+Expected: PASS — both tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add dashboard/backend/app/services/run_lifecycle.py dashboard/backend/tests/<chosen_file>.py
+git commit -m "$(cat <<'EOF'
+feat(run_lifecycle): map agent-side 'skipped' → row status 'skipped' (#446 #447)
+
+Adds explicit entry to handle_finished's status_map so idle-run
+status persists correctly and is protected against future map drift.
+Two regression tests pin the mapping and assert skipped is never
+remapped to failed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Document new status + event in `docs/architecture.md`
+
+**Files:**
+- Modify: `docs/architecture.md`
+
+Project rule (CLAUDE.md): "Keep `docs/` in sync with code. Drifted docs are a defect." This task is required.
+
+- [ ] **Step 1: Locate the relevant sections**
+
+Run: `grep -n "^##\|run status\|webhook event\|status values" docs/architecture.md | head -30`
+Identify the section(s) listing run statuses and webhook events. There is typically a status table and an events table or list. Note the line ranges.
+
+- [ ] **Step 2: Add `skipped` to the run-status table**
+
+Locate the table/list of `runs.status` values. Add an entry following the existing style. Example new row:
+
+```markdown
+| `skipped` | Run finished cleanly with no eligible work to do in any configured project. Distinct from `failed`. Introduced 2026-05-17 (#446 / #447). |
+```
+
+If statuses are listed as bullets, mimic that format instead.
+
+- [ ] **Step 3: Add `project_skipped_no_work` to the webhook-events table**
+
+Locate the webhook-events table/list. Add an entry. Example:
+
+```markdown
+| `project_skipped_no_work` | Emitted per-project when the orchestrator found no eligible work and did not open the SDK session. Payload: `{project, reason}` where `reason` is `"no_eligible_work"`. Run-level analogue: `runs.status="skipped"`. Introduced 2026-05-17 (#447). |
+```
+
+- [ ] **Step 4: If a "decision" enum is documented (digest entries), add `SKIP`**
+
+Grep for `decision` documentation in `docs/architecture.md`. If digest entries / per-project results are documented with an enum (APPROVE / PR / REJECT / SKIP / ERROR etc.), confirm `SKIP` is present or add it.
+
+Run: `grep -n "SKIP\|decision" docs/architecture.md | head -10`
+If `SKIP` is already documented: no action. If missing: add it alongside ERROR with description: `"SKIP: project had no eligible work; no SDK session was opened. Paired with the project_skipped_no_work webhook."`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "$(cat <<'EOF'
+docs(architecture): document 'skipped' status and project_skipped_no_work event (#446 #447)
+
+Adds the new run-status value and webhook event introduced by the
+idle-run-semantics work. Keeps docs in lockstep with the agent
+and dashboard changes — drifted docs are a defect per CLAUDE.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Frontend type union — add `"skipped"` and `"project_skipped_no_work"`
+
+**Files:**
+- Modify: `dashboard/frontend/src/lib/types.ts`
+
+This task makes TypeScript aware of the new values. The badge/color mapping is Task 7.
+
+- [ ] **Step 1: Locate the run-status union and event-name union**
+
+Run: `grep -n "skipped\|completed\|failed\|interrupted\|RunStatus\|status:\|event:" dashboard/frontend/src/lib/types.ts | head -30`
+Identify:
+- The TypeScript union type for run statuses (likely `RunStatus`, `RunStatusValue`, or similar).
+- The TypeScript union type for event names (likely `WebhookEvent`, `EventName`, or similar — may also include event-name string-literal unions inline).
+
+- [ ] **Step 2: Add `"skipped"` to the run-status union**
+
+Append `| "skipped"` to the union. Example before/after:
+
+Before:
+```ts
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "reviewing"
+  | "plan_reviewing"
+  | "awaiting_plan_review"
+  | "plan_approved"
+  | "plan_rejected"
+  | "completed"
+  | "failed"
+  | "interrupted"
+  | "orphaned";
+```
+
+After:
+```ts
+export type RunStatus =
+  | "pending"
+  | "running"
+  | "reviewing"
+  | "plan_reviewing"
+  | "awaiting_plan_review"
+  | "plan_approved"
+  | "plan_rejected"
+  | "completed"
+  | "skipped"      // #446 #447: idle runs (no eligible work)
+  | "failed"
+  | "interrupted"
+  | "orphaned";
+```
+
+Match the actual surrounding type name and style in the file.
+
+- [ ] **Step 3: Add `"project_skipped_no_work"` to the event-name union**
+
+Same approach — find the event-name union and add `| "project_skipped_no_work"` with a comment referencing #447.
+
+- [ ] **Step 4: Type-check**
+
+Run: `cd dashboard/frontend && npx tsc --noEmit 2>&1 | head -30`
+Expected: Zero new errors. (Any pre-existing errors carry through unchanged.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/lib/types.ts
+git commit -m "$(cat <<'EOF'
+feat(frontend): add 'skipped' status and project_skipped_no_work event types (#446 #447)
+
+Extends the run-status and webhook-event TypeScript unions with
+the new idle-run values. Badge/color mapping follows in next task.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Frontend badge variant — render `skipped` distinctly from `failed`
+
+**Files:**
+- Modify: `dashboard/frontend/src/lib/run-status.ts` OR wherever badge mapping lives (verify in Step 1).
+
+Goal: any page that renders a status badge for a run shows a neutral-grey (or analogous unobtrusive color) variant for `skipped`, visually distinct from `failed` (red) and `completed` (green).
+
+- [ ] **Step 1: Locate the badge mapping**
+
+Run: `grep -rn "failed\|completed\|interrupted" dashboard/frontend/src/lib/ dashboard/frontend/src/components/ 2>/dev/null | grep -i "color\|badge\|bg-\|class" | head -20`
+
+Expected: one or two files own the status → color/class mapping. Common patterns:
+- A `getStatusBadge(status)` or `statusBadgeClass(status)` helper.
+- A constant object `STATUS_COLORS = { failed: "bg-red-...", completed: "bg-green-...", ... }`.
+- Inline `class:` directives in Svelte components.
+
+If the mapping is centralized in one file, modify there (best case). If it's duplicated across pages, modify the centralized helper if one exists, or each occurrence if not (use grep output to enumerate).
+
+- [ ] **Step 2: Add the `skipped` variant**
+
+Add `skipped` to whatever mapping you found. Choose a neutral color — `bg-gray-500` / `bg-slate-500` / `bg-zinc-500` (use whichever TailwindCSS palette the existing codebase prefers). Example:
+
+```ts
+const STATUS_COLORS: Record<RunStatus, string> = {
+  pending: "bg-yellow-500",
+  running: "bg-blue-500",
+  completed: "bg-green-600",
+  skipped: "bg-gray-500",       // #446 #447: neutral; distinct from failed
+  failed: "bg-red-600",
+  interrupted: "bg-orange-500",
+  // ...
+};
+```
+
+If your mapping uses a `switch` or chained ternaries, add a new branch in the same style.
+
+- [ ] **Step 3: Verify the type-checker is happy (the type added in Task 6 should make the missing variant a compile error if your mapping is keyed by `Record<RunStatus, X>`)**
+
+Run: `cd dashboard/frontend && npx tsc --noEmit 2>&1 | head -30`
+Expected: Zero errors. If the type check FAILS with `Property 'skipped' is missing in type ...`, that's actually good news — it confirms you found the right mapping file. Add the variant and re-run.
+
+- [ ] **Step 4: Manual visual smoke (deferred to after merge)**
+
+Note in the PR description that visual verification requires a live `skipped` run, which Task 9 / smoke test exercises end-to-end. Not blocking.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add dashboard/frontend/src/
+git commit -m "$(cat <<'EOF'
+feat(frontend): render 'skipped' status with neutral-grey badge (#446 #447)
+
+Distinct visual treatment for idle runs so operators can tell
+'no eligible work' apart from genuine failures at a glance.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Full backend test suite + agent test sweep
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Run the backend test suite scope used across the recent PRs**
+
+Run:
+```bash
+cd dashboard/backend && python3 -m pytest \
+  tests/test_iterate_projects_python.py \
+  tests/test_project_loop*.py \
+  tests/test_orchestrator_wiring.py \
+  tests/test_orchestrate_project_work_attempted.py \
+  tests/test_run_lifecycle*.py \
+  tests/test_webhook*.py \
+  -xvs 2>&1 | tail -30
+```
+
+Expected: ALL pass. If a test fails, do NOT mark the task complete — fix the regression in a follow-up edit and re-run.
+
+- [ ] **Step 2: Broader backend sweep (excluding postgres-bound files)**
+
+Run:
+```bash
+cd dashboard/backend && python3 -m pytest tests/ \
+  --ignore=tests/test_database.py \
+  --ignore=tests/test_migration_script.py \
+  --ignore=tests/test_pubsub.py \
+  -x 2>&1 | tail -5
+```
+
+Expected: ALL pass (modulo any pre-existing failures unrelated to this change — note them but do NOT fix here).
+
+- [ ] **Step 3: Frontend type-check**
+
+Run: `cd dashboard/frontend && npx tsc --noEmit 2>&1 | tail -10`
+Expected: Zero NEW errors. Pre-existing carry through.
+
+- [ ] **Step 4: No commit** (this is validation only).
+
+---
+
+## Task 9: Open PR + smoke test
+
+**Files:** none (workflow).
+
+- [ ] **Step 1: Push branch**
+
+Run:
+```bash
+git push -u origin <branch-name>
+```
+
+- [ ] **Step 2: Open PR against `dev`**
+
+Run:
+```bash
+gh pr create --base dev --title "feat: introduce 'skipped' run status + project_skipped_no_work event (#446 #447)" --body "$(cat <<'EOF'
+## Summary
+
+Idle runs (no eligible work in any configured project) are now recorded as `status="skipped"` and emit a per-project `project_skipped_no_work` webhook. Real failures still use `status="failed"` + `manager_no_verdicts` as before.
+
+## Spec
+
+`docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md`
+
+## Changes by file
+
+- `agent/station_orchestrator.py` — `orchestrate_project` returns `(rc, state, work_attempted)`; `RunDriver.run` maps `terminal_status_hint="skipped"` to `status="skipped"` on `run_complete`.
+- `agent/project_loop.py` — idle per-project branch emits `project_skipped_no_work` instead of `manager_no_verdicts`; tracks `any_work_attempted` / `any_real_failure` for the run-level hint; returns 3-tuple.
+- `dashboard/backend/app/services/run_lifecycle.py` — `status_map` has explicit `"skipped" → "skipped"`.
+- `dashboard/frontend/src/lib/types.ts` — adds `"skipped"` status and `"project_skipped_no_work"` event types.
+- Frontend badge mapping — `skipped` renders neutral-grey, distinct from `failed`.
+- `docs/architecture.md` — documents new status, new event, optional `SKIP` digest enum entry.
+
+## Tests
+
+- 2 new tests for `orchestrate_project` return contract (work_attempted False/True).
+- 5 new tests for `iterate_projects` (idle emit, real-failure regression pin, run-level precedence × 3).
+- 2 new tests for `run_lifecycle.handle_finished` skipped mapping (forward + regression pin).
+- Frontend type-check confirms the new values are valid throughout.
+
+## Smoke test (post-merge)
+
+1. Trigger a run while no projects have eligible issues: `curl -X POST http://localhost:8420/api/runs/trigger -H "Authorization: Bearer $STATION_API_KEY"`.
+2. Verify via API: `runs.status == "skipped"` (not `failed`).
+3. Verify webhook log shows `project_skipped_no_work`, NOT `manager_no_verdicts`.
+4. Verify digest shows `decision="SKIP"`, not `decision="ERROR"`.
+5. Verify dashboard renders the run with the neutral-grey badge.
+
+## Closes
+
+Closes #446
+Closes #447
+
+## Test plan
+
+- [x] All backend tests pass (focused + broader sweep).
+- [x] Frontend type-check passes.
+- [ ] Smoke test against live container (post-merge): idle run → status='skipped', new event fires, dashboard renders correctly.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After merge — rebuild and smoke**
+
+Wait for merge approval. After merge, on the dev branch:
+
+```bash
+git fetch origin && git reset --hard origin/dev
+docker compose build dashboard agent && docker compose up -d
+```
+
+Trigger an idle run:
+
+```bash
+API_KEY=$(grep '^STATION_API_KEY=' .env | cut -d= -f2)
+curl -s -X POST http://localhost:8420/api/runs/trigger \
+  -H "Authorization: Bearer $API_KEY" -H 'Content-Type: application/json'
+```
+
+Capture the `run_id` and inspect:
+
+```bash
+RUN_ID=<captured>
+sleep 10
+curl -s "http://localhost:8420/api/runs/$RUN_ID" \
+  -H "Authorization: Bearer $API_KEY" | python3 -m json.tool | grep -E '"status"|"skip_reason"'
+```
+
+Expected output:
+```
+"status": "skipped",
+"skip_reason": "no-eligible-issues-proposals-pending",
+```
+
+Then check the dashboard webhook log:
+
+```bash
+docker logs cas-dashboard 2>&1 | grep "$RUN_ID" | grep -E "project_skipped|manager_no_verdicts"
+```
+
+Expected: see `project_skipped_no_work` line(s), NOT `manager_no_verdicts`.
+
+If all four checks pass, close #446 and #447 (squash-merge to dev does not auto-close per `feedback_pr_merge_to_dev_first` memory):
+
+```bash
+MERGE_COMMIT=$(gh pr view <PR-NUMBER> --json mergeCommit -q .mergeCommit.oid | cut -c1-10)
+gh issue close 446 --comment "Fixed in PR #<PR-NUMBER> (commit ${MERGE_COMMIT}), merged into dev. Verified via smoke test on $RUN_ID."
+gh issue close 447 --comment "Fixed in PR #<PR-NUMBER> (commit ${MERGE_COMMIT}), merged into dev. Verified via smoke test on $RUN_ID."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Goal: status=skipped ✅ Task 1, 2, 4. Event project_skipped_no_work ✅ Task 2. Dashboard distinct rendering ✅ Task 6, 7. Backwards-compatible (no migration) ✅ (covered by design choice, no task required).
+- Non-goals: no migration, no rename, no state-machine refactor ✅ (none of these are tasks).
+- Discriminator (`work_attempted` from `orchestrate_project`) ✅ Task 1.
+- Signal flow: orchestrate_project ✅ T1; project_loop branch ✅ T2; run-level status ✅ T2 + T3 (precedence pins) + T4; status_map ✅ T4; webhook routing ✅ existing pass-through via `handle_unknown` (verified during exploration; no code needed); frontend types ✅ T6; frontend badge ✅ T7; docs ✅ T5.
+- Error handling: emit wrapped in try/except + logger.exception ✅ T2; work_attempted=True on uncertainty ✅ T1.
+- Testing: all 9 spec tests mapped to tasks (T1: tests 8, 9; T2: tests 1, 2; T3: tests 3, 4, 5; T4: tests 6, 7; T7: test 10 via type-check; T9: smoke test 11).
+
+**Placeholder scan:** no TBD/TODO in the plan body. All code blocks complete. All commands have expected output stated. Two "verify during Task N" notes (for test file location in T1 and T4) are explicit research steps with grep commands, not placeholders.
+
+**Type consistency:** `work_attempted` used identically in T1 + T2. `terminal_status_hint` introduced in T2's return change and consumed in the same task at the `RunDriver.run` edit. Event name `project_skipped_no_work` identical across T2 (emit), T5 (docs), T6 (type union), T9 (smoke). Status `"skipped"` identical across T2 (terminal_status_hint and RunDriver mapping), T4 (status_map), T6 (type union), T7 (badge), T9 (smoke assertion).
+
+Self-review clean.

--- a/docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md
+++ b/docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md
@@ -1,0 +1,197 @@
+# Idle-Run Semantics — Design
+
+**Issues:** #446 (status taxonomy), #447 (event taxonomy)
+**Scope:** Single PR covering both.
+**Author:** Claude Opus 4.7 (1M context)
+**Date:** 2026-05-17
+
+## Problem
+
+The orchestrator cannot distinguish two terminal conditions that share a code path today:
+
+1. **Idle** — the agent enumerated projects, found no eligible work, and exited cleanly.
+2. **Real failure** — the agent ran work, but the manager produced no verdicts (crashed, hit max-turns, never spawned, etc.).
+
+Both currently surface as `runs.status="failed"` plus `skip_reason="no-eligible-issues-proposals-pending"`, and both emit `manager_no_verdicts`. Consequences:
+
+- Dashboard runs list cannot visually separate idle passes from genuine errors.
+- Any failure-rate metric over `runs.status` is inflated by idle passes (likely the majority once the issue queue drains).
+- `manager_no_verdicts` consumers (dashboard, queue, ops alerting) cannot distinguish "manager ran and failed" from "no manager ever ran".
+
+Live evidence: run `run-20260516T205311Z` (5 s, no eligible issues) recorded `status="failed"` and fired `manager_no_verdicts` despite no manager being spawned.
+
+## Goals
+
+- `runs.status="skipped"` for idle runs; reserve `failed` for genuine errors.
+- New webhook event `project_skipped_no_work` for the idle per-project case; preserve `manager_no_verdicts` exclusively for the real-failure case.
+- Dashboard renders `skipped` distinctly from `failed`.
+- Backwards-compatible at the data layer (no migration of historical rows).
+
+## Non-Goals
+
+- No DB migration / backfill of historical `failed + skip_reason=...` rows.
+- No rename of `manager_no_verdicts`.
+- No restructuring of the verdicts-file check into an explicit state machine.
+- No new `skip_reason` values — existing values are reused.
+
+## Discriminator
+
+A new bool `work_attempted` returned by `agent.station_orchestrator.orchestrate_project`. Semantics:
+
+- `True` — the lead entered an SDK session with eligible work and spawned teammates and/or a manager.
+- `False` — the project had no eligible issues; the lead exited before spawning any teammate or manager.
+
+All non-idle exit paths (orchestrator exception, teammate work attempted, manager spawned) → `True`. The default on any uncertainty is `True` — the safe choice is to preserve the existing failure signal, not to suppress it.
+
+**Detection point.** `orchestrate_project` already determines, before opening the SDK session, whether any eligible issues exist for the project (via the issue picker / vision bootstrap). The exact decision site is implementation-defined and should be identified during the implementation plan; the contract is simply that `work_attempted` reflects whether the picker returned at least one eligible item and the SDK session was therefore opened. If the picker returned items but the SDK session immediately failed to open (e.g. provider auth error), that is `work_attempted=True` (work was attempted; it failed) — preserving the failure signal per the safe-default rule.
+
+## Signal Flow
+
+### `agent/station_orchestrator.py::orchestrate_project`
+Return changes from `(rc, state)` to `(rc, state, work_attempted)`.
+
+### `agent/project_loop.py::iterate_projects` per-project branch
+Unpack the 3-tuple. Branch BEFORE the verdicts-file check:
+
+```python
+proj_rc, proj_state, work_attempted = asyncio.run(
+    orchestrate_project(project, config, run_id, workspaces_dir)
+)
+
+if not work_attempted:
+    # Idle: emit project_skipped_no_work, append SKIP result, do NOT
+    # bump exit_code, do NOT read verdicts, do NOT emit manager_no_verdicts.
+    try:
+        from agent.webhook_emitter import emit as _emit_skip
+        _emit_skip(
+            "project_skipped_no_work",
+            run_id=f"run-{run_id}",
+            payload={
+                "project": project.get("repo", ""),
+                "reason": "no_eligible_work",
+            },
+        )
+    except Exception:  # noqa: BLE001 — best-effort signal
+        logger.exception("project_skipped_no_work webhook emit failed")
+
+    results.append({
+        "project": project.get("repo", ""),
+        "decision": "SKIP",
+        "reason": "no_eligible_work",
+    })
+    continue
+
+# Existing flow: read verdicts file, emit manager_no_verdicts on miss
+# (real failure), iterate verdicts on hit. Unchanged.
+```
+
+### Run-level terminal status (`iterate_projects` epilogue)
+
+Track two flags across the per-project loop:
+
+- `any_work_attempted: bool = False` — set `True` on any project that returns `work_attempted=True`.
+- `any_real_failure: bool = False` — set `True` on any orchestrator exception, missing verdicts after work, executor error, or non-zero `exit_code` bump from existing paths.
+
+Run terminal status logic:
+
+- `any_real_failure` → existing status mapping (`failed`, etc.).
+- `not any_work_attempted and not any_real_failure` AND at least one project enumerated → `"skipped"`.
+- `any_work_attempted and not any_real_failure` → existing `completed` mapping.
+
+The state-emit that closes the run sends `status="skipped"` for the new case. `skip_reason` is preserved unchanged.
+
+### `dashboard/backend/app/services/run_lifecycle.py:153-163` status map
+Add one entry:
+
+```python
+EVENT_STATUS_MAP = {
+    "success": "completed",
+    "finished": "completed",
+    "no_reports": "completed",
+    "completed": "completed",
+    "rate_limited": "completed",
+    "skipped": "skipped",       # NEW
+    "error": "failed",
+    "interrupted": "interrupted",
+}
+```
+
+### `dashboard/backend/app/routers/webhook.py`
+Route `project_skipped_no_work` to its handler. The existing webhook dispatch normalizes by event name — add the handler entry alongside `manager_no_verdicts`.
+
+### Frontend (`dashboard/frontend/src/`)
+- `src/lib/types.ts` — extend the status union to include `"skipped"`; add `"project_skipped_no_work"` to the event-name union.
+- All pages that render run status (`CommandCenter.svelte`, `MissionControl.svelte`, `ProjectsPage.svelte`, `ProjectDetail.svelte`, `RunDetail.svelte`, `AgentTeamsCanvas.svelte`) — add a `skipped` case to the status-badge mapping. Color: neutral grey (distinct from `failed` red and `completed` green).
+
+### `docs/architecture.md`
+- Add `skipped` to the run-status table.
+- Add `project_skipped_no_work` to the webhook-events list with the same row schema as the other events.
+
+## Error Handling
+
+- `project_skipped_no_work` emit wrapped in `try/except Exception` + `logger.exception(...)` — same pattern as the existing `plan_review_start` and `manager_no_verdicts` emits (consistency from #444 / #445 hygiene work).
+- If `orchestrate_project` raises, `work_attempted` is inferred to be `True` (existing error path runs). This preserves the failure signal on the safe side.
+- If a project returns `work_attempted=False` BUT a verdicts file exists on disk (defensive), the verdicts file is ignored and the project is still classified `skipped`. This is contradictory state we don't expect; logging a warning is sufficient.
+
+## Testing
+
+### Backend (`dashboard/backend/tests/`)
+
+1. **`test_iterate_projects_emits_project_skipped_no_work_when_no_work_attempted`** — mock `orchestrate_project` to return `(0, None, False)`. Assert:
+   - `webhook_emitter.emit` called with `("project_skipped_no_work", run_id="run-...", payload={"project": ..., "reason": "no_eligible_work"})`.
+   - `webhook_emitter.emit` NOT called with `"manager_no_verdicts"`.
+   - Result entry has `decision == "SKIP"` and `reason == "no_eligible_work"`.
+   - `exit_code` unchanged from its pre-call value.
+
+2. **`test_iterate_projects_still_emits_manager_no_verdicts_for_real_failure`** — mock `orchestrate_project` to return `(0, None, True)`; mock verdicts file to be absent. Assert existing `manager_no_verdicts` behavior preserved (kwargs shape, `exit_code=6`, `decision="ERROR"`). Regression pin so the `work_attempted` discriminator doesn't accidentally suppress the failure signal.
+
+3. **`test_iterate_projects_sets_run_level_skipped_when_all_projects_skipped`** — all enabled projects return `work_attempted=False`. Assert run's final state-emit carries `status="skipped"`.
+
+4. **`test_iterate_projects_does_not_set_skipped_when_any_project_did_work`** — mixed: one `work_attempted=False`, one `work_attempted=True` with verdicts. Assert run terminal status is `completed`, not `skipped`.
+
+5. **`test_iterate_projects_does_not_set_skipped_when_any_real_failure`** — one project skipped, one raises in `orchestrate_project`. Assert run terminal status is `failed`, not `skipped`.
+
+6. **`test_run_lifecycle_maps_skipped_status`** — drive `handle_finished` (or equivalent) with agent-side `status="skipped"`. Assert row `status == "skipped"`.
+
+7. **`test_run_lifecycle_does_not_remap_skipped_to_failed`** — regression pin against future map drift.
+
+### Agent (`agent/tests/` or `dashboard/backend/tests/` as repo convention dictates)
+
+8. **`test_orchestrate_project_returns_work_attempted_true_when_lead_spawned`** — mock the SDK session to spawn at least one teammate. Assert third tuple element is `True`.
+
+9. **`test_orchestrate_project_returns_work_attempted_false_when_no_eligible_issues`** — mock the SDK session to report no eligible issues. Assert third tuple element is `False`.
+
+### Frontend
+
+10. Type-check / unit test confirming `"skipped"` is a valid status value and `"project_skipped_no_work"` is a valid event name. Visual rendering verified manually post-deploy (badge color, distinct from `failed`).
+
+### End-to-end / smoke
+
+11. Trigger a run with no eligible issues in any configured project. Confirm via API:
+    - `runs.status == "skipped"` (not `failed`).
+    - `runs.skip_reason` preserved.
+    - Dashboard webhook log shows `project_skipped_no_work` event, NOT `manager_no_verdicts`.
+    - Digest entry for the project shows `SKIP`, not `ERROR`.
+
+## Backwards Compatibility
+
+- Historical rows with `status="failed" + skip_reason="no-eligible-issues-proposals-pending"` are unchanged. They remain `failed` in the DB. No migration.
+- `manager_no_verdicts` continues to fire for the real-failure case; existing consumers see no change in that pathway.
+- The new `skipped` status is purely additive at the status enum; consumers that don't know about it will fall through to default rendering (likely indistinguishable from any other unknown status until they update — acceptable since this is an internal app).
+
+## Out-of-Scope Follow-Ups
+
+- DB migration of historical `failed + skip_reason=<idle reason>` rows — possible future cleanup.
+- Refactoring the verdicts-file check into an explicit per-project state machine — possible future hygiene.
+- Renaming `manager_no_verdicts` to `manager_failed_no_verdicts` — would be cleaner but forces every consumer to update at once.
+
+## Acceptance
+
+- [ ] `orchestrate_project` returns 3-tuple with `work_attempted` bool.
+- [ ] `iterate_projects` emits `project_skipped_no_work` (not `manager_no_verdicts`) for the idle case.
+- [ ] Run-level terminal status is `skipped` iff all projects skipped AND no real failures.
+- [ ] `run_lifecycle.py` maps agent-side `skipped` → row `skipped`.
+- [ ] Frontend renders `skipped` distinctly from `failed`.
+- [ ] Tests 1–10 above pass; smoke test 11 confirmed against a real run.
+- [ ] `docs/architecture.md` updated.
+- [ ] PR targets `dev`. Closes #446, Closes #447.


### PR DESCRIPTION
## Summary

Idle runs (no eligible work in any configured project) are now recorded as `runs.status="skipped"` and emit a per-project `project_skipped_no_work` webhook. Real failures still use `status="failed"` + `manager_no_verdicts` as before.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md`
- Plan: `docs/superpowers/plans/2026-05-17-idle-run-semantics.md`

## Changes by file

- **`agent/station_orchestrator.py`** — `orchestrate_project` returns a 3-tuple `(rc, state, work_attempted)` where `work_attempted=False` only on the no-eligible-issues short-circuit. `RunDriver.run` maps the new `terminal_status_hint="skipped"` to `status="skipped"` on `run_complete`.
- **`agent/project_loop.py`** — idle per-project branch emits `project_skipped_no_work` instead of routing through `manager_no_verdicts`; tracks `any_work_attempted` / `any_real_failure` for the run-level hint; returns a 3-tuple. Conservative default: anything ambiguous falls through to existing logic.
- **`dashboard/backend/app/services/run_lifecycle.py`** — `status_map` has explicit `"skipped" → "skipped"`.
- **`dashboard/frontend/src/lib/types.ts`** — adds `"skipped"` to `RunStatus`.
- **Frontend badge mapping** (`CommandCenter.svelte`, `ProjectDetail.svelte`, `RunDetail.svelte`, `DAGNode.svelte`, `app.css`) — `skipped` renders neutral warm-grey (`--graphite`), label `SKIP`, distinct from `failed`/`completed` in all three themes.
- **`docs/architecture.md`** — three new tables: run-status values, webhook events, per-project digest decisions. (No pre-existing tables existed; additive new subsections.)

## Tests (231 in focused scope, 1451 broader, all green)

- 2 tests for `orchestrate_project` return contract (work_attempted False/True).
- 6 tests for `iterate_projects` (idle emit, real-failure regression pin, run-level precedence × 3, preflight 3-tuple regression).
- 2 tests for `run_lifecycle.handle_finished` skipped mapping (forward + non-failed pin).
- 10 mock-site compat fixes in `test_run_driver.py` / `test_run_driver_payload.py` (surfaced by the Task 8 sweep — would have been a runtime crash in `RunDriver.run` otherwise).
- Frontend type-check baseline preserved (2 pre-existing `formatRunMode` errors only).

## Closes

Closes #446
Closes #447

## Test plan

- [x] All backend tests pass (focused 231 + broader 1451 + 1 skipped).
- [x] Frontend type-check: no new errors (2 pre-existing duplicate-identifier errors carry through).
- [ ] **Smoke test against live container** (post-merge): trigger a run while no projects have eligible issues; verify `runs.status == "skipped"` (not `failed`), `project_skipped_no_work` fires (NOT `manager_no_verdicts`), digest shows `SKIP` (not `ERROR`), dashboard renders neutral-grey badge.

## Process notes

Implemented via subagent-driven-development: one implementer subagent per task in this single worktree, two-stage review (spec compliance then code quality) after each. Two review-loops needed mid-stream:
- Task 1: re-amended for docstring inaccuracy + test fragility (now amended in `f66cd70`).
- Task 2: re-amended twice — first for two early-return 2-tuples that would have crashed `RunDriver.run` on preflight failure (caught by spec review), then for a missing `any_real_failure` flag in the `WorkspaceError` handler (caught by code review).
- Task 6: re-amended to delete a dead `WebhookEventName` union (caught by spec review).
- Task 8 broader sweep surfaced the 10 RunDriver mock sites the per-task sweeps missed; fixed in commit `c2f7873`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)