### PR TITLE
fix(webhook): teammate_completed must not flip run.status via handle_unknown (#450)

### DIFF
--- a/dashboard/backend/app/routers/webhook.py
+++ b/dashboard/backend/app/routers/webhook.py
@@ -53,6 +53,24 @@ _MESSAGE_EVENTS = {"conflict_detected", "guidance_sent"}
 _DAG_EVENTS = {"dag_created", "dag_completed"}
 _TEAM_SPAWN_EVENTS = {"teammate_spawned", "team_created"}
 
+# Issue #450: events that are *scoped to a teammate or to a non-terminal
+# progress signal* and therefore MUST NOT flow through ``handle_unknown``.
+# That handler unconditionally propagates ``event.status`` onto
+# ``runs.status`` — which conflates the teammate's lifecycle with the
+# parent run's lifecycle. The orchestrator emits ``teammate_completed`` with
+# ``status="completed"`` to mean "this teammate's task is done", but the
+# `run` row still has live work (other teammates, manager review,
+# verdicts, …). Routing these through the dedicated post-dispatch handlers
+# below (``handle_teammate_completed``, ``handle_progress_update``, etc.)
+# is sufficient — they only mutate the fields they own (team_members,
+# token counters) without touching status or finished_at.
+_TEAM_PROGRESS_EVENTS = {
+    "teammate_completed",
+    "teammate_progress",
+    "progress_update",
+    "narration",
+}
+
 
 @router.post("/run-event")
 async def receive_run_event(
@@ -135,6 +153,18 @@ async def receive_run_event(
                 "plan_excerpt": event.plan_excerpt,
             }),
         ))
