### PR TITLE
feat: acceptance-criteria decomposition + QA test ownership (#464)

### DIFF
--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -11,6 +11,7 @@ Each former bash phase is a dedicated Python module under ``agent/``
 from __future__ import annotations
 
 import logging
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -408,6 +409,44 @@ def iterate_projects(
                         )
         except Exception:  # noqa: BLE001 — best-effort, never crash run
             logger.exception("contract validator failed (non-fatal)")
+
+        # #464: missing-test-coverage advisory check. Fetches each unique
+        # issue body once, scans for test-file paths, and flags any path
+        # not acknowledged by an APPROVE verdict. Advisory only; logged
+        # at WARNING. Fail-soft: errors never block the run.
+        try:
+            from agent.team_contracts import _looks_like_missing_test_coverage
+
+            unique_issues = {
+                v.get("issue_number") for v in raw_verdicts
+                if v.get("issue_number") is not None
+            }
+            issue_bodies: dict[int, str] = {}
+            for n in unique_issues:
+                result = subprocess.run(
+                    ["gh", "issue", "view", str(n),
+                     "--repo", project["repo"],
+                     "--json", "body", "-q", ".body"],
+                    capture_output=True, text=True,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    issue_bodies[n] = result.stdout
+
+            for n, body in issue_bodies.items():
+                coverage_violations = _looks_like_missing_test_coverage(
+                    body, raw_verdicts, project["repo"]
+                )
+                if coverage_violations:
+                    logger.warning(
+                        "missing test coverage on issue #%s: %s",
+                        n,
+                        [
+                            f"{vi.section}: {vi.context}"
+                            for vi in coverage_violations
+                        ],
+                    )
+        except Exception:  # noqa: BLE001 — best-effort, never crash run
+            logger.exception("test-coverage validator failed (non-fatal)")
 
         # #442: plan_only projects fan out into APPROVE_PLAN /
         # REVISE_PLAN / REJECT_PLAN follow-up actions that the manager-sibling

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -934,6 +934,22 @@ any verdict that conflicts with the contract.
 5. **Actively monitor** teammates until each has written
    `.claude-employee-report-<index>.json` or 20 minutes elapse (see monitoring rules below).
 6. After teammates finish, **synthesize a final JSON summary**.
+
+### Acceptance-criteria decomposition (#464)
+
+Read each issue's body carefully. For EVERY item in the acceptance
+criteria, the approved plan should map to the right role:
+
+  - Source code (routes, services, models, components) → backend or
+    frontend per location.
+  - Test files (`*.test.ts`, `*.spec.ts`, `Unit tests in ...`,
+    `tests/test_*.py`) → ALWAYS QA, even when the file path lives
+    inside backend/frontend territory.
+  - Docs / configuration → assign to whoever owns the adjacent code.
+
+If the issue body explicitly names a test file path, the QA teammate
+MUST create that file. The manager will reject any APPROVE that
+doesn't satisfy every acceptance item.
 """
     else:
         workflow_section = f"""## Your Workflow
@@ -949,6 +965,22 @@ any verdict that conflicts with the contract.
 6. Review plans — reject if they conflict with another teammate's work
 7. **Actively monitor** teammates until ALL tasks are completed (see monitoring rules)
 8. After all work is done, **synthesize a final JSON summary**
+
+### Acceptance-criteria decomposition (#464)
+
+Read each issue's body carefully. For EVERY item in the acceptance
+criteria, the approved plan should map to the right role:
+
+  - Source code (routes, services, models, components) → backend or
+    frontend per location.
+  - Test files (`*.test.ts`, `*.spec.ts`, `Unit tests in ...`,
+    `tests/test_*.py`) → ALWAYS QA, even when the file path lives
+    inside backend/frontend territory.
+  - Docs / configuration → assign to whoever owns the adjacent code.
+
+If the issue body explicitly names a test file path, the QA teammate
+MUST create that file. The manager will reject any APPROVE that
+doesn't satisfy every acceptance item.
 """
 
     # Build the manager-spawn section (#390): inject only when the caller
@@ -1104,7 +1136,12 @@ every assertion on an API response field MUST match the contract's
 Response Shapes section. If your test expects a field name that
 isn't in the contract, the test is wrong — fix the test to match
 the contract. Never change source files (routes, services, models)
-to match what your test happened to assert."
+to match what your test happened to assert.
+
+Additionally: when the issue's acceptance criteria reference unit
+tests, integration tests, or specific test files, YOU are responsible for creating those test files.
+NEVER skip a run just because the issue is backend-scoped — your scope is testing, which exists for
+backend issues too. If the lead didn't create a coordinator task for you, claim the test work yourself."
 
 ## Picker rules (#462)
 

--- a/agent/team_contracts.py
+++ b/agent/team_contracts.py
@@ -302,6 +302,18 @@ _DIVERGENCE_SIGNALS = (
 # Used only inside `_looks_like_test_drift` for contracted-name lookup.
 _RESPONSE_SHAPE_TOKEN_RE = re.compile(r"\b[a-z_][\w]{2,}\b")
 
+# #464: strict test-file path matcher. Captures file paths with `/` and
+# either `.test.X` / `.spec.X` infix OR inside a `/tests/` segment.
+# Handles both bare and backticked forms. Rejects bare prose like
+# "unit tests" or "test pass".
+_TEST_FILE_REF_RE = re.compile(
+    r"(?:\b|`)("
+    r"(?:[\w.-]+/)+[\w.-]+\.(?:test|spec)\.[a-zA-Z]+"  # foo/bar.test.ts
+    r"|"
+    r"(?:[\w.-]+/)*tests/[\w./-]+\.\w+"                # tests/foo.py or path/tests/foo.py
+    r")(?:\b|`)"
+)
+
 
 def _candidate_field_names(text: str) -> list[str]:
     """True camelCase identifiers (lowercase start, at least one inner uppercase).
@@ -424,4 +436,65 @@ def _looks_like_test_drift(reasoning: str, contracts: TeamContracts) -> list[Vio
                 f"this field. Tests must follow the contracted response shape."
             ),
         ))
+    return violations
+
+
+def _looks_like_missing_test_coverage(
+    issue_body: str,
+    verdicts: list,
+    project_repo: str,
+) -> list[Violation]:
+    """Detect test-file paths in the issue body that no approved verdict
+    acknowledges. Heuristic; advisory.
+
+    Strict file-path matching only — bare prose like 'write unit tests'
+    is NOT flagged because the manager's existing acceptance-criteria
+    checks already surface those cases.
+
+    Skips when no APPROVE / APPROVE_INTEGRATION verdicts exist (the
+    REJECTs already capture the underlying gap).
+
+    Issue: #464.
+    """
+    if not issue_body:
+        return []
+    test_paths = list(dict.fromkeys(_TEST_FILE_REF_RE.findall(issue_body)))
+    if not test_paths:
+        return []
+
+    approved_verdicts = [
+        v for v in verdicts
+        if (v.get("verdict") or "") in ("APPROVE", "APPROVE_INTEGRATION")
+    ]
+    if not approved_verdicts:
+        # No APPROVEs at all — the REJECTs already capture the issue.
+        return []
+
+    violations: list[Violation] = []
+    for path in test_paths:
+        # Check whether any approved verdict's reasoning/feedback/requirements_met
+        # acknowledges this path.
+        acknowledged = False
+        for v in approved_verdicts:
+            blob_parts = [
+                v.get("reasoning", "") or "",
+                v.get("feedback_to_employee", "") or "",
+                " ".join(v.get("requirements_met", []) or []),
+            ]
+            blob = " ".join(blob_parts)
+            if path in blob:
+                acknowledged = True
+                break
+        if not acknowledged:
+            violations.append(Violation(
+                section="missing_test_coverage",
+                expected=path,
+                found="(no approved verdict acknowledges this path)",
+                context=(
+                    f"Issue body references test path '{path}', but no "
+                    f"APPROVE/APPROVE_INTEGRATION verdict's "
+                    f"requirements_met or feedback acknowledges it. "
+                    f"QA teammate likely did not create the file."
+                ),
+            ))
     return violations

--- a/dashboard/backend/tests/test_iterate_projects_python.py
+++ b/dashboard/backend/tests/test_iterate_projects_python.py
@@ -951,3 +951,79 @@ def test_summarize_prior_verdicts_picks_most_recent_matching_file(tmp_path):
     assert summary is not None
     assert "new reasoning" in summary
     assert "old reasoning" not in summary
+
+
+def test_iterate_projects_logs_missing_test_coverage_warning(
+    tmp_path, monkeypatch, caplog
+):
+    """When the issue body references a test path that no APPROVE verdict
+    acknowledges, iterate_projects logs a WARNING with the missing
+    test path. #464."""
+    import logging
+    from agent import project_loop
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setenv("STATION_LOG_DIR", str(log_dir))
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"projects":[{"repo":"org/repo","enabled":true,"mode":"full"}]}'
+    )
+
+    async def fake_orchestrate(*a, **kw):
+        return (0, None, True)
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace",
+        lambda *a, **kw: str(tmp_path / "ws"),
+    )
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda p: {"verdicts": [{
+            "project": "org/repo",
+            "verdict": "APPROVE",
+            "issue_number": 99,
+            "branch": "feature/backend-issue-99",
+            "base_branch": "claude-agent-station",
+            "reasoning": "Route implementation is correct.",
+            "feedback_to_employee": "Looks good.",
+            "requirements_met": ["Route returns 200"],
+        }]},
+    )
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+    monkeypatch.setattr("agent.verdict_execution.execute",
+                        lambda *a, **kw: None)
+
+    import subprocess
+    def fake_subprocess(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and cmd[:3] == ["gh", "issue", "view"]:
+            body = (
+                "## Acceptance\n"
+                "- Unit tests in src/app/api/health/route.test.ts "
+                "covering both branches"
+            )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=body, stderr=""
+            )
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="", stderr=""
+        )
+    monkeypatch.setattr("agent.project_loop.subprocess.run", fake_subprocess)
+
+    caplog.set_level(logging.WARNING, logger="agent.project_loop")
+    project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "ws")
+    )
+
+    assert any(
+        "missing test coverage" in record.message.lower()
+        for record in caplog.records
+    ), f"Expected 'missing test coverage' WARNING; got: {[r.message for r in caplog.records]}"

