### PR TITLE
fix(queue): replace SQLite-only julianday() with portable extract(epoch, ...) (#449)

### DIFF
--- a/dashboard/backend/app/routers/audit.py
+++ b/dashboard/backend/app/routers/audit.py
@@ -94,12 +94,30 @@ async def audit_stats(
     error_rate = (errored / counted) if counted else 0.0
 
     # Average duration in ms for finished rows only.
-    dur_q = select(
-        func.avg(
-            (func.julianday(AuditEntry.finished_at) - func.julianday(AuditEntry.started_at))
-            * 86_400_000.0
+    #
+    # The original expression used SQLite's ``julianday()`` which does not
+    # exist on Postgres (see issue #449 — every call to /api/audit/stats
+    # was raising ``function julianday(timestamp with time zone) does not
+    # exist`` after the Postgres migration in PR #393). Same fix pattern
+    # as ``app/routers/queue.py::queue_stats``: branch on the bound
+    # engine's dialect because ``func.extract('epoch', ...)`` compiles to
+    # nonsense on SQLite. Both branches end in milliseconds so the
+    # ``avg_duration_ms`` wire format is unchanged.
+    dialect_name = db.bind.dialect.name if db.bind is not None else "sqlite"
+    if dialect_name == "postgresql":
+        # extract(epoch from interval) -> seconds; *1000 -> ms.
+        duration_ms_expr = (
+            func.extract("epoch", AuditEntry.finished_at - AuditEntry.started_at)
+            * 1_000.0
         )
-    ).where(
+    else:
+        # julianday(a) - julianday(b) -> fractional days; *86_400_000 -> ms.
+        duration_ms_expr = (
+            func.julianday(AuditEntry.finished_at)
+            - func.julianday(AuditEntry.started_at)
+        ) * 86_400_000.0
+
+    dur_q = select(func.avg(duration_ms_expr)).where(
         AuditEntry.started_at >= since,
         AuditEntry.finished_at.is_not(None),
     )

--- a/dashboard/backend/app/routers/queue.py
+++ b/dashboard/backend/app/routers/queue.py
@@ -81,19 +81,42 @@ async def queue_stats(db: AsyncSession = Depends(get_db)):
     by_state = {row[0]: row[1] for row in result.all()}
     total = sum(by_state.values())
 
-    # Average time to complete (completed items with both timestamps)
+    # Average time to complete (completed items with both timestamps).
+    #
+    # The original expression used SQLite's ``julianday()`` which does not
+    # exist on Postgres (see issue #449 — every call to /api/queue/stats
+    # was raising ``function julianday(timestamp with time zone) does not
+    # exist`` after the Postgres migration in PR #393).
+    #
+    # ``func.extract('epoch', a - b)`` is the portable Postgres expression
+    # (it returns the interval in seconds), but SQLAlchemy silently
+    # compiles ``extract('epoch', ...)`` to nonsense on SQLite — a quick
+    # repro with two rows 10 s apart returns ``-2.1e11``. So we pick the
+    # expression based on the bound engine's dialect. Wire format stays
+    # ``avg_time_to_complete_ms``; the frontend (``QueueStatsBar.svelte``
+    # -> ``formatDuration``) was never updated for a unit change, so we
+    # keep ms.
+    dialect_name = db.bind.dialect.name if db.bind is not None else "sqlite"
+    if dialect_name == "postgresql":
+        latency_expr = func.extract(
+            "epoch", QueueItem.completed_at - QueueItem.created_at
+        )
+        scale = 1_000.0  # seconds -> ms
+    else:
+        latency_expr = (
+            func.julianday(QueueItem.completed_at)
+            - func.julianday(QueueItem.created_at)
+        )
+        scale = 86_400_000.0  # fractional days -> ms
+
     avg_result = await db.execute(
-        select(
-            func.avg(
-                func.julianday(QueueItem.completed_at) - func.julianday(QueueItem.created_at)
-            )
-        ).where(
+        select(func.avg(latency_expr)).where(
             QueueItem.state == "completed",
             QueueItem.completed_at.isnot(None),
         )
     )
-    avg_days = avg_result.scalar()
-    avg_ms = avg_days * 86_400_000 if avg_days else None
+    avg_value = avg_result.scalar()
+    avg_ms = avg_value * scale if avg_value is not None else None
 
     return QueueStats(by_state=by_state, total=total, avg_time_to_complete_ms=avg_ms)
 

--- a/dashboard/backend/tests/test_audit_log.py
+++ b/dashboard/backend/tests/test_audit_log.py
@@ -201,6 +201,83 @@ async def test_stats_returns_kind_distribution_and_error_rate(client):
     assert body["avg_duration_ms"] > 0
 
 
+# --- GET /api/audit/stats avg-duration dialect portability (#449) ----------
+
+
+@pytest.mark.asyncio
+async def test_stats_avg_duration_none_on_empty_window(client):
+    """No finished rows in the window -> ``avg_duration_ms is None``,
+    handler must not raise. Regression for #449: previously
+    ``julianday()`` raised on Postgres even for empty result sets because
+    the function itself does not exist on that dialect.
+    """
+    resp = await client.get("/api/audit/stats", params={"days": 7})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["avg_duration_ms"] is None
+
+
+@pytest.mark.asyncio
+async def test_stats_avg_duration_matches_expected_ms(client):
+    """Two finished rows (10s + 30s) -> avg = 20_000 ms.
+
+    Pins the dialect-aware unit math: postgres uses
+    ``EXTRACT(EPOCH FROM finished_at - started_at) * 1000``; sqlite uses
+    ``(julianday(b) - julianday(a)) * 86_400_000``. Both must agree on ms.
+    """
+    base = datetime.now(timezone.utc) - timedelta(hours=1)
+    async with async_session() as db:
+        db.add(_entry(
+            key="dur-10s", status="ok",
+            started_at=base, finished_at=base + timedelta(seconds=10),
+        ))
+        db.add(_entry(
+            key="dur-30s", status="ok",
+            started_at=base, finished_at=base + timedelta(seconds=30),
+        ))
+        # A 'started' row (finished_at is NULL) must be excluded — its
+        # presence used to crash julianday() on Postgres anyway.
+        db.add(_entry(
+            key="dur-pending", status="started",
+            started_at=base, finished_at=None,
+        ))
+        await db.commit()
+
+    resp = await client.get("/api/audit/stats", params={"days": 7})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["avg_duration_ms"] is not None
+    # 20 s = 20_000 ms; allow a 1 ms slop for float rounding across
+    # dialects (rounded server-side to 2 decimals already).
+    assert abs(body["avg_duration_ms"] - 20_000.0) < 1.0
+
+
+@pytest.mark.asyncio
+async def test_stats_sqlite_branch_uses_julianday_not_extract(client):
+    """Regression guard for the SQLite branch: on SQLite the handler
+    must use ``julianday()`` because ``extract('epoch', ...)`` is
+    silently nonsense there (returns ~ -2.1e11 for a 10s gap). If a
+    future refactor swaps the SQLite branch to ``extract``, this test
+    catches the wrong-by-1e10 result.
+    """
+    base = datetime.now(timezone.utc) - timedelta(hours=1)
+    async with async_session() as db:
+        db.add(_entry(
+            key="dur-sqlite-pin", status="ok",
+            started_at=base, finished_at=base + timedelta(seconds=10),
+        ))
+        await db.commit()
+
+    resp = await client.get("/api/audit/stats", params={"days": 7})
+    assert resp.status_code == 200
+    body = resp.json()
+    # Expected ~10_000 ms; if extract(epoch) were used on SQLite the
+    # value would be in the e13 ms range (clearly wrong).
+    assert body["avg_duration_ms"] is not None
+    assert abs(body["avg_duration_ms"] - 10_000.0) < 1.0
+
+
 # --- retention -------------------------------------------------------------
 
 

--- a/dashboard/backend/tests/test_queue.py
+++ b/dashboard/backend/tests/test_queue.py
@@ -220,6 +220,88 @@ class TestDeleteCompleted:
 
 
 # ---------------------------------------------------------------------------
+# Test: /api/queue/stats avg-latency expression is dialect-portable (#449)
+# ---------------------------------------------------------------------------
+
+class TestQueueStatsAvgLatency:
+    """``queue_stats`` previously used SQLite-only ``julianday()`` which
+    raised ``function julianday(timestamp with time zone) does not exist``
+    on Postgres (issue #449). The handler now picks a dialect-appropriate
+    expression. These tests pin both behaviours.
+    """
+
+    async def test_stats_returns_none_avg_on_empty_queue(self, db):
+        """No completed rows -> ``avg_time_to_complete_ms`` is None, no raise."""
+        from app.routers.queue import queue_stats
+
+        result = await queue_stats(db=db)
+        assert result.avg_time_to_complete_ms is None
+        assert result.total == 0
+
+    async def test_stats_avg_matches_expected_ms(self, db):
+        """Two completed rows with known durations -> avg matches the math.
+
+        Row A: 10 s end-to-end. Row B: 30 s end-to-end. Avg = 20 s = 20_000 ms.
+        """
+        base = _utcnow()
+        _make_queue_item(
+            db,
+            state="completed",
+            created_at=base,
+            completed_at=base + timedelta(seconds=10),
+        )
+        _make_queue_item(
+            db,
+            issue_number=2,
+            state="completed",
+            created_at=base,
+            completed_at=base + timedelta(seconds=30),
+        )
+        # A non-completed row must be ignored even if it has timestamps.
+        _make_queue_item(
+            db,
+            issue_number=3,
+            state="in_progress",
+            created_at=base,
+            completed_at=base + timedelta(seconds=9999),
+        )
+        await db.commit()
+
+        from app.routers.queue import queue_stats
+
+        result = await queue_stats(db=db)
+        assert result.avg_time_to_complete_ms is not None
+        # 20 s = 20_000 ms; allow a 1 ms slop for float rounding across
+        # dialects (postgres extract(epoch) returns a numeric; sqlite
+        # julianday returns a float with ~us precision).
+        assert abs(result.avg_time_to_complete_ms - 20_000.0) < 1.0
+
+    async def test_stats_sqlite_branch_uses_julianday_not_extract(self, db):
+        """Regression guard for the SQLite branch: on SQLite the handler
+        must use ``julianday()`` because ``extract('epoch', ...)`` is
+        silently nonsense there (returns ~ -2.1e11 for a 10 s gap). If a
+        future refactor swaps the SQLite branch to ``extract``, this test
+        catches the wrong-by-1e10 result.
+        """
+        base = _utcnow()
+        _make_queue_item(
+            db,
+            state="completed",
+            created_at=base,
+            completed_at=base + timedelta(seconds=10),
+        )
+        await db.commit()
+
+        from app.routers.queue import queue_stats
+
+        result = await queue_stats(db=db)
+        # Expected 10_000 ms; if extract(epoch) were used on SQLite the
+        # value would be in the e13 ms range (clearly wrong).
+        assert result.avg_time_to_complete_ms is not None
+        assert abs(result.avg_time_to_complete_ms - 10_000.0) < 1.0
+
+
+# ---------------------------------------------------------------------------
 # Test: Update with explicit null clears fields
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Root cause

`julianday()` is a SQLite-only function. After the Postgres migration in
#393 it survived in **two** API handlers, and every call on Postgres
raised `function julianday(timestamp with time zone) does not exist` —
276 errors in a single smoke session.

The original PR description claimed a single occurrence; an independent
grep on the PR branch found a second site. Both are fixed here.

## Sites changed (two occurrences)

Found via `grep -rn "julianday" dashboard/backend/ agent/`:

1. **`dashboard/backend/app/routers/queue.py:88`** — `queue_stats()` avg
   completion latency, backing `GET /api/queue/stats`. Computed
   `avg(julianday(completed_at) - julianday(created_at)) * 86_400_000`
   and returned as `avg_time_to_complete_ms`.

2. **`dashboard/backend/app/routers/audit.py:99`** — `audit_stats()` avg
   tool-call duration, backing `GET /api/audit/stats`. Computed
   `avg((julianday(finished_at) - julianday(started_at)) * 86_400_000)`
   and returned as `avg_duration_ms`.

Both handlers had the same shape, both broke the same way on Postgres,
both get the same fix.

## Approach — dialect-aware expression

`func.extract('epoch', a - b)` is the correct Postgres replacement
(returns seconds), but a quick verification showed SQLAlchemy compiles
`extract('epoch', ...)` on SQLite to something that silently returns
nonsense (two rows 10 s apart -> `-2.1e11`). So both handlers branch on
`db.bind.dialect.name`:

| Dialect    | Expression                                                | Unit | Scale to ms  |
|------------|-----------------------------------------------------------|------|--------------|
| postgresql | `EXTRACT(EPOCH FROM b - a)`                               | sec  | * 1_000      |
| sqlite     | `julianday(b) - julianday(a)`                             | days | * 86_400_000 |

## Unit decision

**Kept ms** in both endpoints (no wire-format change). Response fields
remain `avg_time_to_complete_ms` (queue) and `avg_duration_ms` (audit);
the frontend reads both directly. A unit change would silently break
the duration display.

## Regression tests

`dashboard/backend/tests/test_queue.py::TestQueueStatsAvgLatency`
(3 cases) and
`dashboard/backend/tests/test_audit_log.py::test_stats_avg_duration_*`
+ `test_stats_sqlite_branch_uses_julianday_not_extract` (3 cases):

1. Empty window -> `avg_*_ms is None`, no raise.
2. Two rows (10 s + 30 s) -> avg = 20_000 ms (within 1 ms slop).
3. SQLite branch must still use `julianday` — guards against a future
   refactor that naively swaps `extract` in on both dialects (which
   would silently return a wrong-by-1e10 value on SQLite).

Targeted: `pytest tests/test_queue.py tests/test_audit_log.py tests/test_audit_hook.py tests/test_audit_hook_log.py tests/test_audit_inline_writes.py` -> **58 passed**.
Broader sweep: `pytest tests/ --ignore=tests/test_database.py --ignore=tests/test_migration_script.py --ignore=tests/test_pubsub.py -x` -> **1457 passed, 1 skipped, 0 failed**.

## Verification of generated Postgres SQL

Compile-test on the postgres dialect emits clean SQL on both endpoints,
e.g. for `queue_stats`:

```sql
SELECT avg(EXTRACT(epoch FROM task_queue.completed_at - task_queue.created_at)) AS avg_1
FROM task_queue
WHERE task_queue.state = 'completed' AND task_queue.completed_at IS NOT NULL
```

Closes #449