### PR TITLE
feat: QA test-fixture discipline (#458)

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1097,7 +1097,14 @@ When spawning a teammate, include in their prompt:
 "Your worktree is at <path>. Run `cd <path>` as your FIRST action before doing anything else.
 READ FIRST: `.claude-team-contracts.md` in your worktree root. It documents the cross-team
 contracts (field names, route ownership, response shapes, enum values) you MUST follow.
-Manager review will reject any branch that violates the contract."
+Manager review will reject any branch that violates the contract.
+
+For the QA teammate specifically: when writing or modifying tests,
+every assertion on an API response field MUST match the contract's
+Response Shapes section. If your test expects a field name that
+isn't in the contract, the test is wrong — fix the test to match
+the contract. Never change source files (routes, services, models)
+to match what your test happened to assert."
 
 ## Teammate Configuration
 

--- a/agent/team_contracts.py
+++ b/agent/team_contracts.py
@@ -250,6 +250,10 @@ def validate_verdict_against_contracts(
                             f"reasoning references '{token}'.",
                 ))
 
+    # 4. Test-assertion drift (#458). Look for "test expects FIELD" patterns
+    #    where FIELD is not contracted AND a divergence signal follows.
+    violations.extend(_looks_like_test_drift(reasoning, contracts))
+
     return violations
 
 