--- a/dashboard/backend/tests/test_orchestrator_wiring.py
+++ b/dashboard/backend/tests/test_orchestrator_wiring.py
@@ -2049,3 +2049,25 @@ def test_build_team_prompt_includes_picker_rules():
     )
     assert "BEFORE assigning any work" in prompt
     assert "workspace_setup automatically prunes" in prompt
+
+
+def test_build_team_prompt_includes_acceptance_decomposition_and_qa_test_ownership():
+    """Both the lead's acceptance-criteria decomposition block and the
+    QA spawn-prompt test-ownership addendum must appear in the prompt
+    for non-plan_only modes. #464."""
+    from agent.station_orchestrator import build_team_prompt
+    prompt = build_team_prompt(
+        repo="org/repo",
+        issues=[{"number": 99, "title": "Test"}],
+        config={"projects": []},
+        run_id="run-test",
+        project_mode="full",
+    )
+    # A — Lead workflow tightening
+    assert "Acceptance-criteria decomposition" in prompt
+    assert "test files (`*.test.ts`" in prompt.lower() or \
+           "test files (*.test.ts" in prompt.lower() or \
+           "test files" in prompt.lower()
+    # B — QA spawn-prompt addendum
+    assert "you are responsible for creating those test files" in prompt.lower()
+    assert "never skip a run just because" in prompt.lower()

--- a/dashboard/backend/tests/test_team_contracts.py
+++ b/dashboard/backend/tests/test_team_contracts.py
@@ -374,3 +374,109 @@ def test_validator_drift_does_not_fire_on_technical_rationale(tmp_path):
     assert not drift, (
         f"Technical 'instead of' rationale fired drift: {drift}"
     )
