### PR TITLE
fix(run_lifecycle): monotonic telemetry + drop handle_unknown status mirror (#453 #454)

### DIFF
--- a/dashboard/backend/app/routers/webhook.py
+++ b/dashboard/backend/app/routers/webhook.py
@@ -53,15 +53,17 @@ _MESSAGE_EVENTS = {"conflict_detected", "guidance_sent"}
 _DAG_EVENTS = {"dag_created", "dag_completed"}
 _TEAM_SPAWN_EVENTS = {"teammate_spawned", "team_created"}
 
-# Issue #450: events that are *scoped to a teammate or to a non-terminal
-# progress signal* and therefore MUST NOT flow through ``handle_unknown``.
-# That handler unconditionally propagates ``event.status`` onto
-# ``runs.status`` — which conflates the teammate's lifecycle with the
-# parent run's lifecycle. The orchestrator emits ``teammate_completed`` with
+# Issue #450 / #453: events that are *scoped to a teammate or to a
+# non-terminal progress signal*, routed through dedicated post-dispatch
+# handlers rather than the ``handle_unknown`` fallback. Historically the
+# motivation was that ``handle_unknown`` mirrored ``event.status`` onto
+# ``runs.status``, conflating the teammate's lifecycle with the parent
+# run's (the orchestrator emits ``teammate_completed`` with
 # ``status="completed"`` to mean "this teammate's task is done", but the
-# `run` row still has live work (other teammates, manager review,
-# verdicts, …). Routing these through the dedicated post-dispatch handlers
-# below (``handle_teammate_completed``, ``handle_progress_update``, etc.)
+# ``run`` row still has live work). #453 removed that mirror so the
+# fallback is now inert on ``status``, but these events still belong in
+# the dedicated post-dispatch handlers below (``handle_teammate_completed``,
+# ``handle_progress_update``, etc.)
 # is sufficient — they only mutate the fields they own (team_members,
 # token counters) without touching status or finished_at.
 _TEAM_PROGRESS_EVENTS = {
@@ -120,8 +122,9 @@ async def receive_run_event(
     # stale-run reaper doesn't mark a healthy run as ``interrupted``
     # during legitimate long-Sonnet-turn quiet windows. No state
     # transition; explicit branch so future devs don't accidentally
-    # route it through ``handle_unknown`` (which mutates ``run.status``
-    # if the event happens to carry one).
+    # route it through ``handle_unknown`` (which is intentionally
+    # minimal — it does NOT mutate ``run.status`` after #453, but
+    # heartbeats still don't need to bounce off it).
     if event_name == "heartbeat":
         pass
 
@@ -155,15 +158,18 @@ async def receive_run_event(
         ))
 
     elif event_name in _TEAM_PROGRESS_EVENTS:
-        # Issue #450: these events have dedicated post-dispatch handlers
-        # (below) that mutate only the fields they own. They MUST NOT fall
-        # through to ``handle_unknown``, which would propagate the
-        # teammate-scoped ``event.status`` onto ``runs.status`` and
-        # prematurely flip the parent run terminal while it's still alive.
-        # ``teammate_spawned`` and ``team_created`` are already explicitly
-        # branched via ``_TEAM_SPAWN_EVENTS`` post-dispatch — they don't
-        # carry a misleading ``status`` field so they were safe, but the
-        # other members of this surface area weren't.
+        # Issue #450 / #453: these events have dedicated post-dispatch
+        # handlers (below) that mutate only the fields they own.
+        # Historically the danger was that falling through to
+        # ``handle_unknown`` would propagate the teammate-scoped
+        # ``event.status`` onto ``runs.status`` and prematurely flip the
+        # parent run terminal while it's still alive. #453 removed that
+        # status mirror from ``handle_unknown``, but these events still
+        # belong in their dedicated handlers because they own teammate-
+        # scoped fields (token deltas, team_members JSON, etc.) that the
+        # generic fallback wouldn't touch. ``teammate_spawned`` and
+        # ``team_created`` are already explicitly branched via
+        # ``_TEAM_SPAWN_EVENTS`` post-dispatch.
         pass
 
     elif event_name in ("conflict_resolution_started",

--- a/dashboard/backend/app/services/run_lifecycle.py
+++ b/dashboard/backend/app/services/run_lifecycle.py
@@ -175,11 +175,28 @@ async def handle_finished(
 
     run.status = final_status
     run.trace_id = event.trace_id or run.trace_id
-    run.cost_usd = event.cost_usd
-    run.tokens_input = event.tokens_input
-    run.tokens_output = event.tokens_output
-    run.tokens_total = event.tokens_total
-    run.turns = event.turns
+
+    # Telemetry monotonicity (issue #454). The terminal ``finished`` event
+    # is emitted by the orchestrator at run exit and historically clobbered
+    # ``turns`` / ``tokens_*`` / ``cost_usd`` unconditionally. But these
+    # same fields are also ratcheted upward by ``handle_progress_update``
+    # (PR #438, issue #434) as the run proceeds — if the terminal payload
+    # carries a lower value (e.g. an early teammate-scoped snapshot, or a
+    # truncated final event) it would clobber a higher accumulated value.
+    # Live repro: run-20260517T144539Z had turns=31 for 19 minutes then
+    # was regressed to 7 by the finished event. Guard each cumulative
+    # field with ``max(existing, incoming)`` and skip None entirely.
+    if event.turns is not None:
+        run.turns = max(run.turns or 0, event.turns)
+    if event.tokens_input is not None:
+        run.tokens_input = max(run.tokens_input or 0, event.tokens_input)
+    if event.tokens_output is not None:
+        run.tokens_output = max(run.tokens_output or 0, event.tokens_output)
+    if event.tokens_total is not None:
+        run.tokens_total = max(run.tokens_total or 0, event.tokens_total)
+    if event.cost_usd is not None:
+        run.cost_usd = max(run.cost_usd or 0.0, event.cost_usd)
+
     run.duration_ms = event.duration_ms
     run.finished_at = datetime.now(timezone.utc)
 
@@ -469,12 +486,26 @@ async def handle_team_member_spawn(run: Run, event: WebhookRunEvent) -> None:
 async def handle_unknown(
     db: AsyncSession, event: WebhookRunEvent, project_id: int | None, run: Run | None
 ) -> Run:
-    """Handle unknown event types -- still create/update run record."""
+    """Handle unknown event types -- still create/update run record.
+
+    Run-level state contract (#453): this fallback handler does NOT mirror
+    ``event.status`` onto ``run.status``. The mirror was a latent foot-gun
+    behind issue #450 — ``teammate_completed`` carried the teammate's
+    terminal status, fell through to ``handle_unknown``, and flipped the
+    parent run to ``completed`` even though the run was still alive.
+    PR #452 closed that specific offender via an explicit dispatcher
+    entry; #453 removes the underlying foot-gun so any FUTURE unmapped
+    event that should affect ``run.status`` must land in
+    ``_RUN_HANDLERS`` explicitly rather than silently mutating state.
+    """
     if not run:
+        # NOTE: a brand-new run materialised from an unmapped event has no
+        # established status to preserve, so default to ``running`` rather
+        # than adopting the event's status (which may be teammate-scoped).
         run = Run(
             run_id=event.run_id,
             project_id=project_id,
-            status=event.status or "running",
+            status="running",
             started_at=datetime.now(timezone.utc),
             trace_id=event.trace_id,
         )
@@ -483,17 +514,6 @@ async def handle_unknown(
         run.mode = event.mode
     if event.model:
         run.model = event.model
-    # NOTE: This blind status mirror is a latent foot-gun — any unmapped
-    # event carrying a ``status`` field will mutate ``run.status``, even
-    # if that status is teammate-scoped or task-scoped rather than
-    # run-scoped. See issue #453 for the design follow-up (reviewer
-    # recommends removing this mirror entirely and requiring explicit
-    # ``_RUN_HANDLERS`` entries for any event that wants to set a
-    # run-level status). PR #452 (issue #450) closed the only known
-    # offender (``teammate_completed``) by adding a dispatcher
-    # pass-through, but the underlying foot-gun remains.
-    if event.status:
-        run.status = event.status
     if project_id:
         run.project_id = project_id
     run.trace_id = event.trace_id or run.trace_id

--- a/dashboard/backend/tests/test_run_lifecycle_hardening.py
+++ b/dashboard/backend/tests/test_run_lifecycle_hardening.py
@@ -1,0 +1,302 @@
+"""Regression tests for issues #453 and #454 — run_lifecycle hardening.
+
+Two defensive-programming follow-ups from PRs #438 (issue #434, telemetry
+oscillation) and #452 (issue #450, teammate_completed flipping run.status):
+
+* **#454 — non-monotonic telemetry in ``handle_finished``.** The terminal
+  ``finished`` event used to unconditionally clobber ``run.turns`` /
+  ``run.tokens_*`` / ``run.cost_usd`` with whatever the event carried, even
+  if that was lower than the values already accumulated by repeated
+  ``progress_update`` events. Live reproduction:
+  ``run-20260517T144539Z`` ratcheted ``turns`` up to 31 over 19 minutes,
+  then the terminal ``finished`` event reset it to 7.
+  Fix: mirror ``handle_progress_update``'s monotonic ratchet —
+  ``run.X = max(run.X or 0, event.X)`` for each cumulative field.
+
+* **#453 — ``handle_unknown`` blind status mirror.** The fallback handler
+  did ``if event.status: run.status = event.status`` for every unmapped
+  event. PR #452 closed the only known offender (``teammate_completed``)
+  by adding an explicit dispatcher entry, but the foot-gun stayed loaded:
+  any future unmapped event carrying a ``status`` field would still
+  mutate the run's status. Fix: remove the mirror entirely and require
+  explicit ``_RUN_HANDLERS`` entries for events that should set run state.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+
+from app.database import Base, async_session, engine
+from app.models import Run
+from app.schemas import WebhookRunEvent
+from app.services.run_lifecycle import handle_finished, handle_unknown
+
+
+@pytest_asyncio.fixture
+async def setup_db():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+
+
+def _finished_event(**kwargs) -> WebhookRunEvent:
+    base = {"event": "finished", "run_id": kwargs.pop("run_id", "run-454-test")}
+    base.update(kwargs)
+    return WebhookRunEvent(**base)
+
+
+# ---------------------------------------------------------------------------
+# Issue #454 — handle_finished must be monotonic on telemetry fields.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_does_not_regress_turns(setup_db):
+    """The smoking gun: turns=31 accumulated via handle_progress_update must
+    not be clobbered by a terminal ``finished`` event carrying turns=7.
+
+    Mirrors the live event sequence observed for run-20260517T144539Z.
+    """
+    run_id = "run-454-turns"
+    async with async_session() as db:
+        run = Run(run_id=run_id, status="running", turns=31,
+                  tokens_total=12000)
+        db.add(run)
+        await db.commit()
+
+        event = _finished_event(
+            run_id=run_id, status="success", turns=7, tokens_total=4000,
+        )
+        await handle_finished(db, event, project_id=None, run=run)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.turns == 31, (
+        f"run.turns regressed from 31 to {run.turns!r} on handle_finished "
+        "— issue #454. Terminal event clobbered the higher cumulative value."
+    )
+    assert run.tokens_total == 12000, (
+        f"run.tokens_total regressed from 12000 to {run.tokens_total!r} "
+        "— issue #454."
+    )
+    # And the status mapping still has to happen.
+    assert run.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_does_not_regress_all_token_fields(setup_db):
+    """All four telemetry int fields (turns, tokens_input/output/total)
+    must be guarded together."""
+    run_id = "run-454-tokens"
+    async with async_session() as db:
+        run = Run(
+            run_id=run_id, status="running",
+            turns=50,
+            tokens_input=8000,
+            tokens_output=4000,
+            tokens_total=12000,
+        )
+        db.add(run)
+        await db.commit()
+
+        event = _finished_event(
+            run_id=run_id, status="success",
+            turns=5,
+            tokens_input=100,
+            tokens_output=50,
+            tokens_total=150,
+        )
+        await handle_finished(db, event, project_id=None, run=run)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.turns == 50
+    assert run.tokens_input == 8000
+    assert run.tokens_output == 4000
+    assert run.tokens_total == 12000
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_does_not_regress_cost_usd(setup_db):
+    """Cost is cumulative — terminal event with a lower value must not
+    clobber a higher accumulated cost."""
+    run_id = "run-454-cost"
+    async with async_session() as db:
+        run = Run(run_id=run_id, status="running", cost_usd=1.25)
+        db.add(run)
+        await db.commit()
+
+        event = _finished_event(
+            run_id=run_id, status="success", cost_usd=0.10,
+        )
+        await handle_finished(db, event, project_id=None, run=run)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.cost_usd == 1.25, (
+        f"cost_usd regressed from 1.25 to {run.cost_usd!r} on handle_finished "
+        "— issue #454."
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_advances_on_higher_values(setup_db):
+    """The monotonic guard must still let the terminal event ratchet
+    counters upward when its values exceed what's been accumulated."""
+    run_id = "run-454-advance"
+    async with async_session() as db:
+        run = Run(run_id=run_id, status="running", turns=5,
+                  tokens_total=200, cost_usd=0.1)
+        db.add(run)
+        await db.commit()
+
+        event = _finished_event(
+            run_id=run_id, status="success",
+            turns=12, tokens_total=999, cost_usd=0.75,
+        )
+        await handle_finished(db, event, project_id=None, run=run)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.turns == 12
+    assert run.tokens_total == 999
+    assert run.cost_usd == 0.75
+
+
+@pytest.mark.asyncio
+async def test_handle_finished_handles_none_existing_telemetry(setup_db):
+    """Fresh runs whose telemetry columns are NULL must still accept the
+    terminal event's values (no TypeError from max(None, int))."""
+    run_id = "run-454-fresh"
+    async with async_session() as db:
+        run = Run(run_id=run_id, status="running")  # all telemetry NULL
+        db.add(run)
+        await db.commit()
+
+        event = _finished_event(
+            run_id=run_id, status="success",
+            turns=8, tokens_input=300, tokens_output=200,
+            tokens_total=500, cost_usd=0.42,
+        )
+        await handle_finished(db, event, project_id=None, run=run)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.turns == 8
+    assert run.tokens_input == 300
+    assert run.tokens_output == 200
+    assert run.tokens_total == 500
+    assert run.cost_usd == 0.42
+
+
+# ---------------------------------------------------------------------------
+# Issue #453 — handle_unknown must not mirror event.status onto run.status.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_does_not_mirror_status(setup_db):
+    """Synthetic unmapped event carrying status='completed' must NOT flip
+    the run's status. Future unmapped events should require an explicit
+    handler in ``_RUN_HANDLERS`` to mutate run-level state — see #453.
+    """
+    run_id = "run-453-unknown"
+    async with async_session() as db:
+        run = Run(run_id=run_id, status="running")
+        db.add(run)
+        await db.commit()
+
+        # Pretend this is some new event type the dashboard doesn't know
+        # about yet, but which carries a teammate-scoped or task-scoped
+        # status that should NOT propagate to the run row.
+        event = WebhookRunEvent(
+            event="some_future_unmapped_event",
+            run_id=run_id,
+            status="completed",
+        )
+        await handle_unknown(db, event, project_id=None, run=run)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.status == "running", (
+        f"handle_unknown blindly mirrored event.status='completed' onto "
+        f"run.status (got {run.status!r}) — issue #453. The reviewer's "
+        "recommended fix is to remove the mirror entirely so future "
+        "unmapped events cannot quietly mutate run-level state."
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_does_not_mirror_error_status(setup_db):
+    """Same contract for status='error' — a teammate failing must not
+    cascade to the parent run via the unknown-event fallback."""
+    run_id = "run-453-unknown-error"
+    async with async_session() as db:
+        run = Run(run_id=run_id, status="running")
+        db.add(run)
+        await db.commit()
+
+        event = WebhookRunEvent(
+            event="hypothetical_new_event",
+            run_id=run_id,
+            status="error",
+        )
+        await handle_unknown(db, event, project_id=None, run=run)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_still_updates_other_fields(setup_db):
+    """Removing the status mirror must NOT regress the other side-effects:
+    mode/model/project_id/trace_id assignments still apply."""
+    run_id = "run-453-unknown-other"
+    async with async_session() as db:
+        run = Run(run_id=run_id, status="running")
+        db.add(run)
+        await db.commit()
+
+        event = WebhookRunEvent(
+            event="hypothetical_event_with_model",
+            run_id=run_id,
+            mode="auto",
+            model="sonnet-4-6",
+            trace_id="trace-xyz",
+            status="completed",  # must be IGNORED for run.status
+        )
+        await handle_unknown(db, event, project_id=None, run=run)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.status == "running"
+    assert run.mode == "auto"
+    assert run.model == "sonnet-4-6"
+    assert run.trace_id == "trace-xyz"
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_creating_new_run_defaults_to_running(setup_db):
+    """If handle_unknown has to materialise a brand-new run row (no
+    pre-existing row), it must default to status='running' — never adopt
+    the event's status as the initial run status."""
+    run_id = "run-453-unknown-fresh"
+    async with async_session() as db:
+        event = WebhookRunEvent(
+            event="hypothetical_first_sighting",
+            run_id=run_id,
+            status="completed",  # must be IGNORED for run.status
+        )
+        run = await handle_unknown(db, event, project_id=None, run=None)
+        await db.commit()
+        await db.refresh(run)
+
+    assert run.status == "running", (
+        f"New run materialised by handle_unknown adopted event.status="
+        f"'completed' (got {run.status!r}) — issue #453. The fallback "
+        "must default to 'running' regardless of the event payload."
+    )

--- a/dashboard/backend/tests/test_webhook.py
+++ b/dashboard/backend/tests/test_webhook.py
@@ -591,7 +591,14 @@ async def test_guidance_sent_creates_message(project_client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_unknown_event_creates_run(project_client: AsyncClient):
-    """Unknown event name should still create a Run record gracefully."""
+    """Unknown event name should still create a Run record gracefully.
+
+    Contract (#453): the unknown-event fallback does NOT mirror
+    ``event.status`` onto ``run.status`` — events that should set run
+    state must have explicit ``_RUN_HANDLERS`` entries. A new run
+    materialised by ``handle_unknown`` therefore defaults to
+    ``status='running'`` regardless of the event payload.
+    """
     resp = await project_client.post("/api/webhook/run-event", json={
         "run_id": "run-unknown-001",
         "event": "some_new_event",
@@ -605,7 +612,8 @@ async def test_unknown_event_creates_run(project_client: AsyncClient):
         result = await db.execute(select(Run).where(Run.run_id == "run-unknown-001"))
         run = result.scalar_one_or_none()
         assert run is not None
-        assert run.status == "special"
+        # NEW behaviour per #453: handle_unknown ignores event.status.
+        assert run.status == "running"
         assert run.mode == "employee"
 
 


### PR DESCRIPTION
## Summary

Two defensive-programming follow-ups in `dashboard/backend/app/services/run_lifecycle.py`, addressed together because both touch the same file and both came out of recent reviews on PRs #438 (issue #434) and #452 (issue #450). Neither bug currently has a live-firing trigger after PR #452 closed #450's specific offender, but both are latent foot-guns that would silently misbehave for any future event.

## Fixes

### #454 — `handle_finished` non-monotonic telemetry

`handle_finished` used to do straight assignment of `run.turns`, `run.tokens_input/output/total`, and `run.cost_usd` from the event payload. But the same fields are ratcheted upward by `handle_progress_update` (PR #438 / issue #434) over the run's lifetime — if the terminal `finished` payload happens to carry a lower value (truncated final emit, teammate-scoped snapshot, etc.) it would clobber the higher accumulated value.

**Live repro**: run `run-20260517T144539Z` accumulated `turns=31` over 19 minutes via `handle_progress_update`, then the terminal `finished` event reset it back to 7.

**Fix**: mirror `handle_progress_update`'s monotonic ratchet — `run.X = max(run.X or 0, event.X)` for `turns`, `tokens_input`, `tokens_output`, `tokens_total`, and `cost_usd`. Each guarded with `if event.X is not None` to skip absent fields.

### #453 — `handle_unknown` blind status mirror

`handle_unknown` used to do `if event.status: run.status = event.status` for every unmapped event, plus adopt `event.status or "running"` as the initial status when materialising a brand-new run row. That mirror was the latent foot-gun behind #450 — `teammate_completed` carried the teammate's own terminal status, fell through to `handle_unknown`, and flipped the parent run to `completed` even though the run was still alive. PR #452 closed that specific offender via an explicit dispatcher entry, but the foot-gun stayed loaded for any future unmapped event.

**Fix** (reviewer's recommended option (b)): remove the status mirror entirely and require explicit `_RUN_HANDLERS` entries for any event that should mutate run-level state. The brand-new-run branch also stops adopting `event.status` as the initial value — it defaults to `running`. Other side-effects (`mode`, `model`, `project_id`, `trace_id`) are preserved.

## Regression tests

New file: `dashboard/backend/tests/test_run_lifecycle_hardening.py` (9 tests).

- **#454 telemetry**: turns=31 seeded then handle_finished(turns=7) asserts run.turns stays 31; same for all four token fields and for cost_usd; counter-tests that higher values still ratchet forward, that fresh runs with NULL telemetry don't TypeError on `max(None, int)`.
- **#453 unknown**: synthetic unmapped event with `status="completed"` or `status="error"` does NOT flip `run.status`; other fields (`mode`/`model`/`trace_id`) still update; a brand-new run materialised by `handle_unknown` defaults to `running`.

Also updated `test_unknown_event_creates_run` in `test_webhook.py` — it had encoded the buggy mirror behavior (`assert run.status == "special"`) and now asserts the new contract.

## Test plan

- [x] `pytest tests/test_run_lifecycle_hardening.py -v` → 9 passed
- [x] `pytest tests/test_run_lifecycle*.py tests/test_webhook*.py` → 183 passed
- [x] Broader sweep (excluding test_database/test_migration_script/test_pubsub per project convention) → 1470 passed, 1 skipped

Closes #453
Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)