+
+    elif event_name in _TEAM_PROGRESS_EVENTS:
+        # Issue #450: these events have dedicated post-dispatch handlers
+        # (below) that mutate only the fields they own. They MUST NOT fall
+        # through to ``handle_unknown``, which would propagate the
+        # teammate-scoped ``event.status`` onto ``runs.status`` and
+        # prematurely flip the parent run terminal while it's still alive.
+        # ``teammate_spawned`` and ``team_created`` are already explicitly
+        # branched via ``_TEAM_SPAWN_EVENTS`` post-dispatch — they don't
+        # carry a misleading ``status`` field so they were safe, but the
+        # other members of this surface area weren't.
+        pass
 
     elif event_name in ("conflict_resolution_started",
                         "conflict_resolution_phase",

--- a/dashboard/backend/app/services/run_lifecycle.py
+++ b/dashboard/backend/app/services/run_lifecycle.py
@@ -483,6 +483,15 @@ async def handle_unknown(
         run.mode = event.mode
     if event.model:
         run.model = event.model
+    # NOTE: This blind status mirror is a latent foot-gun — any unmapped
+    # event carrying a ``status`` field will mutate ``run.status``, even
+    # if that status is teammate-scoped or task-scoped rather than
+    # run-scoped. See issue #453 for the design follow-up (reviewer
+    # recommends removing this mirror entirely and requiring explicit
+    # ``_RUN_HANDLERS`` entries for any event that wants to set a
+    # run-level status). PR #452 (issue #450) closed the only known
+    # offender (``teammate_completed``) by adding a dispatcher
+    # pass-through, but the underlying foot-gun remains.
     if event.status:
         run.status = event.status
     if project_id:

--- a/dashboard/backend/tests/test_run_lifecycle_no_premature_completion.py
+++ b/dashboard/backend/tests/test_run_lifecycle_no_premature_completion.py
@@ -1,0 +1,215 @@
+"""Regression tests for issue #450 — incoherent finished state.
+
+A live run row was observed flipping to ``status="completed"`` with
+``finished_at`` set while the corresponding runner container was still alive
+and still emitting heartbeats / narration / progress_update / Lead-agent tool
+calls for 191 seconds afterwards.
+
+Webhook tally for the offending run ``run-20260517T100903Z``:
+
+    narration, heartbeat, progress_update, teammate_spawned, run_start,
+    teammate_completed, orchestrator_start, employee_start
+
+Conspicuously absent: ``run_complete``, ``orchestrator_complete``, ``finished``,
+``manager_review``, ``manager_no_verdicts``, ``verdict_execute``,
+``project_skipped_no_work``. None of the events that legitimately drive
+``handle_finished`` ever fired.
+
+Smoking gun: ``teammate_completed`` is NOT in the dispatcher's main
+``_RUN_HANDLERS`` / ``_TASK_EVENTS`` / ``_MESSAGE_EVENTS`` / ``_DAG_EVENTS``
+sets, so it falls through the if/elif chain to ``handle_unknown``. The
+orchestrator emits ``teammate_completed`` with ``status="completed"``
+(the *teammate's* terminal status — see
+``agent/station_orchestrator.py::TaskNotificationMessage`` branch). And
+``handle_unknown`` does ``run.status = event.status`` unconditionally,
+which conflates the teammate's status with the *run's* status and flips
+the parent run row terminal.
+
+Once ``run.status == "completed"``, the log_importer's backfill loop
+populates ``finished_at`` from ``started_at + duration_ms`` (see
+``log_importer._update_run_from_logs`` line 120), producing the
+``finished_at`` half of the incoherence.
+
+These tests pin the contract: a ``teammate_completed`` webhook MUST NOT
+mutate the parent ``runs.status`` to a terminal state. The only events
+that may flip ``status`` to a terminal value are the explicit run-level
+events handled by :mod:`app.services.run_lifecycle` (``finished``,
+``plan_approved``, ``plan_rejected``) — not teammate-scoped events.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.database import Base, async_session, engine
+from app.main import app
+from app.models import Run
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+@pytest_asyncio.fixture
+async def client(setup_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+async def _seed_running_run(run_id: str = "run-450-regression") -> None:
+    """Insert a row mirroring an active run mid-flight: status=running, no
+    finished_at, no terminal verdict — the state the offending run was in
+    before the teammate_completed event flipped it."""
+    from datetime import datetime, timezone
+    async with async_session() as db:
+        db.add(Run(
+            run_id=run_id,
+            status="running",
+            started_at=datetime.now(timezone.utc),
+        ))
+        await db.commit()
+
+
+async def _fetch_run(run_id: str) -> Run | None:
+    async with async_session() as db:
+        result = await db.execute(select(Run).where(Run.run_id == run_id))
+        return result.scalar_one_or_none()
+
+
+@pytest.mark.asyncio
+async def test_teammate_completed_does_not_flip_run_status_to_completed(
+    client: AsyncClient,
+) -> None:
+    """The smoking gun. A teammate finishing must not mark the parent run done."""
+    run_id = "run-450-regression"
+    await _seed_running_run(run_id)
+
+    # Mirror the orchestrator's emit at station_orchestrator.py:1665 — the
+    # teammate's own terminal status, NOT the run's.
+    resp = await client.post("/api/webhook/run-event", json={
+        "run_id": run_id,
+        "event": "teammate_completed",
+        "task_id": "task-1",
+        "status": "completed",
+        "agent_name": "backend",
+        "tokens_total": 500,
+        "turns": 10,
+    })
+    assert resp.status_code == 200
+
+    run = await _fetch_run(run_id)
+    assert run is not None
+    assert run.status == "running", (
+        f"teammate_completed event flipped run.status to {run.status!r} — "
+        "this is issue #450. The dispatcher fell through to handle_unknown, "
+        "which propagated the teammate's status to the run row."
+    )
+    assert run.finished_at is None, (
+        f"teammate_completed event set finished_at={run.finished_at!r} — "
+        "issue #450. No terminal-lifecycle handler should have fired here."
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_event_sequence_from_offending_run_keeps_status_running(
+    client: AsyncClient,
+) -> None:
+    """Replay the actual event sequence observed for run-20260517T100903Z.
+
+    The tally was: narration, heartbeat, progress_update, teammate_spawned,
+    run_start, teammate_completed, orchestrator_start, employee_start.
+    Notably absent: any event that legitimately drives ``handle_finished``.
+    After replaying every one of these, status MUST still be ``running``.
+    """
+    run_id = "run-450-sequence"
+
+    sequence = [
+        {"event": "run_start", "run_id": run_id, "mode": "auto", "model": "sonnet-4-6"},
+        {"event": "orchestrator_start", "run_id": run_id},
+        {"event": "employee_start", "run_id": run_id, "employee_index": 0},
+        {"event": "teammate_spawned", "run_id": run_id, "task_id": "t1",
+         "agent_id": "a1", "agent_name": "backend", "team_name": "team-1"},
+        {"event": "narration", "run_id": run_id,
+         "narration": "Spawning teammate", "narration_kind": "system"},
+        {"event": "heartbeat", "run_id": run_id},
+        {"event": "progress_update", "run_id": run_id,
+         "tokens_total": 200, "turns": 4},
+        {"event": "teammate_completed", "run_id": run_id, "task_id": "t1",
+         "status": "completed", "agent_name": "backend",
+         "tokens_total": 500, "turns": 10},
+        {"event": "narration", "run_id": run_id,
+         "narration": "Finished (completed)", "narration_kind": "step"},
+        {"event": "heartbeat", "run_id": run_id},
+    ]
+
+    for ev in sequence:
+        resp = await client.post("/api/webhook/run-event", json=ev)
+        assert resp.status_code == 200, (
+            f"event {ev['event']!r} returned {resp.status_code}: {resp.text}"
+        )
+        run = await _fetch_run(run_id)
+        assert run is not None
+        assert run.status == "running", (
+            f"After event {ev['event']!r}, run.status is {run.status!r} — "
+            f"should still be 'running'. Issue #450."
+        )
+        assert run.finished_at is None, (
+            f"After event {ev['event']!r}, run.finished_at={run.finished_at!r} "
+            f"— should still be None. Issue #450."
+        )
+
+
+@pytest.mark.asyncio
+async def test_teammate_completed_with_error_status_does_not_fail_run(
+    client: AsyncClient,
+) -> None:
+    """A teammate failing must not propagate to the parent run row either —
+    other teammates may still be running, and the run-level outcome is only
+    determined by ``handle_finished``."""
+    run_id = "run-450-teammate-error"
+    await _seed_running_run(run_id)
+
+    resp = await client.post("/api/webhook/run-event", json={
+        "run_id": run_id,
+        "event": "teammate_completed",
+        "task_id": "task-2",
+        "status": "error",
+        "agent_name": "qa",
+    })
+    assert resp.status_code == 200
+
+    run = await _fetch_run(run_id)
+    assert run is not None
+    assert run.status == "running"
+    assert run.finished_at is None
+
+
+@pytest.mark.asyncio
+async def test_finished_webhook_still_marks_terminal(
+    client: AsyncClient,
+) -> None:
+    """Sanity counter-test: the legitimate ``finished`` lifecycle event MUST
+    still flip status and finished_at. Otherwise we've over-corrected."""
+    run_id = "run-450-finished-counter"
+    await _seed_running_run(run_id)
+
+    resp = await client.post("/api/webhook/run-event", json={
+        "run_id": run_id,
+        "event": "run_complete",  # normalised to "finished"
+        "status": "success",
+    })
+    assert resp.status_code == 200
+
+    run = await _fetch_run(run_id)
+    assert run is not None
+    assert run.status == "completed"
+    assert run.finished_at is not None


### PR DESCRIPTION
## Summary

Closes #450.

A live run row was observed flipping to `status="completed"` with `finished_at` set while the orchestrator was still alive — runner kept emitting heartbeats, narration, progress_update, and Lead-agent tool calls for **191 seconds** after the row was marked finished. For `run-20260517T100903Z`, `finished_at=10:22:24Z` but `last_event_at=10:25:35Z`.

## Root cause

`teammate_completed` was absent from the dispatcher's main if/elif chain in `dashboard/backend/app/routers/webhook.py`:

- not in `_RUN_HANDLERS`, `_TASK_EVENTS`, `_MESSAGE_EVENTS`, `_DAG_EVENTS`
- not `verdict`, `heartbeat`, `vision_misalignment`, `conflict_resolution_*`

So it fell through to the final `else: handle_unknown` branch (webhook.py:156, pre-fix). And `handle_unknown` (`run_lifecycle.py:486-487`) does:

```python
if event.status:
    run.status = event.status
```

The orchestrator emits `teammate_completed` with `status="completed"` to mean *this teammate's task is done* (`agent/station_orchestrator.py:1665-1672`). That conflated the teammate's status with the run's status and flipped the parent `runs` row terminal while it still had live work (other teammates, manager review, verdicts, …).

The `finished_at` half of the incoherence was the log_importer backfilling `started_at + duration_ms` once it saw the row's `status` had become `completed` (`log_importer.py:120` — the `not in ("running", "reviewing")` gate let it through).

## Fix

Route `teammate_completed`, `teammate_progress`, `progress_update`, and `narration` through an explicit pass-through branch in the dispatcher (new `_TEAM_PROGRESS_EVENTS` set) so they no longer reach `handle_unknown`. Each already has a dedicated post-dispatch handler that mutates only the fields it owns (team_members JSON, monotonic token counters) without touching `status` or `finished_at`.

The post-dispatch hooks (lines 178+) are unchanged — `handle_teammate_completed`, `handle_progress_update`, `handle_team_member_spawn`, `handle_teammate_progress` all still fire as before. Only the spurious main-dispatch hit to `handle_unknown` is removed.

## Test plan

- [x] New regression test: `dashboard/backend/tests/test_run_lifecycle_no_premature_completion.py` — 4 tests
  - `test_teammate_completed_does_not_flip_run_status_to_completed` — the smoking gun: posts the exact `teammate_completed` payload, asserts `run.status == "running"` and `finished_at is None`. Confirmed failing pre-fix with `status == 'completed'`.
  - `test_full_event_sequence_from_offending_run_keeps_status_running` — replays the entire observed event tally for `run-20260517T100903Z` (run_start → orchestrator_start → employee_start → teammate_spawned → narration → heartbeat → progress_update → teammate_completed → narration → heartbeat) and asserts the row stays `running`/`None` after every single event.
  - `test_teammate_completed_with_error_status_does_not_fail_run` — symmetrical check for the failure path.
  - `test_finished_webhook_still_marks_terminal` — counter-test: the legitimate `run_complete` event MUST still flip status and set `finished_at`, so we haven't over-corrected.
- [x] Broader sweep: `python3 -m pytest tests/ --ignore=tests/test_database.py --ignore=tests/test_migration_script.py --ignore=tests/test_pubsub.py` → **1458 passed, 1 skipped**.
- [ ] Manual smoke against a live container — trigger a run with eligible work, observe `runs.status` stays `running` until the runner actually emits `run_complete` or the reaper fires.

## Follow-ups worth a separate issue

While auditing I noted that `handle_unknown` (run_lifecycle.py:469-491) still propagates `event.status` onto `run.status` for *any* unmapped event that happens to carry a `status` field. With this PR's fix, no known-emitted event in the current codebase hits that path with a misleading status, but it remains a foot-gun for future events. A follow-up could either (a) remove the `event.status` propagation entirely, or (b) whitelist only run-level status values (`running`, `pending`, `reviewing`, …). Out of scope here per the issue-#450 instruction to fix only the offending path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)