+
+
+# --- #464: missing_test_coverage validator pass ---
+
+
+def test_test_file_ref_regex_matches_strict_paths():
+    """Regex captures file-path-shaped test references, in both bare
+    and backticked forms. Rejects bare prose."""
+    from agent.team_contracts import _TEST_FILE_REF_RE
+
+    # Should match — file paths ending in .test.X or .spec.X
+    assert _TEST_FILE_REF_RE.findall(
+        "Unit tests in src/app/api/health/route.test.ts covering both branches"
+    ) == ["src/app/api/health/route.test.ts"]
+
+    assert _TEST_FILE_REF_RE.findall(
+        "Tests in `lib/utils.spec.ts` cover the helpers."
+    ) == ["lib/utils.spec.ts"]
+
+    # Should match — paths inside /tests/ segment
+    assert _TEST_FILE_REF_RE.findall(
+        "See dashboard/backend/tests/test_foo.py for examples"
+    ) == ["dashboard/backend/tests/test_foo.py"]
+
+    # Should NOT match — bare prose
+    assert _TEST_FILE_REF_RE.findall("Write unit tests for the auth module") == []
+    assert _TEST_FILE_REF_RE.findall("All tests pass on the QA branch") == []
+    assert _TEST_FILE_REF_RE.findall("the test for purchaseCost is wrong") == []
+
+
+def test_validator_flags_missing_test_coverage_when_no_verdict_addresses_path(tmp_path):
+    """When issue body references a test path and no APPROVE verdict
+    acknowledges it, fire a missing_test_coverage violation."""
+    from agent.team_contracts import _looks_like_missing_test_coverage
+
+    issue_body = (
+        "## Acceptance\n"
+        "- Unit tests in src/app/api/health/route.test.ts covering both branches"
+    )
+    verdicts = [
+        {
+            "verdict": "APPROVE",
+            "branch": "feature/backend-issue-61",
+            "reasoning": "Route implements all functional requirements correctly.",
+            "feedback_to_employee": "Good route implementation.",
+            "requirements_met": [
+                "GET /api/health returns 200 + success shape",
+                "Returns 503 + failure shape when Prisma throws",
+            ],
+        }
+    ]
+    violations = _looks_like_missing_test_coverage(
+        issue_body, verdicts, "owner/repo"
+    )
+    assert len(violations) == 1
+    assert violations[0].section == "missing_test_coverage"
+    assert violations[0].expected == "src/app/api/health/route.test.ts"
+    assert "QA teammate likely did not create the file" in violations[0].context
+
+
+def test_validator_passes_when_verdict_acknowledges_test_path():
+    """When an APPROVE verdict's requirements_met includes the test path,
+    no violation fires."""
+    from agent.team_contracts import _looks_like_missing_test_coverage
+
+    issue_body = (
+        "## Acceptance\n"
+        "- Unit tests in src/app/api/health/route.test.ts covering both branches"
+    )
+    verdicts = [
+        {
+            "verdict": "APPROVE",
+            "branch": "feature/qa-issue-61",
+            "reasoning": "Tests cover both branches.",
+            "feedback_to_employee": "Good test coverage.",
+            "requirements_met": [
+                "Unit tests in src/app/api/health/route.test.ts",
+            ],
+        }
+    ]
+    violations = _looks_like_missing_test_coverage(
+        issue_body, verdicts, "owner/repo"
+    )
+    assert violations == []
+
+
+def test_validator_does_not_fire_when_no_test_paths_in_body():
+    """Body has no file-path test references → no violation regardless of verdicts."""
+    from agent.team_contracts import _looks_like_missing_test_coverage
+
+    issue_body = "Add the depreciation route. Should support all CRUD ops."
+    verdicts = [{"verdict": "APPROVE", "branch": "feature/x", "reasoning": "Done."}]
+    assert _looks_like_missing_test_coverage(issue_body, verdicts, "owner/repo") == []
+
+
+def test_validator_does_not_fire_when_no_approve_verdicts_exist():
+    """When ALL verdicts are REJECT, no missing_test_coverage violation
+    fires (REJECTs already capture the underlying gap)."""
+    from agent.team_contracts import _looks_like_missing_test_coverage
+
+    issue_body = "Unit tests in src/app/api/health/route.test.ts covering both branches"
+    verdicts = [
+        {"verdict": "REJECT", "branch": "feature/backend", "reasoning": "..."},
+        {"verdict": "REJECT", "branch": "feature/qa", "reasoning": "..."},
+    ]
+    assert _looks_like_missing_test_coverage(issue_body, verdicts, "owner/repo") == []

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -372,10 +372,16 @@ the new contracts file.
 **Advisory validator:** `agent/team_contracts.py::validate_verdict_against_contracts`
 scans each manager verdict's `reasoning` text for contract violations
 (field-name mismatch, route-ownership conflict, enum-value drift,
-test-assertion drift).
+test-assertion drift, test-file coverage).
 The test-assertion drift check (#458) flags `"test expects X"`
 patterns where X isn't in the contract's Response Shapes section AND
 a divergence signal (`will break`, `after merge`, etc.) follows.
+The test-file coverage check (#464) fires when an issue body
+references a specific test file path (e.g.
+`src/app/api/health/route.test.ts`) but no APPROVE verdict's
+requirements_met or feedback acknowledges that path. Surfaces the
+case where QA produced no verdict OR produced one without creating
+the requested test file.
 Violations are logged at WARNING; verdicts are NOT auto-flipped —
 the manager has final say. The validator is heuristic by design
 (string matching against the manager's prose), not a full code parser.

--- a/docs/superpowers/plans/2026-05-19-acceptance-criteria-decomposition.md
+++ b/docs/superpowers/plans/2026-05-19-acceptance-criteria-decomposition.md
@@ -1,0 +1,977 @@
+# Acceptance-Criteria Decomposition + QA Test Ownership Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the gap where the QA teammate produces no verdict on backend-scoped issues that have test-file requirements — via three additive pieces: lead workflow tightening, QA spawn-prompt addendum, and a `missing_test_coverage` advisory validator.
+
+**Architecture:** All changes live in three files. (A) `agent/station_orchestrator.py::build_team_prompt` gains an `Acceptance-criteria decomposition (#464)` block in BOTH workflow_section branches plus an extension to the existing QA-specific paragraph. (B) `agent/team_contracts.py` gains `_TEST_FILE_REF_RE` constant + `_looks_like_missing_test_coverage` standalone helper (not embedded in `validate_verdict_against_contracts` — keeps that signature stable). (C) `agent/project_loop.py::iterate_projects` fetches issue bodies via `gh issue view` and calls the new helper alongside the existing per-verdict validator. Fail-soft throughout; advisory only.
+
+**Tech Stack:** Python 3.11 / pytest / `gh` CLI / regex
+
+**Spec:** `docs/superpowers/specs/2026-05-19-acceptance-criteria-decomposition-design.md`
+**Issue:** Closes #464
+**Target branch:** PR `--base dev` (per project policy)
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `agent/station_orchestrator.py` | MODIFY `build_team_prompt`: add `Acceptance-criteria decomposition (#464)` block to BOTH workflow_section branches (approved-plans at line ~924, fresh-issues at line ~939); APPEND test-ownership addendum to the existing QA-specific paragraph in the teammate-spawn READ FIRST block (line ~1102-1108). ~25 lines of literal text. |
+| `agent/team_contracts.py` | ADD `_TEST_FILE_REF_RE` constant + `_looks_like_missing_test_coverage(issue_body, verdicts, project_repo) -> list[Violation]` standalone helper. ~55 lines. Does NOT modify `validate_verdict_against_contracts` signature. |
+| `agent/project_loop.py` | ADD a second validator pass after the existing one (~lines 386-410). Fetches unique issue bodies via `gh issue view --json body`, iterates them, runs `_looks_like_missing_test_coverage` per issue, logs violations at WARNING. ~25 lines, wrapped in `try/except` for fail-soft. |
+| `dashboard/backend/tests/test_team_contracts.py` | EXTEND with 5 new tests covering regex + helper behavior. |
+| `dashboard/backend/tests/test_orchestrator_wiring.py` | EXTEND with 1 new snapshot test for the prompt additions. |
+| `dashboard/backend/tests/test_iterate_projects_python.py` | EXTEND with 1 new integration test for the iterate_projects glue. |
+| `docs/architecture.md` | EXTEND the validator section's enumeration to include `test-file coverage` as the 5th violation type. |
+
+---
+
+## Task 1: `_TEST_FILE_REF_RE` regex + `_looks_like_missing_test_coverage` helper
+
+**Files:**
+- Modify: `agent/team_contracts.py`
+- Test: `dashboard/backend/tests/test_team_contracts.py` (extend)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `dashboard/backend/tests/test_team_contracts.py`:
+
+```python
+# --- #464: missing_test_coverage validator pass ---
+
+
+def test_test_file_ref_regex_matches_strict_paths():
+    """Regex captures file-path-shaped test references, in both bare
+    and backticked forms. Rejects bare prose."""
+    from agent.team_contracts import _TEST_FILE_REF_RE
+
+    # Should match — file paths ending in .test.X or .spec.X
+    assert _TEST_FILE_REF_RE.findall(
+        "Unit tests in src/app/api/health/route.test.ts covering both branches"
+    ) == ["src/app/api/health/route.test.ts"]
+
+    assert _TEST_FILE_REF_RE.findall(
+        "Tests in `lib/utils.spec.ts` cover the helpers."
+    ) == ["lib/utils.spec.ts"]
+
+    # Should match — paths inside /tests/ segment
+    assert _TEST_FILE_REF_RE.findall(
+        "See dashboard/backend/tests/test_foo.py for examples"
+    ) == ["dashboard/backend/tests/test_foo.py"]
+
+    # Should NOT match — bare prose
+    assert _TEST_FILE_REF_RE.findall("Write unit tests for the auth module") == []
+    assert _TEST_FILE_REF_RE.findall("All tests pass on the QA branch") == []
+    assert _TEST_FILE_REF_RE.findall("the test for purchaseCost is wrong") == []
+
+
+def test_validator_flags_missing_test_coverage_when_no_verdict_addresses_path(tmp_path):
+    """When issue body references a test path and no APPROVE verdict
+    acknowledges it, fire a missing_test_coverage violation."""
+    from agent.team_contracts import _looks_like_missing_test_coverage
+
+    issue_body = (
+        "## Acceptance\n"
+        "- Unit tests in src/app/api/health/route.test.ts covering both branches"
+    )
+    verdicts = [
+        {
+            "verdict": "APPROVE",
+            "branch": "feature/backend-issue-61",
+            "reasoning": "Route implements all functional requirements correctly.",
+            "feedback_to_employee": "Good route implementation.",
+            "requirements_met": [
+                "GET /api/health returns 200 + success shape",
+                "Returns 503 + failure shape when Prisma throws",
+            ],
+        }
+    ]
+    violations = _looks_like_missing_test_coverage(
+        issue_body, verdicts, "owner/repo"
+    )
+    assert len(violations) == 1
+    assert violations[0].section == "missing_test_coverage"
+    assert violations[0].expected == "src/app/api/health/route.test.ts"
+    assert "QA teammate likely did not create the file" in violations[0].context
+
+
+def test_validator_passes_when_verdict_acknowledges_test_path():
+    """When an APPROVE verdict's requirements_met includes the test path,
+    no violation fires."""
+    from agent.team_contracts import _looks_like_missing_test_coverage
+
+    issue_body = (
+        "## Acceptance\n"
+        "- Unit tests in src/app/api/health/route.test.ts covering both branches"
+    )
+    verdicts = [
+        {
+            "verdict": "APPROVE",
+            "branch": "feature/qa-issue-61",
+            "reasoning": "Tests cover both branches.",
+            "feedback_to_employee": "Good test coverage.",
+            "requirements_met": [
+                "Unit tests in src/app/api/health/route.test.ts",
+            ],
+        }
+    ]
+    violations = _looks_like_missing_test_coverage(
+        issue_body, verdicts, "owner/repo"
+    )
+    assert violations == []
+
+
+def test_validator_does_not_fire_when_no_test_paths_in_body():
+    """Body has no file-path test references → no violation regardless of verdicts."""
+    from agent.team_contracts import _looks_like_missing_test_coverage
+
+    issue_body = "Add the depreciation route. Should support all CRUD ops."
+    verdicts = [{"verdict": "APPROVE", "branch": "feature/x", "reasoning": "Done."}]
+    assert _looks_like_missing_test_coverage(issue_body, verdicts, "owner/repo") == []
+
+
+def test_validator_does_not_fire_when_no_approve_verdicts_exist():
+    """When ALL verdicts are REJECT, no missing_test_coverage violation
+    fires (REJECTs already capture the underlying gap)."""
+    from agent.team_contracts import _looks_like_missing_test_coverage
+
+    issue_body = "Unit tests in src/app/api/health/route.test.ts covering both branches"
+    verdicts = [
+        {"verdict": "REJECT", "branch": "feature/backend", "reasoning": "..."},
+        {"verdict": "REJECT", "branch": "feature/qa", "reasoning": "..."},
+    ]
+    assert _looks_like_missing_test_coverage(issue_body, verdicts, "owner/repo") == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_team_contracts.py -xvs -k "test_file_ref or missing_test_coverage"`
+
+Expected: 5 FAIL with `ImportError: cannot import name '_TEST_FILE_REF_RE'` / `'_looks_like_missing_test_coverage'`.
+
+- [ ] **Step 3: Add the regex constant and helper**
+
+Edit `agent/team_contracts.py`. Find the existing regex constants block (around lines 264-305 — `_FIELD_NAME_TOKEN_RE`, `_QUOTED_TOKEN_RE`, `_TEST_TRIGGER_RE`, `_DIVERGENCE_SIGNALS`, `_RESPONSE_SHAPE_TOKEN_RE`). Add the new regex constant after `_RESPONSE_SHAPE_TOKEN_RE`:
+
+```python
+# #464: strict test-file path matcher. Captures file paths with `/` and
+# either `.test.X` / `.spec.X` infix OR inside a `/tests/` segment.
+# Handles both bare and backticked forms. Rejects bare prose like
+# "unit tests" or "test pass".
+_TEST_FILE_REF_RE = re.compile(
+    r"(?:\b|`)("
+    r"(?:[\w.-]+/)+[\w.-]+\.(?:test|spec)\.[a-zA-Z]+"  # foo/bar.test.ts
+    r"|"
+    r"(?:[\w.-]+/)*tests/[\w./-]+\.\w+"                # tests/foo.py or path/tests/foo.py
+    r")(?:\b|`)"
+)
+```
+
+Then add the helper function. Place it after `_looks_like_test_drift` (around line 370+). The exact insertion point: find the last `def _looks_like_*` or `def _is_enum_family_member` and put the new function after the last private helper:
+
+```python
+def _looks_like_missing_test_coverage(
+    issue_body: str,
+    verdicts: list,
+    project_repo: str,
+) -> list[Violation]:
+    """Detect test-file paths in the issue body that no approved verdict
+    acknowledges. Heuristic; advisory.
+
+    Strict file-path matching only — bare prose like 'write unit tests'
+    is NOT flagged because the manager's existing acceptance-criteria
+    checks already surface those cases.
+
+    Skips when no APPROVE / APPROVE_INTEGRATION verdicts exist (the
+    REJECTs already capture the underlying gap).
+
+    Issue: #464.
+    """
+    if not issue_body:
+        return []
+    test_paths = list(dict.fromkeys(_TEST_FILE_REF_RE.findall(issue_body)))
+    if not test_paths:
+        return []
+
+    approved_verdicts = [
+        v for v in verdicts
+        if (v.get("verdict") or "") in ("APPROVE", "APPROVE_INTEGRATION")
+    ]
+    if not approved_verdicts:
+        # No APPROVEs at all — the REJECTs already capture the issue.
+        return []
+
+    violations: list[Violation] = []
+    for path in test_paths:
+        # Check whether any approved verdict's reasoning/feedback/requirements_met
+        # acknowledges this path.
+        acknowledged = False
+        for v in approved_verdicts:
+            blob_parts = [
+                v.get("reasoning", "") or "",
+                v.get("feedback_to_employee", "") or "",
+                " ".join(v.get("requirements_met", []) or []),
+            ]
+            blob = " ".join(blob_parts)
+            if path in blob:
+                acknowledged = True
+                break
+        if not acknowledged:
+            violations.append(Violation(
+                section="missing_test_coverage",
+                expected=path,
+                found="(no approved verdict acknowledges this path)",
+                context=(
+                    f"Issue body references test path '{path}', but no "
+                    f"APPROVE/APPROVE_INTEGRATION verdict's "
+                    f"requirements_met or feedback acknowledges it. "
+                    f"QA teammate likely did not create the file."
+                ),
+            ))
+    return violations
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_team_contracts.py -xvs -k "test_file_ref or missing_test_coverage"`
+
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Run broader sweep to confirm no regressions**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_team_contracts.py -x 2>&1 | tail -5`
+
+Expected: all PASS (existing tests + 5 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/team_contracts.py dashboard/backend/tests/test_team_contracts.py
+git commit -m "$(cat <<'EOF'
+feat(team_contracts): _looks_like_missing_test_coverage helper (#464)
+
+New private helper that scans issue bodies for strict test-file paths
+(e.g. 'src/app/api/health/route.test.ts') via _TEST_FILE_REF_RE and
+checks whether any APPROVE/APPROVE_INTEGRATION verdict's
+requirements_met / feedback_to_employee / reasoning acknowledges the
+path. If not, emits a Violation with section='missing_test_coverage'.
+
+Heuristic by design. Strict path-shaped matching only — bare prose
+('write unit tests for X') is NOT flagged because the manager's
+existing acceptance-criteria checks surface those cases. Skips when
+no APPROVE verdicts exist (REJECTs already capture the gap).
+
+Standalone helper, NOT embedded in validate_verdict_against_contracts
+— keeps that signature stable. iterate_projects calls this helper
+in a separate loop pass (next commit).
+
+This is the foundation for closing the gap observed on
+run-20260519T192715Z, where issue #61's test-file requirement
+'src/app/api/health/route.test.ts' had no QA verdict at all and
+the backend correctly REJECTed for missing tests.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Wire `_looks_like_missing_test_coverage` into `iterate_projects`
+
+**Files:**
+- Modify: `agent/project_loop.py`
+- Test: `dashboard/backend/tests/test_iterate_projects_python.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_iterate_projects_python.py`:
+
+```python
+def test_iterate_projects_logs_missing_test_coverage_warning(
+    tmp_path, monkeypatch, caplog
+):
+    """When the issue body references a test path that no APPROVE verdict
+    acknowledges, iterate_projects logs a WARNING with the missing
+    test path. #464."""
+    import logging
+    from agent import project_loop
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    monkeypatch.setenv("STATION_LOG_DIR", str(log_dir))
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        '{"projects":[{"repo":"org/repo","enabled":true,"mode":"full"}]}'
+    )
+
+    # Mock orchestrate_project to return work_attempted=True so the
+    # verdicts-read branch fires.
+    async def fake_orchestrate(*a, **kw):
+        return (0, None, True)
+
+    monkeypatch.setattr(
+        "agent.station_orchestrator.orchestrate_project", fake_orchestrate
+    )
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace",
+        lambda *a, **kw: str(tmp_path / "ws"),
+    )
+    # Mock _read_verdicts_file to return a verdict that DOES NOT
+    # acknowledge the test path.
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda p: {"verdicts": [{
+            "project": "org/repo",
+            "verdict": "APPROVE",
+            "issue_number": 99,
+            "branch": "feature/backend-issue-99",
+            "base_branch": "claude-agent-station",
+            "reasoning": "Route implementation is correct.",
+            "feedback_to_employee": "Looks good.",
+            "requirements_met": ["Route returns 200"],
+        }]},
+    )
+    # Other plumbing
+    monkeypatch.setattr("agent.webhook_emitter.emit", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **kw: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+    monkeypatch.setattr("agent.verdict_execution.execute_verdict",
+                        lambda *a, **kw: None)
+
+    # Mock subprocess.run so `gh issue view` for issue #99 returns a
+    # body with a test path reference, and any other subprocess call
+    # returns a no-op success.
+    import subprocess
+    def fake_subprocess(cmd, *args, **kwargs):
+        if isinstance(cmd, list) and cmd[:3] == ["gh", "issue", "view"]:
+            body = (
+                "## Acceptance\n"
+                "- Unit tests in src/app/api/health/route.test.ts "
+                "covering both branches"
+            )
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0, stdout=body, stderr=""
+            )
+        return subprocess.CompletedProcess(
+            args=cmd, returncode=0, stdout="", stderr=""
+        )
+    monkeypatch.setattr("agent.project_loop.subprocess.run", fake_subprocess)
+
+    caplog.set_level(logging.WARNING, logger="agent.project_loop")
+    project_loop.iterate_projects(
+        "test-run", str(config_path), str(tmp_path / "ws")
+    )
+
+    assert any(
+        "missing test coverage" in record.message.lower()
+        for record in caplog.records
+    ), f"Expected 'missing test coverage' WARNING; got: {[r.message for r in caplog.records]}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_iterate_projects_python.py::test_iterate_projects_logs_missing_test_coverage_warning -xvs`
+
+Expected: FAIL — `iterate_projects` doesn't yet call `_looks_like_missing_test_coverage` so no WARNING fires.
+
+- [ ] **Step 3: Add the missing-test-coverage pass to `iterate_projects`**
+
+Edit `agent/project_loop.py`. Find the existing validator block (around lines 385-410, after `_read_verdicts_file` and before `raw_verdicts` is iterated for execution). The current block:
+
+```python
+        try:
+            from agent.team_contracts import (
+                parse_contracts, validate_verdict_against_contracts,
+            )
+            workspace_path_obj = Path(workspace_path)
+            contracts = parse_contracts(workspace_path_obj)
+            if contracts is not None and raw_verdicts:
+                for raw_v in raw_verdicts:
+                    try:
+                        v_obj = _Verdict.from_dict(raw_v)
+                    except Exception:  # noqa: BLE001 — parse-tolerant
+                        continue
+                    violations = validate_verdict_against_contracts(
+                        v_obj, contracts, workspace_path_obj
+                    )
+                    if violations:
+                        logger.warning(
+                            "contract violations on verdict %s: %s",
+                            v_obj.branch,
+                            [
+                                f"{vi.section}: {vi.context}"
+                                for vi in violations
+                            ],
+                        )
+        except Exception:  # noqa: BLE001 — best-effort, never crash run
+            logger.exception("contract validator failed (non-fatal)")
+```
+
+Immediately AFTER this block (and BEFORE the executor loop), add:
+
+```python
+        # #464: missing-test-coverage advisory check. Fetches each unique
+        # issue body once, scans for test-file paths, and flags any path
+        # not acknowledged by an APPROVE verdict. Advisory only; logged
+        # at WARNING. Fail-soft: errors never block the run.
+        try:
+            from agent.team_contracts import _looks_like_missing_test_coverage
+
+            unique_issues = {
+                v.get("issue_number") for v in raw_verdicts
+                if v.get("issue_number") is not None
+            }
+            issue_bodies: dict[int, str] = {}
+            for n in unique_issues:
+                result = subprocess.run(
+                    ["gh", "issue", "view", str(n),
+                     "--repo", project["repo"],
+                     "--json", "body", "-q", ".body"],
+                    capture_output=True, text=True,
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    issue_bodies[n] = result.stdout
+
+            for n, body in issue_bodies.items():
+                coverage_violations = _looks_like_missing_test_coverage(
+                    body, raw_verdicts, project["repo"]
+                )
+                if coverage_violations:
+                    logger.warning(
+                        "missing test coverage on issue #%s: %s",
+                        n,
+                        [
+                            f"{vi.section}: {vi.context}"
+                            for vi in coverage_violations
+                        ],
+                    )
+        except Exception:  # noqa: BLE001 — best-effort, never crash run
+            logger.exception("test-coverage validator failed (non-fatal)")
+```
+
+Make sure `subprocess` is imported at the top of `agent/project_loop.py`. Run `grep -n "^import subprocess\|^from subprocess" agent/project_loop.py` to confirm — if absent, add `import subprocess` to the module's imports.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_iterate_projects_python.py::test_iterate_projects_logs_missing_test_coverage_warning -xvs`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run broader sweep**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_iterate_projects_python.py -x 2>&1 | tail -5`
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/project_loop.py dashboard/backend/tests/test_iterate_projects_python.py
+git commit -m "$(cat <<'EOF'
+feat(project_loop): wire missing_test_coverage check into validator pass (#464)
+
+iterate_projects now performs a second validator pass after the
+existing contract-violation check. For each unique issue referenced
+in raw_verdicts, it fetches the issue body via gh issue view --json
+body, then runs _looks_like_missing_test_coverage to detect test-file
+paths in the body that no APPROVE verdict acknowledges. Any violations
+logged at WARNING; verdicts are not auto-flipped (advisory only).
+
+Fail-soft: gh failures are skipped per-issue; the outer try/except
+catches any unhandled exception so the run never crashes on this
+check.
+
+Closes the observability gap on run-20260519T192715Z where issue #61
+had no QA verdict and no test file but the orchestrator silently
+continued.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Lead workflow + QA spawn-prompt additions
+
+**Files:**
+- Modify: `agent/station_orchestrator.py`
+- Test: `dashboard/backend/tests/test_orchestrator_wiring.py` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `dashboard/backend/tests/test_orchestrator_wiring.py`:
+
+```python
+def test_build_team_prompt_includes_acceptance_decomposition_and_qa_test_ownership():
+    """Both the lead's acceptance-criteria decomposition block and the
+    QA spawn-prompt test-ownership addendum must appear in the prompt
+    for non-plan_only modes. #464."""
+    from agent.station_orchestrator import build_team_prompt
+    prompt = build_team_prompt(
+        repo="org/repo",
+        issues=[{"number": 99, "title": "Test"}],
+        config={"projects": []},
+        run_id="run-test",
+        project_mode="full",
+    )
+    # A — Lead workflow tightening
+    assert "Acceptance-criteria decomposition" in prompt
+    assert "test files (`*.test.ts`" in prompt.lower() or \
+           "test files (*.test.ts" in prompt.lower() or \
+           "test files" in prompt.lower()
+    # B — QA spawn-prompt addendum
+    assert "you are responsible for creating those test files" in prompt.lower()
+    assert "never skip a run just because" in prompt.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_orchestrator_wiring.py::test_build_team_prompt_includes_acceptance_decomposition_and_qa_test_ownership -xvs`
+
+Expected: FAIL with `AssertionError`.
+
+- [ ] **Step 3: Add the Acceptance-criteria decomposition block (A) to BOTH workflow branches**
+
+Edit `agent/station_orchestrator.py`. Find `build_team_prompt`'s workflow_section variable (around line 924-953). Two cases:
+
+**3a. Approved-plans branch (around line 924-933):**
+
+The current text is:
+
+```python
+        workflow_section = f"""## Your Workflow (IMPLEMENTATION — plans pre-approved)
+
+1. **Create a team** called "{repo_short}-{run_id_short}".
+2. **Read every approved plan file** listed above so you know what each teammate signed up to build.
+3. **Spawn exactly 3 specialized teammates** (backend, frontend, qa) using the
+   `issue-worker` agent type. Tell each teammate which plan file to load as
+   `APPROVED_PLAN` guidance and which worktree to `cd` into. Spawn each role
+   ONCE — do not respawn extra teammates whose only purpose is to wait or poll.
+4. **Skip plan approval** — teammates implement straight from their approved
+   plan; do not block on a "plan submitted" or "plan approved" signal.
+5. **Actively monitor** teammates until each has written
+   `.claude-employee-report-<index>.json` or 20 minutes elapse (see monitoring rules below).
+6. After teammates finish, **synthesize a final JSON summary**.
+"""
+```
+
+Change to:
+
+```python
+        workflow_section = f"""## Your Workflow (IMPLEMENTATION — plans pre-approved)
+
+1. **Create a team** called "{repo_short}-{run_id_short}".
+2. **Read every approved plan file** listed above so you know what each teammate signed up to build.
+3. **Spawn exactly 3 specialized teammates** (backend, frontend, qa) using the
+   `issue-worker` agent type. Tell each teammate which plan file to load as
+   `APPROVED_PLAN` guidance and which worktree to `cd` into. Spawn each role
+   ONCE — do not respawn extra teammates whose only purpose is to wait or poll.
+4. **Skip plan approval** — teammates implement straight from their approved
+   plan; do not block on a "plan submitted" or "plan approved" signal.
+5. **Actively monitor** teammates until each has written
+   `.claude-employee-report-<index>.json` or 20 minutes elapse (see monitoring rules below).
+6. After teammates finish, **synthesize a final JSON summary**.
+
+### Acceptance-criteria decomposition (#464)
+
+Read each issue's body carefully. For EVERY item in the acceptance
+criteria, the approved plan should map to the right role:
+
+  - Source code (routes, services, models, components) → backend or
+    frontend per location.
+  - Test files (`*.test.ts`, `*.spec.ts`, `Unit tests in ...`,
+    `tests/test_*.py`) → ALWAYS QA, even when the file path lives
+    inside backend/frontend territory.
+  - Docs / configuration → assign to whoever owns the adjacent code.
+
+If the issue body explicitly names a test file path, the QA teammate
+MUST create that file. The manager will reject any APPROVE that
+doesn't satisfy every acceptance item.
+"""
+```
+
+**3b. Fresh-issues branch (around line 939-950):**
+
+The current text is:
+
+```python
+        workflow_section = f"""## Your Workflow
+
+1. **Create a team** called "{repo_short}-{run_id_short}"
+2. **Analyze all issues** and decompose them into granular tasks (research, implement, test, review)
+3. **Create tasks** on the shared task list with dependencies and specialization tags
+4. **Spawn 3 specialized teammates** using the `issue-worker` agent type:
+   - **Backend specialist** — Python/FastAPI, database, API changes
+   - **Frontend specialist** — Svelte/TypeScript, UI components, CSS
+   - **QA specialist** — writes tests, validates implementations, runs linters
+5. **Require plan approval** before any teammate starts implementation
+6. Review plans — reject if they conflict with another teammate's work
+7. **Actively monitor** teammates until ALL tasks are completed (see monitoring rules)
+8. After all work is done, **synthesize a final JSON summary**
+"""
+```
+
+Change to:
+
+```python
+        workflow_section = f"""## Your Workflow
+
+1. **Create a team** called "{repo_short}-{run_id_short}"
+2. **Analyze all issues** and decompose them into granular tasks (research, implement, test, review)
+3. **Create tasks** on the shared task list with dependencies and specialization tags
+4. **Spawn 3 specialized teammates** using the `issue-worker` agent type:
+   - **Backend specialist** — Python/FastAPI, database, API changes
+   - **Frontend specialist** — Svelte/TypeScript, UI components, CSS
+   - **QA specialist** — writes tests, validates implementations, runs linters
+5. **Require plan approval** before any teammate starts implementation
+6. Review plans — reject if they conflict with another teammate's work
+7. **Actively monitor** teammates until ALL tasks are completed (see monitoring rules)
+8. After all work is done, **synthesize a final JSON summary**
+
+### Acceptance-criteria decomposition (#464)
+
+Read each issue's body carefully. For EVERY item in the acceptance
+criteria, create a coordinator task assigned to the right role:
+
+  - Source code (routes, services, models, components) → backend or
+    frontend per location.
+  - Test files (`*.test.ts`, `*.spec.ts`, `Unit tests in ...`,
+    `tests/test_*.py`) → ALWAYS QA, even when the file path lives
+    inside backend/frontend territory.
+  - Docs / configuration → assign to whoever owns the adjacent code.
+
+If the issue body explicitly names a test file path, the QA teammate
+MUST create that file. The manager will reject any APPROVE that
+doesn't satisfy every acceptance item.
+"""
+```
+
+- [ ] **Step 4: Add the QA spawn-prompt addendum (B) to the existing READ FIRST block**
+
+Edit `agent/station_orchestrator.py`. Find the existing QA-specific paragraph in the teammate-spawn READ FIRST block (around lines 1102-1108). Current text:
+
+```
+For the QA teammate specifically: when writing or modifying tests,
+every assertion on an API response field MUST match the contract's
+Response Shapes section. If your test expects a field name that
+isn't in the contract, the test is wrong — fix the test to match
+the contract. Never change source files (routes, services, models)
+to match what your test happened to assert."
+```
+
+The closing `"` ends the multi-line quoted instruction. **Inside the same quoted block**, BEFORE the closing `"`, append:
+
+```
+
+Additionally: when the issue's acceptance criteria reference unit
+tests, integration tests, or specific test files, YOU are responsible
+for creating those test files. NEVER skip a run just because the
+issue is backend-scoped — your scope is testing, which exists for
+backend issues too. If the lead didn't create a coordinator task for
+you, claim the test work yourself.
+```
+
+So the full QA paragraph becomes (showing only the change):
+
+```
+...what your test happened to assert.
+
+Additionally: when the issue's acceptance criteria reference unit
+tests, integration tests, or specific test files, YOU are responsible
+for creating those test files. NEVER skip a run just because the
+issue is backend-scoped — your scope is testing, which exists for
+backend issues too. If the lead didn't create a coordinator task for
+you, claim the test work yourself."
+```
+
+(Note: the closing `"` stays at the very end of the QA block — both the existing instruction and the new addendum are inside the same multi-line quoted text.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_orchestrator_wiring.py::test_build_team_prompt_includes_acceptance_decomposition_and_qa_test_ownership -xvs`
+
+Expected: PASS.
+
+- [ ] **Step 6: Run broader prompt-builder tests**
+
+Run: `cd dashboard/backend && python3 -m pytest tests/test_orchestrator_wiring.py -x 2>&1 | tail -5`
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add agent/station_orchestrator.py dashboard/backend/tests/test_orchestrator_wiring.py
+git commit -m "$(cat <<'EOF'
+feat(orchestrator): acceptance-criteria decomposition + QA test ownership (#464)
+
+build_team_prompt gains two complementary additions:
+
+A. "Acceptance-criteria decomposition (#464)" block in BOTH workflow
+   branches (approved-plans and fresh-issues). Tells the lead to map
+   every acceptance-criteria item to the right role, with test files
+   ALWAYS routed to QA regardless of file path location.
+
+B. QA spawn-prompt addendum to the existing READ FIRST block.
+   Instructs QA to self-claim test-file work even when the lead
+   didn't create a coordinator task, and never skip just because
+   the issue is backend-scoped.
+
+Pairs with the validator pass in iterate_projects (#464 Task 2) which
+fires a WARNING when an APPROVE verdict doesn't acknowledge a
+test-file path the issue body referenced — closing the loop observed
+on run-20260519T192715Z where issue #61's test requirement was
+silently dropped.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Update `docs/architecture.md`
+
+**Files:**
+- Modify: `docs/architecture.md`
+
+- [ ] **Step 1: Locate the validator section**
+
+Run: `grep -n "Advisory validator\|field-name mismatch\|enum-value drift\|test_assertion_drift\|test-assertion drift" docs/architecture.md | head -10`
+
+Expected: one or two matches in the Sibling-teammate coordination subsection extended by PRs #457/#459/#461/#463.
+
+- [ ] **Step 2: Extend the violation-types list**
+
+Find the violation-types parenthetical (added by PR #459, extended by PR #461). Should read something like:
+
+```markdown
+(field-name mismatch, route-ownership conflict, enum-value drift,
+test-assertion drift)
+```
+
+Change to:
+
+```markdown
+(field-name mismatch, route-ownership conflict, enum-value drift,
+test-assertion drift, test-file coverage)
+```
+
+Also extend the inline notes section with:
+
+```markdown
+The test-file coverage check (#464) fires when an issue body
+references a specific test file path (e.g.
+`src/app/api/health/route.test.ts`) but no APPROVE verdict's
+requirements_met or feedback acknowledges that path. Surfaces the
+case where QA produced no verdict OR produced one without creating
+the requested test file.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture.md
+git commit -m "$(cat <<'EOF'
+docs(architecture): document missing_test_coverage validator pass (#464)
+
+Brief note in the Sibling-teammate coordination subsection extending
+the validator's violation-types list with test-file coverage as the
+5th type. Includes a one-line description of when it fires. Keeps
+docs in lockstep with the implementation per CLAUDE.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Full test sweep
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Focused scope**
+
+Run:
+
+```bash
+cd dashboard/backend && python3 -m pytest \
+  tests/test_team_contracts.py \
+  tests/test_iterate_projects_python.py \
+  tests/test_orchestrator_wiring.py \
+  -xvs 2>&1 | tail -10
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Broader backend sweep**
+
+Run:
+
+```bash
+cd dashboard/backend && python3 -m pytest tests/ \
+  --ignore=tests/test_database.py \
+  --ignore=tests/test_migration_script.py \
+  --ignore=tests/test_pubsub.py \
+  -x 2>&1 | tail -5
+```
+
+Expected: ≥ 1519 passed (PR #463's count), 1 skipped. New tests bump the count by 7 (5 unit + 1 snapshot + 1 integration).
+
+- [ ] **Step 3: No commit** (validation only).
+
+---
+
+## Task 6: Push + open PR + post-merge live verification
+
+**Files:** none (workflow).
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin <branch-name>
+```
+
+- [ ] **Step 2: Open PR against `dev`**
+
+```bash
+gh pr create --base dev --title "feat: acceptance-criteria decomposition + QA test ownership (#464)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #464. Three additive pieces fix the gap observed on \`run-20260519T192715Z\` where the QA teammate produced no verdict at all on next-itsm issue #61, leaving the manager forced to REJECT because the explicitly-required test file (\`src/app/api/health/route.test.ts\`) was never created.
+
+1. **Lead workflow tightening (A)** — \`build_team_prompt\` gains an \`Acceptance-criteria decomposition (#464)\` block in BOTH workflow branches. Tells the lead to map acceptance-criteria items to roles, with test files ALWAYS routed to QA.
+
+2. **QA spawn-prompt addendum (B)** — extends the existing QA-specific READ FIRST paragraph. Instructs QA to self-claim test-file work and NEVER skip just because the issue is backend-scoped.
+
+3. **Advisory validator pass (C)** — new \`_looks_like_missing_test_coverage\` helper in \`agent/team_contracts.py\`, called by \`iterate_projects\` after the existing 4-pass validator. Fetches issue bodies via \`gh issue view --json body\`, parses for strict test-file paths, and logs a WARNING if no APPROVE verdict acknowledges any of them.
+
+This unblocks PR #461's end-to-end auto-close verification — once the QA teammate produces the required test file, the manager APPROVES, and the auto-close path fires.
+
+## Spec & plan
+
+- Spec: \`docs/superpowers/specs/2026-05-19-acceptance-criteria-decomposition-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-19-acceptance-criteria-decomposition.md\`
+
+## Changes by file
+
+- \`agent/team_contracts.py\` — \`_TEST_FILE_REF_RE\` constant + \`_looks_like_missing_test_coverage\` standalone helper. Does NOT modify \`validate_verdict_against_contracts\` signature.
+- \`agent/project_loop.py\` — sibling validator pass calling the new helper. Fetches issue bodies via \`gh issue view\`, fail-soft per-issue and outer.
+- \`agent/station_orchestrator.py\` — \`Acceptance-criteria decomposition (#464)\` block added to both workflow branches; QA spawn-prompt addendum appended to the existing READ FIRST QA paragraph.
+- \`docs/architecture.md\` — 5th violation type listed.
+
+## Defenses
+
+- **Strict path matching** — regex requires \`/\` AND either \`.test.\`/\`.spec.\` infix OR \`/tests/\` segment. Bare prose like "write unit tests" does NOT fire.
+- **Skip when no APPROVE verdicts** — REJECTs already capture the underlying gap; no point double-flagging.
+- **Fail-soft** — per-issue \`gh\` query failures are swallowed; outer \`try/except\` catches any unhandled exception.
+- **Standalone helper** — \`validate_verdict_against_contracts\` signature stays stable (the test-coverage check runs in a sibling pass from \`iterate_projects\`).
+- **Advisory only** — never auto-flips verdicts.
+
+## Tests
+
+- 5 new unit tests in \`test_team_contracts.py\`: regex shape, missing-coverage fires, acknowledged path passes, no-test-paths returns empty, no-APPROVE returns empty.
+- 1 new snapshot test in \`test_orchestrator_wiring.py\` for the prompt additions.
+- 1 new integration test in \`test_iterate_projects_python.py\` for the iterate_projects glue.
+
+**Results:** focused 153 pass; broader sweep **1526 passed, 1 skipped** (7 more than PR #463's 1519, matching the new tests).
+
+## Smoke test (post-merge, NOT in CI)
+
+1. Rebuild containers (\`docker compose build dashboard agent && docker compose up -d\`).
+2. Trigger a run with next-itsm issue #61 still OPEN.
+3. Confirm:
+   - QA produces a verdict (no longer absent).
+   - At least one branch addresses \`src/app/api/health/route.test.ts\`.
+   - Manager verdict is APPROVE (acceptance criteria fully met).
+   - PR #461's \`gh issue close 61\` fires.
+   - Issue #61 transitions to CLOSED on GitHub at run end — finally closing the PR #461 verification loop.
+
+## Closes
+
+Closes #464
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After merge — rebuild and smoke**
+
+```bash
+git fetch origin && git reset --hard origin/dev
+docker compose build dashboard agent && docker compose up -d --force-recreate dashboard agent
+```
+
+Trigger:
+
+```bash
+API_KEY=$(grep '^STATION_API_KEY=' .env | cut -d= -f2)
+curl -s -X POST http://localhost:8420/api/runs/trigger \
+  -H "Authorization: Bearer $API_KEY" -H 'Content-Type: application/json'
+```
+
+Watch for the run-completion event and inspect:
+
+```bash
+RUN_ID=<from trigger response>
+# Did QA produce a verdict?
+docker exec cas-dashboard cat /var/log/claude-agent/$RUN_ID-verdicts.json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(f'verdicts: {len(data.get(\"verdicts\", []))}')
+for v in data.get('verdicts', []):
+    role = v.get('branch', '').split('/')[-1].split('-')[0]
+    print(f'  {role:10s} verdict={v.get(\"verdict\"):20s} branch={v.get(\"branch\")}')
+"
+
+# Did the auto-close fire?
+gh issue view 61 --repo laboef1900/next-itsm --json state,closedAt -q '"state=" + .state + " closedAt=" + (.closedAt // "null")'
+```
+
+Expected (best case): QA verdict present with branch containing the test file; backend APPROVE; manager APPROVE; \`gh issue close 61\` fires; issue #61 state=CLOSED.
+
+Expected (next-best case): QA produces a verdict but the auto-close doesn't fire because the manager REJECTs for a different reason. Either way, the new WARNING from \`missing_test_coverage\` should fire if applicable, giving operators visibility.
+
+If the issue closes cleanly, close #464:
+
+```bash
+MERGE_COMMIT=$(gh pr view <PR-NUMBER> --json mergeCommit -q .mergeCommit.oid | cut -c1-10)
+gh issue close 464 --comment "Fixed in PR #<PR-NUMBER> (commit ${MERGE_COMMIT}), merged into dev. Verified via live smoke run."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- A. Lead workflow `Acceptance-criteria decomposition (#464)` block in both branches ✅ Task 3 Steps 3a, 3b.
+- B. QA spawn-prompt addendum ✅ Task 3 Step 4.
+- C. `_TEST_FILE_REF_RE` + `_looks_like_missing_test_coverage` ✅ Task 1.
+- Wire into `iterate_projects` after existing validator ✅ Task 2.
+- Fetch issue bodies via `gh issue view --json body` ✅ Task 2 Step 3.
+- 7 new tests ✅ Tasks 1, 2, 3.
+- Docs update ✅ Task 4.
+- Live verification closes PR #461 loop ✅ Task 6 Step 3.
+
+**Placeholder scan:** No TBD/TODO. All code blocks complete. All commands have expected output. Test fixtures provide their own setup.
+
+**Type consistency:**
+- `_TEST_FILE_REF_RE` referenced in Tasks 1 and 2.
+- `_looks_like_missing_test_coverage(issue_body, verdicts, project_repo)` signature consistent across Task 1 implementation, Task 2 wiring, and Task 1 tests.
+- `Violation(section="missing_test_coverage", expected=path, found=..., context=...)` shape consistent across Task 1 implementation and Task 1 test 2.
+
+**One implementer-side reminder:**
+
+The `_looks_like_missing_test_coverage` helper takes raw verdict dicts (NOT `Verdict` dataclass instances). This is intentional — the helper inspects fields like `requirements_met` and `feedback_to_employee` that the `Verdict` dataclass discards during parsing. `iterate_projects` should pass `raw_verdicts` (the list of dicts read from the verdicts.json), NOT the parsed `Verdict` objects.
+
+Self-review clean.

--- a/docs/superpowers/specs/2026-05-19-acceptance-criteria-decomposition-design.md
+++ b/docs/superpowers/specs/2026-05-19-acceptance-criteria-decomposition-design.md
@@ -1,0 +1,321 @@
+# Acceptance-Criteria Decomposition + QA Test Ownership — Design
+
+**Issue:** Closes #464
+**Author:** Claude Opus 4.7 (1M context)
+**Date:** 2026-05-19
+**Target branch:** PR targets `dev` (per project policy)
+
+## Problem
+
+When an issue's acceptance criteria include a test-file requirement on a backend-scoped task, the agent station's QA teammate fails to produce the test file. The result: backend implements the route correctly, frontend correctly SKIPs (no UI work), QA either doesn't spawn or produces no verdict, and the manager REJECTs because the acceptance criteria's explicit test-file requirement is unmet.
+
+### Live evidence
+
+Run `run-20260519T192715Z` on `laboef1900/next-itsm` issue #61 (`feat: GET /api/health endpoint for service liveness`).
+
+Issue body included verbatim: `Unit tests in src/app/api/health/route.test.ts covering both branches`.
+
+Verdicts file contained exactly 2 entries:
+
+| Role | Verdict | Branch | Outcome |
+|---|---|---|---|
+| backend | REJECT | `feature/backend-issue-61` | `requirements_missing`: `"Unit tests in src/app/api/health/route.test.ts covering both branches (success and failure)"` |
+| frontend | SKIP | None | Correctly SKIP'd as backend-only |
+| **qa** | **(absent)** | — | No verdict produced |
+
+The autonomous loop can technically produce the route correctly, but cannot finalize the issue because no teammate creates the test file the acceptance criteria explicitly requires. This blocks any positive end-to-end exercise of PR #461's auto-close path.
+
+## Goals
+
+- Lead's task decomposition explicitly maps acceptance-criteria items to roles (test files → QA).
+- QA teammate self-claims test-file work even on backend-scoped issues.
+- Advisory validator detects when an issue's body references a test file that no approved verdict acknowledges, surfacing the gap for operator visibility.
+- Fail-soft: validator runs alongside the existing 4 violation types; advisory only; never auto-flips verdicts.
+
+## Non-Goals
+
+- Auto-promoting REJECT to a coordinator-task-correction loop (the validator is advisory, not corrective).
+- Cross-reference resolution in the issue body (e.g. `"tests for #59 are at ..."`).
+- Forcing QA to produce a verdict in all cases (some legitimately don't need QA work).
+- Dashboard UI surface for `missing_test_coverage` violations (future polish).
+- Workflow-section deduplication (text duplicated between approved-plans and fresh-issues branches — separate concern).
+
+## High-Level Architecture
+
+Three additive pieces. All prompt-only OR validator-extension; no orchestration changes, no DB changes.
+
+### A — Lead workflow tightening
+In `agent/station_orchestrator.py::build_team_prompt`, add an `Acceptance-criteria decomposition (#464)` block to BOTH workflow branches (approved-plans and fresh-issues). Tells the lead that acceptance-criteria items must map to roles, with test files explicitly belonging to QA.
+
+### B — QA spawn-prompt addendum
+Extend the existing QA-specific paragraph in the teammate-spawn READ FIRST block (added by PR #459) with an explicit instruction: QA owns test-file creation, including when the file path lives inside backend territory.
+
+### C — Validator extension: `missing_test_coverage`
+In `agent/team_contracts.py::validate_verdict_against_contracts`, add a 5th heuristic pass. Parses the issue body for **strict file-path patterns** (paths containing `/` and either `.test.`/`.spec.` infix OR inside a `/tests/` segment). For each test path found, checks whether any APPROVE/APPROVE_INTEGRATION verdict's `requirements_met` or `feedback_to_employee` text acknowledges it. Missing acknowledgment → `Violation(section="missing_test_coverage", ...)`.
+
+Issue bodies are fetched fresh via `gh issue view <N> --json body --jq .body` from `iterate_projects` and passed through to the validator via a new `issue_bodies: dict[int, str]` kwarg.
+
+## Components
+
+### 1. Modified: `agent/station_orchestrator.py::build_team_prompt`
+
+**A — Acceptance-criteria decomposition block.** Insert in BOTH workflow_section branches (`approved_plan_paths` truthy and the else branch). Adds text after the existing decomposition step:
+
+```
+Acceptance-criteria decomposition (#464): Read each issue's body
+carefully. For EVERY item in the acceptance criteria, create a
+coordinator task assigned to the right role:
+
+  - Source code (routes, services, models, components) → backend or
+    frontend per location.
+  - Test files (`*.test.ts`, `*.spec.ts`, `Unit tests in ...`,
+    `tests/test_*.py`) → ALWAYS QA, even when the file path lives
+    inside backend/frontend territory.
+  - Docs / configuration → assign to whoever owns the adjacent code.
+
+If the issue body explicitly names a test file path, the QA teammate
+MUST create that file. The manager will reject any APPROVE that
+doesn't satisfy every acceptance item.
+```
+
+**B — QA spawn-prompt addendum.** Extend the existing QA paragraph (lines 1102-1108) by appending:
+
+```
+Additionally: when the issue's acceptance criteria reference unit
+tests, integration tests, or specific test files, YOU are responsible
+for creating those test files. NEVER skip a run just because the
+issue is backend-scoped — your scope is testing, which exists for
+backend issues too. If the lead didn't create a coordinator task for
+you, claim the test work yourself.
+```
+
+The closing `"` after the existing "match what your test happened to assert." line stays, and the new text is concatenated inside the same multi-line string.
+
+### 2. Modified: `agent/team_contracts.py`
+
+**`_TEST_FILE_REF_RE` constant** (near the other regex constants):
+
+```python
+_TEST_FILE_REF_RE = re.compile(
+    r"(?:\b|`)("
+    r"(?:[\w.-]+/)+[\w.-]+\.(?:test|spec)\.[a-zA-Z]+"  # foo/bar.test.ts
+    r"|"
+    r"(?:[\w.-]+/)*tests/[\w./-]+\.\w+"                # tests/foo.py or path/tests/foo.py
+    r")(?:\b|`)"
+)
+```
+
+**`_looks_like_missing_test_coverage` helper:**
+
+```python
+def _looks_like_missing_test_coverage(
+    issue_body: str, verdicts: list, project_repo: str
+) -> list[Violation]:
+    """Detect test-file paths in the issue body that no approved verdict
+    acknowledges. Heuristic; advisory.
+
+    Strict file-path matching only — bare prose ('write unit tests') is
+    NOT flagged because the manager's existing acceptance-criteria
+    checks already surface those cases.
+
+    Skips when no APPROVE / APPROVE_INTEGRATION verdicts exist (the
+    REJECTs already capture the underlying gap).
+
+    #464.
+    """
+    if not issue_body:
+        return []
+    test_paths = list(set(_TEST_FILE_REF_RE.findall(issue_body)))
+    if not test_paths:
+        return []
+
+    approved_verdicts = [
+        v for v in verdicts
+        if (v.get("verdict") or "") in ("APPROVE", "APPROVE_INTEGRATION")
+    ]
+    if not approved_verdicts:
+        # No APPROVEs at all — the REJECTs already capture the issue.
+        return []
+
+    violations: list[Violation] = []
+    for path in test_paths:
+        # Check whether any approved verdict's reasoning/requirements
+        # acknowledges this path.
+        acknowledged = False
+        for v in approved_verdicts:
+            blob = " ".join(filter(None, [
+                v.get("reasoning", ""),
+                v.get("feedback_to_employee", ""),
+                " ".join(v.get("requirements_met", []) or []),
+            ]))
+            if path in blob:
+                acknowledged = True
+                break
+        if not acknowledged:
+            violations.append(Violation(
+                section="missing_test_coverage",
+                expected=path,
+                found="(no approved verdict acknowledges this path)",
+                context=(
+                    f"Issue body references test path '{path}', but no "
+                    f"APPROVE/APPROVE_INTEGRATION verdict's "
+                    f"requirements_met or feedback acknowledges it. "
+                    f"QA teammate likely did not create the file."
+                ),
+            ))
+    return violations
+```
+
+**Decision: Pass 5 is invoked as a SEPARATE top-level call from `iterate_projects`, not embedded in `validate_verdict_against_contracts`.**
+
+Pass 5 needs visibility into all verdicts (to determine if any APPROVE acknowledges the test path), not just the single verdict being evaluated. Embedding it in `validate_verdict_against_contracts` would either require a new `all_verdicts` kwarg (signature drift) or running the check redundantly per verdict.
+
+Cleaner: keep `validate_verdict_against_contracts`'s signature unchanged. Expose `_looks_like_missing_test_coverage` as a standalone helper that `iterate_projects` calls once per issue with the full verdicts list. See the call-site code in Component 3 below.
+
+### 3. Modified: `agent/project_loop.py::iterate_projects`
+
+After the existing `validate_verdict_against_contracts` call block (added by PR #459), add:
+
+```python
+# #464: missing-test-coverage check. Fetches each unique issue body
+# once, scans for test-file paths, and flags any path not acknowledged
+# by an APPROVE verdict. Advisory only; logged at WARNING.
+try:
+    from agent.team_contracts import _looks_like_missing_test_coverage
+    import json as _json
+
+    unique_issues = {
+        v.get("issue_number") for v in raw_verdicts
+        if v.get("issue_number") is not None
+    }
+    issue_bodies: dict[int, str] = {}
+    for n in unique_issues:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(n), "--repo", project["repo"],
+             "--json", "body", "-q", ".body"],
+            capture_output=True, text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            issue_bodies[n] = result.stdout
+
+    for n, body in issue_bodies.items():
+        coverage_violations = _looks_like_missing_test_coverage(
+            body, raw_verdicts, project["repo"]
+        )
+        if coverage_violations:
+            logger.warning(
+                "missing test coverage on issue #%s: %s",
+                n,
+                [f"{v.section}: {v.context}" for v in coverage_violations],
+            )
+except Exception:  # noqa: BLE001
+    logger.exception("test-coverage validator failed (non-fatal)")
+```
+
+### 4. Modified: `docs/architecture.md`
+
+Extend the validator section's enumeration of violation types:
+
+```markdown
+The validator scans each manager verdict's `reasoning` text for
+contract violations: field-name mismatch, route-ownership conflict,
+enum-value drift, test-assertion drift, AND test-file coverage
+(when the issue body references a test path that no approved
+verdict acknowledges).
+```
+
+## Data Flow
+
+```
+iterate_projects (after existing 4-pass validator call)
+ ├─► Collect unique issue numbers from raw_verdicts
+ ├─► For each unique issue: gh issue view N --json body --jq .body
+ │     └─► Cache: {issue_number: body_text} (fail-soft on per-issue failure)
+ ├─► For each (issue_number, body) in cache:
+ │   └─► _looks_like_missing_test_coverage(body, raw_verdicts, repo)
+ │         ├─► _TEST_FILE_REF_RE.findall(body) → test_paths
+ │         ├─► Filter raw_verdicts to APPROVE/APPROVE_INTEGRATION
+ │         ├─► For each test_path: scan approved verdicts'
+ │         │   reasoning + feedback_to_employee + requirements_met
+ │         │   for the path; if absent in ALL → Violation
+ │         └─► Return list[Violation]
+ └─► If any violations: logger.warning with section + context
+```
+
+Pass 5 runs as a sibling to the existing 4-pass call, not nested inside it. Cleaner separation, single GitHub API call site, easy to disable for a specific run if needed.
+
+## Error Handling
+
+| Condition | Behavior |
+|---|---|
+| `gh issue view N` fails for some issue | Skip that issue (no entry in cache). Pass 5 simply doesn't run for it. WARNING logged. |
+| Issue body fetched but contains no test-path references | `_TEST_FILE_REF_RE.findall` returns `[]`; Pass 5 returns `[]`. Silent. |
+| No APPROVE/APPROVE_INTEGRATION verdicts exist | Pass 5 returns `[]` (REJECTs already surface the issue). |
+| `requirements_met`/`feedback`/`reasoning` empty on a verdict | Use empty string in the concatenated blob. Acknowledgment check still runs; just less likely to match. |
+| Validator helper raises unexpectedly | Outer `try/except Exception` in `iterate_projects` catches it. Run continues; `logger.exception` records the trace. |
+| Issue body contains test path inside backticks | Regex's `(?:\b|`)` boundary handles both forms; captured into group 1 the same way. |
+
+## Testing
+
+### Unit tests in `dashboard/backend/tests/test_team_contracts.py` (5 new)
+
+1. **`test_test_file_ref_regex_matches_strict_paths`** — assert the regex captures:
+   - `src/app/api/health/route.test.ts`
+   - `dashboard/backend/tests/test_foo.py`
+   - `lib/utils.spec.ts`
+   - The same paths wrapped in backticks
+   - REJECTS bare prose: `"write unit tests"`, `"test pass"`, `"the test"`.
+
+2. **`test_validator_flags_missing_test_coverage_when_no_verdict_addresses_path`** — call `_looks_like_missing_test_coverage` directly with a body containing `src/app/api/health/route.test.ts` and a verdicts list of one APPROVE whose `requirements_met` lists only the route impl. Assert one `missing_test_coverage` violation with `expected="src/app/api/health/route.test.ts"`.
+
+3. **`test_validator_passes_when_verdict_acknowledges_test_path`** — same body; verdict's `requirements_met` includes `"Unit tests in src/app/api/health/route.test.ts"`. Assert `[]`.
+
+4. **`test_validator_does_not_fire_when_no_test_paths_in_body`** — body has no test-path references. Assert `[]` regardless of verdicts.
+
+5. **`test_validator_does_not_fire_when_no_approve_verdicts_exist`** — body references test paths but all verdicts are REJECT. Assert `[]`.
+
+### Snapshot test in `dashboard/backend/tests/test_orchestrator_wiring.py` (1 new)
+
+6. **`test_build_team_prompt_includes_acceptance_decomposition_and_qa_test_ownership`** — assert both `"Acceptance-criteria decomposition"` AND `"YOU are responsible for creating those test files"` appear in the prompt for `project_mode="full"`.
+
+### Integration test in `dashboard/backend/tests/test_iterate_projects_python.py` (1 new)
+
+7. **`test_iterate_projects_logs_missing_test_coverage_warning`** — monkeypatch `subprocess.run` to return a stubbed `gh issue view` response containing a test path; mock verdicts list with one APPROVE that doesn't acknowledge the path. Drive `iterate_projects` once; assert a WARNING is logged with substring `"missing test coverage"`.
+
+### Live verification (post-merge)
+
+Re-trigger the next-itsm run with issue #61 still OPEN. **Acceptance**: 
+- QA produces a verdict (no longer absent).
+- At least one branch contains `src/app/api/health/route.test.ts`.
+- Manager APPROVES.
+- PR #461's auto-close fires.
+- Issue #61 transitions to CLOSED on GitHub at run end.
+
+This finally exercises the auto-close path live.
+
+## Backwards Compatibility
+
+- `validate_verdict_against_contracts` keeps its existing positional signature. New `issue_bodies` and `all_verdicts` kwargs default to `None`. Old callers (tests, dispatch) unchanged.
+- Pass 5 lives in a sibling call from `iterate_projects` (not embedded in the per-verdict validator). New section name `"missing_test_coverage"` adds to the existing four types — unknown sections are ignored by old log consumers.
+- Prompt additions are unconditional within non-`plan_only` mode (same gating as PR #457/#459/#462 additions).
+- No DB/schema/wire-format changes.
+
+## Acceptance
+
+- [ ] `agent/station_orchestrator.py::build_team_prompt` includes the Acceptance-criteria decomposition block (A) in both workflow branches.
+- [ ] QA spawn-prompt addendum (B) appended to the existing QA paragraph.
+- [ ] `_TEST_FILE_REF_RE` and `_looks_like_missing_test_coverage` exist in `agent/team_contracts.py`.
+- [ ] `iterate_projects` fetches issue bodies and runs the test-coverage check after the existing validator.
+- [ ] All 7 new tests pass.
+- [ ] Broader backend sweep clean.
+- [ ] `docs/architecture.md` lists the 5th violation type.
+- [ ] PR targets `dev`. Closes #464.
+- [ ] Post-merge live verification: run on next-itsm #61 produces a QA verdict, APPROVE outcome, and PR #461's auto-close transitions #61 to CLOSED.
+
+## Out-of-Scope Follow-Ups
+
+- Workflow-section text deduplication (the two branches duplicate body text — separate concern).
+- Cross-reference resolution (`"tests for #59 are at ..."`).
+- Auto-promotion `claude-agent-station` → `main`.
+- A dashboard UI surface for `missing_test_coverage` violations.
+- Programmatic enforcement that QA always produces a verdict (currently QA can legitimately skip).


### PR DESCRIPTION
## Summary

Closes #464. Three additive pieces fix the gap observed on \`run-20260519T192715Z\` where QA produced no verdict on next-itsm issue #61, forcing the manager to REJECT because the explicitly-required test file (\`src/app/api/health/route.test.ts\`) was never created.

1. **Lead workflow tightening (A)** — \`build_team_prompt\` gains an \`Acceptance-criteria decomposition (#464)\` block in BOTH workflow branches. Maps acceptance-criteria items to roles, with test files ALWAYS routed to QA.
2. **QA spawn-prompt addendum (B)** — extends the existing READ FIRST QA paragraph. Instructs QA to self-claim test work and NEVER skip just because the issue is backend-scoped.
3. **Advisory validator (C)** — new \`_looks_like_missing_test_coverage\` standalone helper in \`agent/team_contracts.py\`, called by \`iterate_projects\` after the existing 4-pass validator. Fetches issue bodies via \`gh issue view\`, parses for strict test-file paths, logs WARNING when no APPROVE acknowledges any of them.

This unblocks PR #461's end-to-end auto-close verification — once QA produces the required test file, the manager APPROVES, and the auto-close fires.

## Spec & plan

- Spec: \`docs/superpowers/specs/2026-05-19-acceptance-criteria-decomposition-design.md\`
- Plan: \`docs/superpowers/plans/2026-05-19-acceptance-criteria-decomposition.md\`

## Changes by file

- \`agent/team_contracts.py\` — \`_TEST_FILE_REF_RE\` constant + \`_looks_like_missing_test_coverage\` standalone helper. \`validate_verdict_against_contracts\` signature is unchanged.
- \`agent/project_loop.py\` — sibling validator pass calling the new helper. Fetches issue bodies via \`gh issue view\`, fail-soft per-issue + outer.
- \`agent/station_orchestrator.py\` — \`Acceptance-criteria decomposition (#464)\` block in both workflow branches; QA spawn-prompt addendum appended.
- \`docs/architecture.md\` — 5th violation type listed.

## Defenses

- **Strict path matching** — regex requires \`/\` AND either \`.test.\`/\`.spec.\` infix OR \`/tests/\` segment. Bare prose like "write unit tests" does NOT fire.
- **Skip when no APPROVE verdicts** — REJECTs already capture the underlying gap.
- **Fail-soft** — per-issue \`gh\` query failures swallowed; outer \`try/except\` catches any unhandled exception.
- **Standalone helper** — \`validate_verdict_against_contracts\` signature stays stable.
- **Advisory only** — never auto-flips verdicts.

## Tests

- 5 unit tests in \`test_team_contracts.py\`: regex shape, missing-coverage fires, acknowledged path passes, no-test-paths returns empty, no-APPROVE returns empty.
- 1 snapshot test in \`test_orchestrator_wiring.py\` for the prompt additions.
- 1 integration test in \`test_iterate_projects_python.py\` for iterate_projects glue.

**Results:** focused 147 pass; broader sweep **1526 passed, 1 skipped** (7 more than PR #463's 1519, matching the new tests).

## Smoke test (post-merge, NOT in CI)

1. Rebuild containers (\`docker compose build dashboard agent && docker compose up -d\`).
2. Trigger a run with next-itsm issue #61 still OPEN.
3. Confirm:
   - QA produces a verdict (no longer absent).
   - At least one branch contains \`src/app/api/health/route.test.ts\`.
   - Manager verdict is APPROVE.
   - PR #461's \`gh issue close 61\` fires.
   - Issue #61 transitions to CLOSED on GitHub at run end — closing the PR #461 verification loop.

## Closes

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)