@@ -259,6 +263,44 @@ def validate_verdict_against_contracts(
 # Excludes 'should', 'correctly', 'previously', etc.
 _FIELD_NAME_TOKEN_RE = re.compile(r"\b[a-z][a-z]*[A-Z][A-Za-z]+\b")
 _QUOTED_TOKEN_RE = re.compile(r"['\"]([A-Za-z_][\w]*)['\"]")
+# Require ≥3 chars starting with at least 2 letters — excludes very short
+# captures like 'a', 'an' which the looser pattern would match as the
+# `id` group (review feedback on PR #458). The regex alone cannot reject
+# longer English stopwords like 'the' / 'that' / 'valid'; those are
+# filtered by `_TEST_DRIFT_STOPWORDS` below.
+_TEST_TRIGGER_RE = re.compile(
+    r"\b(?:test|tests)\s+(?:expects?|asserts?)\s+(?P<id>[a-zA-Z][a-zA-Z]\w+)",
+    flags=re.IGNORECASE,
+)
+
+# Common English determiners / stopwords that the trigger regex could
+# capture as the `id` group. Compared case-insensitively below.
+_TEST_DRIFT_STOPWORDS = frozenset({
+    "the", "that", "this", "these", "those",
+    "valid", "invalid", "any", "all", "some", "none",
+    "true", "false", "null", "undefined",
+    "error", "errors", "data", "response", "request",
+    "field", "fields", "value", "values", "token", "tokens",
+    "result", "results", "type", "types", "list", "array",
+    "object", "string", "number", "boolean",
+    "it", "its", "their", "his", "her",
+    "a", "an",
+})
+
+# 'instead of' was dropped — too common in benign technical rationale
+# (e.g. "uses fieldA instead of fieldB"). The remaining signals are
+# specific to actual cross-branch breakage.
+_DIVERGENCE_SIGNALS = (
+    "will break",
+    "but backend returns",
+    "after merge",
+    "cross-branch",
+)
+
+# Broader token matcher for response-shape contents — covers snake_case
+# identifiers (e.g. `created_at`) that `_FIELD_NAME_TOKEN_RE` would skip.
+# Used only inside `_looks_like_test_drift` for contracted-name lookup.
+_RESPONSE_SHAPE_TOKEN_RE = re.compile(r"\b[a-z_][\w]{2,}\b")
 
 
 def _candidate_field_names(text: str) -> list[str]:
@@ -323,3 +365,63 @@ def _is_enum_family_member(candidate: str, allowed: list[str]) -> bool:
         if candidate.startswith(a[:4]) or a.startswith(candidate[:4]):
             return True
     return False
+
+
+def _looks_like_test_drift(reasoning: str, contracts: TeamContracts) -> list[Violation]:
+    """Detect 'test expects X' patterns where X is not contracted AND a
+    divergence signal appears AFTER the trigger phrase.
+
+    Heuristic by design — same approach as the other validator passes.
+    False-positive defenses:
+      1. Both the trigger phrase (``test expects X`` / ``tests assert X``)
+         AND a divergence signal (``will break``, ``after merge``, etc.)
+         must be present. Neither alone fires.
+      2. The identifier ``X`` must NOT be in any contracted name set
+         (field_names values, response_shapes tokens). Mentioning a
+         contracted name in a test phrase is benign.
+      3. The divergence signal must appear AFTER the trigger phrase in
+         the text (positional check), not anywhere.
+
+    Issue: #458.
+    """
+    violations: list[Violation] = []
+    if not reasoning:
+        return violations
+
+    # Build the set of every name the contract considers valid.
+    contracted_names = set(contracts.field_names.values())
+    # Response-shape values are free-form strings; extract identifier-like
+    # tokens from them so the validator knows they're contract-blessed.
+    # Uses the broader response-shape regex (snake_case + camelCase) so
+    # contract names like `created_at` aren't missed (review feedback #458).
+    for shape in contracts.response_shapes.values():
+        for token in _RESPONSE_SHAPE_TOKEN_RE.findall(shape):
+            contracted_names.add(token)
+
+    lower = reasoning.lower()
+    for match in _TEST_TRIGGER_RE.finditer(reasoning):
+        identifier = match.group("id")
+        if identifier.lower() in _TEST_DRIFT_STOPWORDS:
+            continue
+        if identifier in contracted_names:
+            continue
+        # match is over `reasoning` (raw); `lower` has same length so the index is safe.
+        # The divergence signal must appear AFTER the trigger phrase.
+        trigger_end = match.end()
+        suffix = lower[trigger_end:]
+        if not any(sig in suffix for sig in _DIVERGENCE_SIGNALS):
+            continue
+        contracted_list = sorted(contracted_names)
+        expected_str = ", ".join(contracted_list[:5])
+        if len(contracted_list) > 5:
+            expected_str += ", ..."
+        violations.append(Violation(
+            section="test_assertion_drift",
+            expected=expected_str,
+            found=identifier,
+            context=(
+                f"QA test expects '{identifier}' but contract doesn't include "
+                f"this field. Tests must follow the contracted response shape."
+            ),
+        ))
+    return violations

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -2015,3 +2015,22 @@ def test_build_team_prompt_teammates_get_read_first_instruction():
     assert "READ FIRST" in prompt or "Read first" in prompt
     # And it names the file:
     assert ".claude-team-contracts.md" in prompt
+
+
+def test_build_team_prompt_qa_instruction_in_read_first_block():
+    """The QA-specific test-fixture instruction must appear in the
+    teammate-spawn block for non-plan_only modes. #458."""
+    from agent.station_orchestrator import build_team_prompt
+    prompt = build_team_prompt(
+        repo="org/repo",
+        issues=[{"number": 29, "title": "Test"}],
+        config={"projects": []},
+        run_id="run-test",
+        project_mode="full",
+    )
+    assert "For the QA teammate specifically" in prompt
+    # The instruction must name the contract section it points at:
+    assert "Response Shapes" in prompt
+    # And state the rule plainly:
+    assert "fix the test to match the contract" in prompt.lower() or \
+           "fix the test" in prompt.lower()

--- a/dashboard/backend/tests/test_team_contracts.py
+++ b/dashboard/backend/tests/test_team_contracts.py
@@ -253,3 +253,124 @@ def test_validator_does_not_flag_two_contracted_field_names_together(tmp_path):
     assert violations == [], (
         f"Two contracted names together produced violations: {violations}"
     )
+
+
+# --- #458: test_assertion_drift violation type ---
+
+
+def test_validator_flags_test_assertion_drift(tmp_path):
+    """QA verdict reasoning matching the run-20260519T070352Z pattern:
+    'test expects body/newValue fields which will break when the backend
+    branch merges (backend now returns content/author)' must flag a
+    test_assertion_drift violation with found='body'."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    # Contract uses 'content' and 'author' in the response shape; QA tests
+    # asserting on 'body' / 'newValue' is the drift case.
+    contracts_text = """\
+## Field Names
+- comment_body: content
+- comment_author: author
+
+## Response Shapes
+- /api/tickets/[id]/activity: { id, type, author, content, createdAt }
+"""
+    (tmp_path / CONTRACTS_FILENAME).write_text(contracts_text)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict(
+        "QA branch test expects body fields which will break when the "
+        "backend branch merges (backend now returns content/author)."
+    )
+    violations = validate_verdict_against_contracts(v, contracts, tmp_path)
+    drift = [vi for vi in violations if vi.section == "test_assertion_drift"]
+    assert drift, f"Expected test_assertion_drift violation, got: {violations}"
+    # The found identifier should be 'body' (the non-contracted field the
+    # test asserts on).
+    assert any(vi.found == "body" for vi in drift), (
+        f"Expected found='body' in violations: {drift}"
+    )
+
+
+def test_validator_does_not_flag_benign_test_mentions(tmp_path):
+    """A reasoning that mentions 'tests' in a non-drift way must not fire."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    (tmp_path / CONTRACTS_FILENAME).write_text(SAMPLE_CONTRACTS)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict("All tests pass on the QA branch.")
+    violations = validate_verdict_against_contracts(v, contracts, tmp_path)
+    assert not any(vi.section == "test_assertion_drift" for vi in violations), (
+        f"Benign 'tests pass' produced drift violations: {violations}"
+    )
+
+
+def test_validator_does_not_flag_contracted_field_in_test_phrase(tmp_path):
+    """When the test expects a CONTRACTED field name (no real drift),
+    the test_assertion_drift check must NOT fire. Both defenses apply:
+    the identifier is in the contracted set, AND no divergence signal
+    follows the trigger."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    (tmp_path / CONTRACTS_FILENAME).write_text(SAMPLE_CONTRACTS)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict("Test expects purchaseCost as documented in the contract.")
+    violations = validate_verdict_against_contracts(v, contracts, tmp_path)
+    assert not any(vi.section == "test_assertion_drift" for vi in violations), (
+        f"Test for contracted field produced drift violation: {violations}"
+    )
+
+
+def test_validator_does_not_flag_divergence_without_test_trigger(tmp_path):
+    """A divergence signal alone (without 'test expects') must NOT trigger
+    test_assertion_drift. The field-name validator may catch this case
+    separately; this test only asserts the drift check stays silent."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    (tmp_path / CONTRACTS_FILENAME).write_text(SAMPLE_CONTRACTS)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict("Backend returns content but frontend wants body.")
+    violations = validate_verdict_against_contracts(v, contracts, tmp_path)
+    assert not any(vi.section == "test_assertion_drift" for vi in violations), (
+        f"Divergence without test trigger produced drift violation: {violations}"
+    )
+
+
+def test_validator_drift_does_not_fire_on_stopword_identifier(tmp_path):
+    """Regex must not capture English stopwords as the test-expects identifier."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    (tmp_path / CONTRACTS_FILENAME).write_text(SAMPLE_CONTRACTS)
+    contracts = parse_contracts(tmp_path)
+    for stopword_reasoning in [
+        "test expects the response to include data after merge",
+        "test expects a valid token which will break after deployment",
+        "test expects an error after merge",
+    ]:
+        v = _make_verdict(stopword_reasoning)
+        drift = [vi for vi in validate_verdict_against_contracts(v, contracts, tmp_path)
+                 if vi.section == "test_assertion_drift"]
+        assert not drift, (
+            f"Stopword reasoning fired drift: {stopword_reasoning!r} -> {drift}"
+        )
+
+
+def test_validator_drift_does_not_fire_on_technical_rationale(tmp_path):
+    """'instead of' must not be a divergence signal — too common in benign prose."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    (tmp_path / CONTRACTS_FILENAME).write_text(SAMPLE_CONTRACTS)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict(
+        "test expects legacyName using fieldA instead of fieldB to avoid duplication"
+    )
+    drift = [vi for vi in validate_verdict_against_contracts(v, contracts, tmp_path)
+             if vi.section == "test_assertion_drift"]
+    assert not drift, (
+        f"Technical 'instead of' rationale fired drift: {drift}"
+    )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -371,7 +371,11 @@ the new contracts file.
 
 **Advisory validator:** `agent/team_contracts.py::validate_verdict_against_contracts`
 scans each manager verdict's `reasoning` text for contract violations
-(field-name mismatch, route-ownership conflict, enum-value drift).
+(field-name mismatch, route-ownership conflict, enum-value drift,
+test-assertion drift).
+The test-assertion drift check (#458) flags `"test expects X"`
+patterns where X isn't in the contract's Response Shapes section AND
+a divergence signal (`will break`, `after merge`, etc.) follows.
 Violations are logged at WARNING; verdicts are NOT auto-flipped —
 the manager has final say. The validator is heuristic by design
 (string matching against the manager's prose), not a full code parser.

--- a/docs/superpowers/plans/2026-05-19-qa-test-fixture-discipline.md
+++ b/docs/superpowers/plans/2026-05-19-qa-test-fixture-discipline.md
@@ -1,0 +1,609 @@
+# QA Test-Fixture Discipline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the QA-discipline gap surfaced in PR #457's verification — tighten the lead's spawn prompt to require QA test assertions to match the contracted Response Shapes, and add a 4th heuristic violation type to the advisory validator that flags `"test expects X"` patterns where X is not contracted and a divergence signal follows.
+
+**Architecture:** Two tiny touch points. (A) `agent/station_orchestrator.py::build_team_prompt` gets a QA-specific paragraph appended to the existing READ FIRST instruction at lines 1096–1100. (B) `agent/team_contracts.py::validate_verdict_against_contracts` calls a new private helper `_looks_like_test_drift` after the existing 3 violation passes. Both pieces are advisory — no auto-flipping of verdicts, no schema change to `.claude-team-contracts.md`.
+
+**Tech Stack:** Python 3.11 / pytest / Claude Agent SDK (prompt-level changes only).
+
+**Spec:** `docs/superpowers/specs/2026-05-19-qa-test-fixture-discipline-design.md`
+**Issue:** Closes #458
+**Target branch:** PR `--base dev` (per project policy)
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `agent/station_orchestrator.py` | MODIFY the READ FIRST string at lines 1096–1100 — append a QA-specific paragraph. ~6 lines added. |
+| `agent/team_contracts.py` | ADD module-level constant `_DIVERGENCE_SIGNALS`, regex `_TEST_TRIGGER_RE`, and private helper `_looks_like_test_drift`. EXTEND `validate_verdict_against_contracts` to call it after the existing 3 passes. ~45 lines added. |
+| `dashboard/backend/tests/test_team_contracts.py` | ADD 4 new tests: 1 positive (real drift) + 3 negative (benign mentions). |
+| `dashboard/backend/tests/test_orchestrator_wiring.py` | ADD 1 snapshot test for the new QA paragraph in the prompt. |
+| `docs/architecture.md` | EXTEND the "Advisory validator" paragraph in the Sibling-teammate coordination subsection to mention the 4th violation type. |
+
+---
+
+## Task 1: Prompt addition — QA-specific paragraph in READ FIRST block
+
+**Files:**
+- Modify: `agent/station_orchestrator.py:1096-1100` (the existing teammate-spawn instruction block)
+- Test: `dashboard/backend/tests/test_orchestrator_wiring.py` (extend with 1 snapshot test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_orchestrator_wiring.py`:
+
+```python
+def test_build_team_prompt_qa_instruction_in_read_first_block():
+    """The QA-specific test-fixture instruction must appear in the
+    teammate-spawn block for non-plan_only modes. #458."""
+    from agent.station_orchestrator import build_team_prompt
+    prompt = build_team_prompt(
+        repo="org/repo",
+        issues=[{"number": 29, "title": "Test"}],
+        config={"projects": []},
+        run_id="run-test",
+        project_mode="full",
+    )
+    assert "For the QA teammate specifically" in prompt
+    # The instruction must name the contract section it points at:
+    assert "Response Shapes" in prompt
+    # And state the rule plainly:
+    assert "fix the test to match the contract" in prompt.lower() or \
+           "fix the test" in prompt.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_orchestrator_wiring.py::test_build_team_prompt_qa_instruction_in_read_first_block -xvs`
+
+Expected: FAIL with `AssertionError` — the string `"For the QA teammate specifically"` is not in the prompt yet.
+
+- [ ] **Step 3: Append the QA paragraph to the READ FIRST block**
+
+Edit `agent/station_orchestrator.py:1096-1100`. The current block is:
+
+```python
+When spawning a teammate, include in their prompt:
+"Your worktree is at <path>. Run `cd <path>` as your FIRST action before doing anything else.
+READ FIRST: `.claude-team-contracts.md` in your worktree root. It documents the cross-team
+contracts (field names, route ownership, response shapes, enum values) you MUST follow.
+Manager review will reject any branch that violates the contract."
+```
+
+Change to:
+
+```python
+When spawning a teammate, include in their prompt:
+"Your worktree is at <path>. Run `cd <path>` as your FIRST action before doing anything else.
+READ FIRST: `.claude-team-contracts.md` in your worktree root. It documents the cross-team
+contracts (field names, route ownership, response shapes, enum values) you MUST follow.
+Manager review will reject any branch that violates the contract.
+
+For the QA teammate specifically: when writing or modifying tests,
+every assertion on an API response field MUST match the contract's
+Response Shapes section. If your test expects a field name that
+isn't in the contract, the test is wrong — fix the test to match
+the contract. Never change source files (routes, services, models)
+to match what your test happened to assert."
+```
+
+Note: this is the literal text inside the lead's spawn-prompt template. The closing `"` after `assert."` ends the multi-line quoted instruction. Keep the indentation level identical to the surrounding lines (no indentation — this is inside a Python f-string that's already at module-level indent).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_orchestrator_wiring.py::test_build_team_prompt_qa_instruction_in_read_first_block -xvs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run broader prompt-builder tests to confirm no regressions**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_orchestrator_wiring.py -x 2>&1 | tail -5`
+
+Expected: all PASS (~98 tests — the existing prompt tests plus the new one). If any pre-existing test fails because it does a length check or whitespace-sensitive comparison, the literal string addition is the only change; investigate and update the assertion if it was checking the old wording verbatim.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/station_orchestrator.py dashboard/backend/tests/test_orchestrator_wiring.py
+git commit -m "$(cat <<'EOF'
+feat(orchestrator): add QA-specific test-fixture discipline to teammate spawn (#458)
+
+build_team_prompt's READ FIRST block now appends a paragraph scoped
+to the QA teammate: every test assertion on an API response field
+must match the contract's Response Shapes section. If a test expects
+a field not in the contract, the test is wrong — never change source
+files to match the test.
+
+The paragraph is unconditional within the existing non-plan_only
+READ FIRST gating; backend/frontend teammates ignore it because they
+aren't writing tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Validator extension — `test_assertion_drift` heuristic
+
+**Files:**
+- Modify: `agent/team_contracts.py` — add `_TEST_TRIGGER_RE`, `_DIVERGENCE_SIGNALS`, `_looks_like_test_drift`; extend `validate_verdict_against_contracts` to call it.
+- Test: `dashboard/backend/tests/test_team_contracts.py` (extend with 4 new tests).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `dashboard/backend/tests/test_team_contracts.py`:
+
+```python
+# --- #458: test_assertion_drift violation type ---
+
+
+def test_validator_flags_test_assertion_drift(tmp_path):
+    """QA verdict reasoning matching the run-20260519T070352Z pattern:
+    'test expects body/newValue fields which will break when the backend
+    branch merges (backend now returns content/author)' must flag a
+    test_assertion_drift violation with found='body'."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    # Contract uses 'content' and 'author' in the response shape; QA tests
+    # asserting on 'body' / 'newValue' is the drift case.
+    contracts_text = """\
+## Field Names
+- comment_body: content
+- comment_author: author
+
+## Response Shapes
+- /api/tickets/[id]/activity: { id, type, author, content, createdAt }
+"""
+    (tmp_path / CONTRACTS_FILENAME).write_text(contracts_text)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict(
+        "QA branch test expects body fields which will break when the "
+        "backend branch merges (backend now returns content/author)."
+    )
+    violations = validate_verdict_against_contracts(v, contracts, tmp_path)
+    drift = [vi for vi in violations if vi.section == "test_assertion_drift"]
+    assert drift, f"Expected test_assertion_drift violation, got: {violations}"
+    # The found identifier should be 'body' (the non-contracted field the
+    # test asserts on).
+    assert any(vi.found == "body" for vi in drift), (
+        f"Expected found='body' in violations: {drift}"
+    )
+
+
+def test_validator_does_not_flag_benign_test_mentions(tmp_path):
+    """A reasoning that mentions 'tests' in a non-drift way must not fire."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    (tmp_path / CONTRACTS_FILENAME).write_text(SAMPLE_CONTRACTS)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict("All tests pass on the QA branch.")
+    violations = validate_verdict_against_contracts(v, contracts, tmp_path)
+    assert not any(vi.section == "test_assertion_drift" for vi in violations), (
+        f"Benign 'tests pass' produced drift violations: {violations}"
+    )
+
+
+def test_validator_does_not_flag_contracted_field_in_test_phrase(tmp_path):
+    """When the test expects a CONTRACTED field name (no real drift),
+    the test_assertion_drift check must NOT fire. Both defenses apply:
+    the identifier is in the contracted set, AND no divergence signal
+    follows the trigger."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    (tmp_path / CONTRACTS_FILENAME).write_text(SAMPLE_CONTRACTS)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict("Test expects purchaseCost as documented in the contract.")
+    violations = validate_verdict_against_contracts(v, contracts, tmp_path)
+    assert not any(vi.section == "test_assertion_drift" for vi in violations), (
+        f"Test for contracted field produced drift violation: {violations}"
+    )
+
+
+def test_validator_does_not_flag_divergence_without_test_trigger(tmp_path):
+    """A divergence signal alone (without 'test expects') must NOT trigger
+    test_assertion_drift. The field-name validator may catch this case
+    separately; this test only asserts the drift check stays silent."""
+    from agent.team_contracts import (
+        parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME,
+    )
+    (tmp_path / CONTRACTS_FILENAME).write_text(SAMPLE_CONTRACTS)
+    contracts = parse_contracts(tmp_path)
+    v = _make_verdict("Backend returns content but frontend wants body.")
+    violations = validate_verdict_against_contracts(v, contracts, tmp_path)
+    assert not any(vi.section == "test_assertion_drift" for vi in violations), (
+        f"Divergence without test trigger produced drift violation: {violations}"
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_team_contracts.py -xvs -k "test_assertion_drift or test_drift or test_validator_flags_test or test_validator_does_not_flag_benign or test_validator_does_not_flag_contracted_field_in_test_phrase or test_validator_does_not_flag_divergence_without_test_trigger"`
+
+Expected: 1 FAIL (the positive test — no `test_assertion_drift` violation produced because the helper doesn't exist yet). The 3 negative tests will pass vacuously because the new section never appears.
+
+- [ ] **Step 3: Implement `_looks_like_test_drift` and wire it into the validator**
+
+Edit `agent/team_contracts.py`. First, add the new module-level regex and constant near the other helpers (right after the existing `_QUOTED_TOKEN_RE = re.compile(...)` line around line 261):
+
+```python
+_TEST_TRIGGER_RE = re.compile(
+    r"\b(?:test|tests)\s+(?:expects?|asserts?)\s+(?P<id>[a-zA-Z_][\w]*)",
+    flags=re.IGNORECASE,
+)
+
+_DIVERGENCE_SIGNALS = (
+    "will break",
+    "but backend returns",
+    "instead of",
+    "after merge",
+    "cross-branch",
+)
+```
+
+Next, add the helper function. Place it after `_is_enum_family_member` (around line 325 after that function's body ends):
+
+```python
+def _looks_like_test_drift(reasoning: str, contracts: TeamContracts) -> list[Violation]:
+    """Detect 'test expects X' patterns where X is not contracted AND a
+    divergence signal appears AFTER the trigger phrase.
+
+    Heuristic by design — same approach as the other validator passes.
+    False-positive defenses:
+      1. Both the trigger phrase (``test expects X`` / ``tests assert X``)
+         AND a divergence signal (``will break``, ``after merge``, etc.)
+         must be present. Neither alone fires.
+      2. The identifier ``X`` must NOT be in any contracted name set
+         (field_names values, response_shapes tokens). Mentioning a
+         contracted name in a test phrase is benign.
+      3. The divergence signal must appear AFTER the trigger phrase in
+         the text (positional check), not anywhere.
+
+    Issue: #458.
+    """
+    violations: list[Violation] = []
+    if not reasoning:
+        return violations
+
+    # Build the set of every name the contract considers valid.
+    contracted_names = set(contracts.field_names.values())
+    # Response-shape values are free-form strings; extract identifier-like
+    # tokens from them so the validator knows they're contract-blessed.
+    for shape in contracts.response_shapes.values():
+        for token in _FIELD_NAME_TOKEN_RE.findall(shape):
+            contracted_names.add(token)
+
+    lower = reasoning.lower()
+    for match in _TEST_TRIGGER_RE.finditer(reasoning):
+        identifier = match.group("id")
+        if identifier in contracted_names:
+            continue
+        # The divergence signal must appear AFTER the trigger phrase.
+        trigger_end = match.end()
+        suffix = lower[trigger_end:]
+        if not any(sig in suffix for sig in _DIVERGENCE_SIGNALS):
+            continue
+        contracted_list = sorted(contracted_names)
+        expected_str = ", ".join(contracted_list[:5])
+        if len(contracted_list) > 5:
+            expected_str += "..."
+        violations.append(Violation(
+            section="test_assertion_drift",
+            expected=expected_str,
+            found=identifier,
+            context=(
+                f"QA test expects '{identifier}' but contract doesn't include "
+                f"this field. Tests must follow the contracted response shape."
+            ),
+        ))
+    return violations
+```
+
+Finally, wire the helper into `validate_verdict_against_contracts`. Find the existing function body around line 155–240. After the existing 3 passes (field-name, route-ownership, enum-value), add the 4th pass just before `return violations`:
+
+```python
+    # 4. Test-assertion drift (#458). Look for "test expects FIELD" patterns
+    #    where FIELD is not contracted AND a divergence signal follows.
+    violations.extend(_looks_like_test_drift(reasoning, contracts))
+
+    return violations
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_team_contracts.py -xvs`
+
+Expected: PASS (19 total — 15 prior + 4 new).
+
+- [ ] **Step 5: Run broader sweep**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_team_contracts.py tests/test_iterate_projects_python.py tests/test_orchestrator_wiring.py -x 2>&1 | tail -5`
+
+Expected: all PASS. Same scope as PR #457's final sweep.
+
+- [ ] **Step 6: Empirical sanity-check on the run-20260519T070352Z verification reasoning**
+
+Run this one-off probe to verify the helper triggers on the exact reasoning the manager wrote during verification:
+
+```bash
+cd /home/simon/Documents/claude-agent-station && python3 -c "
+import sys
+sys.path.insert(0, '.')
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from agent.team_contracts import parse_contracts, validate_verdict_against_contracts, CONTRACTS_FILENAME
+from agent.verdict_execution import Verdict
+
+contract = '''
+## Field Names
+- comment_body: content
+- comment_author: author
+
+## Response Shapes
+- /api/tickets/[id]/activity: { id, type, author, content, createdAt }
+'''
+
+with TemporaryDirectory() as d:
+    (Path(d) / CONTRACTS_FILENAME).write_text(contract)
+    c = parse_contracts(Path(d))
+    v = Verdict(
+        project='x', issue_number=None, verdict='APPROVE_INTEGRATION', branch='qa',
+        reasoning='the new activity timeline test expects body fields which will break when the backend branch merges (backend now returns content/author)',
+    )
+    violations = validate_verdict_against_contracts(v, c, Path(d))
+    drift = [v for v in violations if v.section == 'test_assertion_drift']
+    print(f'test_assertion_drift violations: {len(drift)}')
+    for v in drift:
+        print(f'  found={v.found}  context={v.context[:80]}')
+"
+```
+
+Expected output:
+```
+test_assertion_drift violations: 1
+  found=body  context=QA test expects 'body' but contract doesn't include this field...
+```
+
+If zero violations fire, the trigger regex or contracted-name filtering isn't matching — debug before committing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/team_contracts.py dashboard/backend/tests/test_team_contracts.py
+git commit -m "$(cat <<'EOF'
+feat(team_contracts): add test_assertion_drift violation type to validator (#458)
+
+validate_verdict_against_contracts now performs a 4th pass detecting
+the 'test expects X' pattern where X isn't in any contracted response
+shape or field name AND a divergence signal appears AFTER the trigger
+phrase (e.g. 'will break', 'after merge', 'instead of').
+
+Heuristic by design — same approach as the existing 3 violation types.
+False-positive defenses:
+1. Both trigger phrase AND divergence signal required.
+2. Contracted identifiers are filtered.
+3. Divergence signal must be positional (after trigger, not anywhere).
+
+Empirically verified against the run-20260519T070352Z manager prose
+('test expects body fields which will break when the backend branch
+merges').
+
+Advisory only — does NOT auto-flip verdicts.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Update `docs/architecture.md`
+
+**Files:**
+- Modify: `docs/architecture.md` — the Sibling-teammate coordination subsection added by PR #457.
+
+- [ ] **Step 1: Locate the Advisory validator paragraph**
+
+Run: `grep -n "Advisory validator\|field-name mismatch\|route-ownership conflict\|enum-value drift" docs/architecture.md | head -5`
+
+Expected: one or two matches in the Sibling-teammate coordination subsection (around the docs added by PR #457). Note the exact line.
+
+- [ ] **Step 2: Extend the violation-types list to include the new type**
+
+Find the paragraph that describes the validator's violation types. It should read something like:
+
+```markdown
+**Advisory validator:** `agent/team_contracts.py::validate_verdict_against_contracts`
+scans each manager verdict's `reasoning` text for contract violations
+(field-name mismatch, route-ownership conflict, enum-value drift).
+Violations are logged at WARNING; verdicts are NOT auto-flipped —
+the manager has final say. The validator is heuristic by design
+(string matching against the manager's prose), not a full code parser.
+```
+
+Change the parenthetical list from:
+
+```
+(field-name mismatch, route-ownership conflict, enum-value drift)
+```
+
+to:
+
+```
+(field-name mismatch, route-ownership conflict, enum-value drift,
+test-assertion drift)
+```
+
+Also add a one-sentence inline note after the list, before "Violations are logged":
+
+```markdown
+The test-assertion drift check (#458) flags `"test expects X"`
+patterns where X isn't in the contract's Response Shapes section AND
+a divergence signal (`will break`, `after merge`, etc.) follows.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "$(cat <<'EOF'
+docs(architecture): document test_assertion_drift validator pass (#458)
+
+Extends the Sibling-teammate coordination subsection to list the
+4th violation type the advisory validator now detects. Keeps docs
+in lockstep with the implementation per CLAUDE.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Full test sweep
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Focused scope**
+
+```bash
+cd dashboard/backend && python3 -m pytest \
+  tests/test_team_contracts.py \
+  tests/test_orchestrator_wiring.py \
+  tests/test_iterate_projects_python.py \
+  -xvs 2>&1 | tail -10
+```
+
+Expected: all PASS. `test_team_contracts.py` should now show 19 tests (15 prior + 4 new). `test_orchestrator_wiring.py` should show ~98 (existing + 1 new).
+
+- [ ] **Step 2: Broader backend sweep**
+
+```bash
+cd dashboard/backend && python3 -m pytest tests/ \
+  --ignore=tests/test_database.py \
+  --ignore=tests/test_migration_script.py \
+  --ignore=tests/test_pubsub.py \
+  -x 2>&1 | tail -5
+```
+
+Expected: ~1497 passed, 1 skipped (5 more than PR #457's final sweep).
+
+- [ ] **Step 3: No commit** (validation only).
+
+---
+
+## Task 5: Push + open PR + post-merge live verification
+
+**Files:** none (workflow).
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin <branch-name>
+```
+
+- [ ] **Step 2: Open PR against `dev`**
+
+```bash
+gh pr create --base dev --title "feat: QA test-fixture discipline (#458)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #458. Two complementary pieces:
+
+1. **Prompt addition** — \`build_team_prompt\` appends a QA-specific paragraph to the existing READ FIRST block. QA is told plainly: test assertions must match the contract's Response Shapes section; if a test expects a non-contracted field, fix the test, not the source.
+
+2. **Validator extension** — \`validate_verdict_against_contracts\` gains a 4th pass detecting the \`"test expects X"\` pattern where X isn't contracted and a divergence signal follows. Same heuristic approach as the existing 3 violation types; advisory only.
+
+## Spec
+
+\`docs/superpowers/specs/2026-05-19-qa-test-fixture-discipline-design.md\`
+
+## Changes by file
+
+- \`agent/station_orchestrator.py\` — 6-line addition to the teammate-spawn instruction at the READ FIRST block.
+- \`agent/team_contracts.py\` — new \`_TEST_TRIGGER_RE\` / \`_DIVERGENCE_SIGNALS\` / \`_looks_like_test_drift\`. \`validate_verdict_against_contracts\` calls it after the existing 3 passes.
+- \`docs/architecture.md\` — extends the Advisory validator paragraph in the Sibling-teammate coordination subsection.
+
+## Tests
+
+- 4 new unit tests in \`test_team_contracts.py\`: 1 positive (real drift pattern from run-20260519T070352Z verification) + 3 negative (benign test mentions, contracted field in test phrase, divergence without trigger).
+- 1 new snapshot test in \`test_orchestrator_wiring.py\` covering the new QA paragraph.
+- Focused scope: ~117 pass; broader sweep clean.
+
+## Closes
+
+Closes #458
+
+## Test plan
+
+- [x] Unit tests cover positive + negative cases.
+- [x] Empirical probe against verification-run prose triggers the validator.
+- [ ] Post-merge live verification: trigger a fresh \`next-itsm\` run; the manager's QA verdict should not cite a cross-branch test/API mismatch.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After merge — rebuild and smoke**
+
+```bash
+git fetch origin && git reset --hard origin/dev
+docker compose build dashboard agent && docker compose up -d --force-recreate dashboard agent
+```
+
+Trigger a run:
+
+```bash
+API_KEY=$(grep '^STATION_API_KEY=' .env | cut -d= -f2)
+curl -s -X POST http://localhost:8420/api/runs/trigger \
+  -H "Authorization: Bearer $API_KEY" -H 'Content-Type: application/json'
+```
+
+Wait for terminal. Then inspect the QA verdict:
+
+```bash
+RUN_ID=<from trigger response>
+docker exec cas-dashboard cat /var/log/claude-agent/$RUN_ID-verdicts.json | python3 -m json.tool | grep -A 3 '"qa"' | head -20
+```
+
+Expected:
+- Manager's QA verdict reasoning does NOT contain `"test expects ... will break"` / `"after merge"` / `"cross-branch"` patterns.
+- If `test_assertion_drift` violations appear in agent logs, they correspond to real cross-branch test/API mismatches (which is the validator working as designed).
+- Pass: QA verdict APPROVE_INTEGRATION OR REJECT with reason citing the contract (not a silent merge-time breakage).
+
+If the smoke run reveals the QA teammate still ignores the contract for test assertions, that's a stronger signal that Option 2 (manager downgrade-to-REJECT on cross-branch breakage) is needed — file a follow-up issue but do NOT revert this PR.
+
+If all checks pass, close #458:
+
+```bash
+MERGE_COMMIT=$(gh pr view <PR-NUMBER> --json mergeCommit -q .mergeCommit.oid | cut -c1-10)
+gh issue close 458 --comment "Fixed in PR #<PR-NUMBER> (commit ${MERGE_COMMIT}), merged into dev. Verified via live smoke run on \`next-itsm\`."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- A. QA-specific prompt addition ✅ Task 1.
+- B. Validator extension `test_assertion_drift` ✅ Task 2.
+- Tests: 4 unit (positive + 3 negative) ✅ Task 2 Step 1. Snapshot test ✅ Task 1 Step 1.
+- Docs update ✅ Task 3.
+- Live verification ✅ Task 5 Step 3.
+
+**Placeholder scan:** No TBD/TODO. All code blocks complete. All commands have expected output stated.
+
+**Type consistency:** `_TEST_TRIGGER_RE`, `_DIVERGENCE_SIGNALS`, `_looks_like_test_drift` named identically in Task 2 implementation and Task 4 sweep. `Violation.section="test_assertion_drift"` used consistently in spec, plan, tests, and docs.
+
+**False-positive defenses match the spec:** The three defenses listed in the spec's Section 2 (trigger + divergence; contracted-name skip; positional divergence) are all wired into the helper in Task 2 Step 3.
+
+Self-review clean.

--- a/docs/superpowers/specs/2026-05-19-qa-test-fixture-discipline-design.md
+++ b/docs/superpowers/specs/2026-05-19-qa-test-fixture-discipline-design.md
@@ -1,0 +1,209 @@
+# QA Test-Fixture Discipline — Design
+
+**Issue:** Closes #458 (QA tests pass on QA branch but break on merge — test-fixture contracts not enforced)
+**Author:** Claude Opus 4.7 (1M context)
+**Date:** 2026-05-19
+**Target branch:** PR targets `dev` (per project policy)
+
+## Problem
+
+PR #457 (sibling-coordination) prevents cross-team contract conflicts on API response shapes, field names, route ownership, and enum values. Verification run `run-20260519T070352Z` produced 3× APPROVE_INTEGRATION — a success vs. the prior 3× REJECT / 2× REJECT outcomes.
+
+But the manager flagged a residual problem in the QA verdict:
+
+> *the new activity timeline test expects body/newValue fields which will break when the backend branch merges (backend now returns content/author). This cross-branch integration issue needs resolution after merge.*
+
+The contract had the right info — `ActivityEntry`'s response shape explicitly included `content` and `author`. QA followed the contract for the enum-value rule (`expiring_soon`) but its test assertions used `body`/`newValue` anyway. The manager approved each branch individually, but the merged result would fail QA's own tests.
+
+So contracts.md tells teammates what the API contract IS, but doesn't enforce that QA's test assertions follow it. The system needs a stronger nudge for QA specifically.
+
+## Goals
+
+- QA understands explicitly that test assertions must match the contracted response shape.
+- The advisory validator flags the specific failure pattern (`"test expects X but backend returns Y"`) so operators see it in the log.
+- Fail-soft: no new crash paths; advisory only.
+
+## Non-Goals
+
+- New section in the contracts.md schema for test fixtures (the existing Response Shapes section already has the info).
+- Manager downgrade-to-REJECT on cross-branch breakage (Option 2 from issue — reserved for if recurrence persists).
+- Backend/frontend role-specific addenda. The failure pattern is QA-specific.
+- Auto-fixing QA's test fixtures. The validator stays advisory.
+
+## High-Level Architecture
+
+Two complementary pieces, both lightweight:
+
+### A — QA-specific prompt addition
+In `agent/station_orchestrator.py::build_team_prompt`, extend the existing READ FIRST instruction (added by #457 at lines 1097–1100) with a paragraph scoped to QA. The lead embeds this in each teammate's spawn prompt; backend/frontend treat it as a no-op.
+
+### B — Validator extension: `test_assertion_drift` violation type
+In `agent/team_contracts.py::validate_verdict_against_contracts`, add a 4th pass that scans the manager's `reasoning` for the specific pattern of `"test expects X"` where X is NOT in any contracted response shape AND the reasoning also contains a divergence signal nearby. Heuristic by design — same approach as the existing 3 violation types, with the false-positive defenses we tightened in PR #457's re-review.
+
+## Components
+
+### 1. Modified: `agent/station_orchestrator.py::build_team_prompt`
+
+Around the existing READ FIRST instruction (lines 1097–1100), append a QA-specific paragraph. Literal text added:
+
+```
+For the QA teammate specifically: when writing or modifying tests,
+every assertion on an API response field MUST match the contract's
+Response Shapes section. If your test expects a field name that
+isn't in the contract, the test is wrong — fix the test to match
+the contract. Never change source files (routes, services, models)
+to match what your test happened to assert.
+```
+
+The paragraph appears unconditionally in the spawn-prompt template — backend/frontend ignore it because they aren't writing tests. No mode-gating needed (the existing READ FIRST already exists for all non-`plan_only` modes; this addendum follows the same gating).
+
+### 2. Modified: `agent/team_contracts.py::validate_verdict_against_contracts`
+
+Add a 4th pass after the existing field-name / route-ownership / enum-value passes:
+
+```python
+# 4. Test-assertion drift. Look for "test expects FIELD" patterns where
+#    FIELD is not in any contracted response shape or field name AND a
+#    divergence signal appears AFTER the trigger phrase.
+violations.extend(_looks_like_test_drift(reasoning, contracts))
+```
+
+Helper `_looks_like_test_drift(reasoning: str, contracts: TeamContracts) -> list[Violation]` (~40 lines):
+
+```python
+_TEST_TRIGGER_RE = re.compile(
+    r"\b(?:test|tests)\s+(?:expects?|asserts?)\s+(?P<id>[a-zA-Z_][\w]*)",
+    flags=re.IGNORECASE,
+)
+
+_DIVERGENCE_SIGNALS = (
+    "will break",
+    "but backend returns",
+    "instead of",
+    "after merge",
+    "cross-branch",
+)
+
+
+def _looks_like_test_drift(reasoning: str, contracts: TeamContracts) -> list[Violation]:
+    """Detect 'test expects X' patterns where X is not contracted AND a
+    divergence signal appears after the trigger phrase. Heuristic; advisory."""
+    violations: list[Violation] = []
+    if not reasoning:
+        return violations
+
+    # Build the set of every name the contract considers valid.
+    contracted_names = set(contracts.field_names.values())
+    # Response-shape values are free-form strings; extract identifier-like
+    # tokens from them so the validator knows they're contract-blessed.
+    for shape in contracts.response_shapes.values():
+        for token in _FIELD_NAME_TOKEN_RE.findall(shape):
+            contracted_names.add(token)
+
+    lower = reasoning.lower()
+    for match in _TEST_TRIGGER_RE.finditer(reasoning):
+        identifier = match.group("id")
+        if identifier in contracted_names:
+            continue
+        # The divergence signal must appear AFTER the trigger phrase.
+        trigger_end = match.end()
+        suffix = lower[trigger_end:]
+        if not any(sig in suffix for sig in _DIVERGENCE_SIGNALS):
+            continue
+        violations.append(Violation(
+            section="test_assertion_drift",
+            expected=", ".join(sorted(contracted_names)[:5]) + ("..." if len(contracted_names) > 5 else ""),
+            found=identifier,
+            context=(
+                f"QA test expects '{identifier}' but contract doesn't include "
+                f"this field. Tests must follow the contracted response shape."
+            ),
+        ))
+    return violations
+```
+
+False-positive defenses (mirroring the lessons from PR #457's re-review):
+- Both the trigger phrase AND a divergence signal must be present — neither alone fires.
+- Skip when the identifier IS contracted (no flagging contracted names against themselves).
+- Divergence signal must appear AFTER the trigger phrase in the text (positional, not anywhere).
+- The trigger regex requires both `"test"`/`"tests"` AND `"expects"`/`"asserts"` — generic uses of the word "test" (e.g. "all tests pass") don't trigger.
+
+### 3. New tests in `dashboard/backend/tests/test_team_contracts.py`
+
+Four tests:
+
+1. **`test_validator_flags_test_assertion_drift`** — reasoning contains the verification-run pattern (`"test expects body/newValue fields which will break when the backend branch merges (backend now returns content/author)"`). Asserts a `test_assertion_drift` violation fires with `found="body"`.
+
+2. **`test_validator_does_not_flag_benign_test_mentions`** — reasoning is `"all tests pass on the QA branch."` Asserts no `test_assertion_drift` violation.
+
+3. **`test_validator_does_not_flag_contracted_field_in_test_phrase`** — reasoning is `"test expects purchaseCost as documented in the contract."` Asserts no `test_assertion_drift` violation. Both false-positive defenses apply here: the identifier `purchaseCost` IS contracted (skip via the `contracted_names` filter), AND no divergence signal follows (skip via the suffix check). Either defense alone is sufficient; this test relies on the contracted-name filter primarily.
+
+4. **`test_validator_does_not_flag_divergence_without_test_trigger`** — reasoning is `"backend returns content but frontend wants body."` Asserts no `test_assertion_drift` violation (no `"test expects"` phrase). Note: the existing field-name validator may catch this separately; this test only asserts the test-drift check returns no violations.
+
+### 4. New snapshot test in `dashboard/backend/tests/test_orchestrator_wiring.py`
+
+`test_build_team_prompt_qa_instruction_in_read_first_block` — asserts the literal string `"For the QA teammate specifically"` appears in the returned prompt for non-`plan_only` modes.
+
+### 5. Updated docs: `docs/architecture.md`
+
+In the Sibling-teammate coordination subsection added by #457, extend the "Advisory validator" paragraph to mention the 4th violation type:
+
+> The validator scans each manager verdict's `reasoning` text for contract violations: field-name mismatch, route-ownership conflict, enum-value drift, and **test-assertion drift (QA tests expecting fields not in the contract's Response Shapes)**.
+
+## Data Flow
+
+```
+build_team_prompt
+ └─► returns prompt INCLUDING the QA-specific paragraph
+     └─► lead embeds in each teammate spawn (QA receives + acts on it; backend/frontend no-op)
+
+validate_verdict_against_contracts (existing pipeline)
+ ├─► pass 1: field-name conflicts (existing)
+ ├─► pass 2: route-ownership conflicts (existing)
+ ├─► pass 3: enum-value conflicts (existing)
+ └─► pass 4: NEW — test-assertion drift via _looks_like_test_drift()
+```
+
+No new external touch points. No DB / wire-format / config changes.
+
+## Error Handling
+
+- `_looks_like_test_drift` is pure (no IO, no exceptions). Returns empty list on no match.
+- Fail-soft already inherited from the outer `validate_verdict_against_contracts` wrapper (`try/except` in `iterate_projects`).
+- New violation type is purely additive to the result list — older log consumers ignore unknown `section` values.
+
+## Testing
+
+### Unit tests — `dashboard/backend/tests/test_team_contracts.py` (4 new)
+Listed in Component 3. All 4 must pass; all 15 prior tests must remain green.
+
+### Snapshot test — `dashboard/backend/tests/test_orchestrator_wiring.py` (1 new)
+Listed in Component 4.
+
+### Live verification (post-merge, NOT in CI)
+Trigger a run on `next-itsm` with the same set of issues (#29/#30 if still open, or any open issues that exercise the activity-timeline area). **Acceptance**: the manager's QA verdict does NOT cite a cross-branch test/API mismatch in its reasoning. If the run produces a `test_assertion_drift` violation in the log AND the QA verdict is REJECT, that's also acceptable (the validator caught it for the operator's visibility).
+
+## Backwards Compatibility
+
+- New prompt paragraph is unconditional within the existing non-`plan_only` READ FIRST gating. No new mode signals.
+- New `Violation.section = "test_assertion_drift"` is additive — existing code paths that switch on section name still work; new code can opt to handle the new value.
+- No DB / wire-format changes.
+
+## Acceptance
+
+- [ ] `build_team_prompt`'s READ FIRST block contains the QA-specific paragraph.
+- [ ] `validate_verdict_against_contracts` calls `_looks_like_test_drift` after the existing 3 passes.
+- [ ] All 4 new unit tests pass.
+- [ ] All 15 prior `test_team_contracts.py` tests pass.
+- [ ] Snapshot test in `test_orchestrator_wiring.py` passes.
+- [ ] Broader backend sweep clean.
+- [ ] `docs/architecture.md` updated.
+- [ ] PR targets `dev`. Closes #458.
+- [ ] Post-merge live verification on `next-itsm` (no recurrence of the test/API mismatch in QA verdicts).
+
+## Out-of-Scope Follow-Ups
+
+- Adding a Test Fixtures section to the contracts.md schema (defer until evidence shows the Response Shapes section is insufficient).
+- Option 2: manager downgrade-to-REJECT on cross-branch breakage (reserve for if recurrence persists despite this PR).
+- Backend/frontend-specific addenda (no observed failure pattern).
+- Programmatic AST-level inspection of QA test files (beyond a heuristic prose validator).


### PR DESCRIPTION
## Summary

Closes #458. Builds on PR #457's sibling-coordination work. Two complementary pieces:

1. **Prompt addition** — `build_team_prompt` appends a QA-specific paragraph to the existing READ FIRST block. QA is told plainly: test assertions must match the contract's Response Shapes section; if a test expects a non-contracted field, fix the test, not the source.

2. **Validator extension** — `validate_verdict_against_contracts` gains a 4th pass detecting the `"test expects X"` pattern where X isn't contracted AND a divergence signal follows. Same heuristic approach as the existing 3 violation types, with the FP-reduction lessons from #457 already baked in.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-19-qa-test-fixture-discipline-design.md`
- Plan: `docs/superpowers/plans/2026-05-19-qa-test-fixture-discipline.md`

## Changes by file

- `agent/station_orchestrator.py` — 6-line addition to the teammate-spawn instruction at the READ FIRST block.
- `agent/team_contracts.py` — new `_TEST_TRIGGER_RE`, `_TEST_DRIFT_STOPWORDS`, `_DIVERGENCE_SIGNALS`, `_RESPONSE_SHAPE_TOKEN_RE`, and `_looks_like_test_drift` helper. `validate_verdict_against_contracts` calls it after the existing 3 passes.
- `docs/architecture.md` — extends the Advisory validator paragraph in the Sibling-teammate coordination subsection.

## False-positive defenses (3-layer, mirroring #457's lessons)

1. **Trigger + divergence required.** Neither alone fires.
2. **Stopword filter** + **contracted-name skip.** English determiners (`the`, `that`, `valid`, `error`, etc.) and any contracted identifier are silenced. Issue #458's specific concern was that the heuristic should be conservative — see commit `d8d9e59`'s message for the 6-probe empirical verification.
3. **Positional divergence check.** The signal must appear AFTER the trigger phrase in the text, not anywhere.

## Tests

- 6 new unit tests in `test_team_contracts.py`: 1 positive (real drift from run-20260519T070352Z) + 5 negative (benign mentions, contracted field, divergence-without-trigger, stopword identifier, technical rationale).
- 1 new snapshot test in `test_orchestrator_wiring.py` for the QA paragraph in the prompt.
- Focused: 139 pass. **Broader sweep: 1502 passed, 1 skipped.**

## Process notes

Implemented via subagent-driven-development. T2 needed one code-quality re-review loop — the original validator over-fired on stopwords (`"test expects the response after merge"` would fire) and on `"instead of"` (too common in benign rationale). All caught and fixed before merge with empirical probes.

## Closes

Closes #458

## Test plan

- [x] All unit + integration tests pass.
- [x] Broader sweep clean.
- [x] 6-probe empirical verification: positive case fires, all 5 negative cases silent.
- [ ] Post-merge live verification: trigger a fresh `next-itsm` run; the manager's QA verdict should not cite a cross-branch test/API mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)