### PR TITLE
fix: project delete fails on FK to vision_chat_sessions/brainstorm_sessions

### DIFF
--- a/dashboard/backend/app/routers/projects.py
+++ b/dashboard/backend/app/routers/projects.py
@@ -10,7 +10,8 @@ from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies import get_db
-from app.models import Plan, Project, Run
+from app.models import BrainstormSession, Plan, Project, Run, VisionChatSession
+from app.services import vision_attachments as va
 from app.schemas import ProjectCreate, ProjectOut, ProjectUpdate
 from app.services.config_sync import sync_db_to_config
 
@@ -123,6 +124,20 @@ async def delete_project(project_id: int, db: AsyncSession = Depends(get_db)):
     await db.execute(
         sa_delete(Plan).where(Plan.project_id == project_id)
     )
+    # Brainstorm sessions: project_id FK lacks CASCADE; clean up explicitly.
+    await db.execute(
+        sa_delete(BrainstormSession).where(BrainstormSession.project_id == project_id)
+    )
+    # Vision chat sessions: project_id FK lacks CASCADE. Capture session ids
+    # first so we can scrub their on-disk upload dirs after the rows go away
+    # (attachment rows cascade-delete via vision_chat_attachments.session_id
+    # FK; the binary files on disk do not).
+    vc_sessions = (await db.execute(
+        select(VisionChatSession.id).where(VisionChatSession.project_id == project_id)
+    )).scalars().all()
+    await db.execute(
+        sa_delete(VisionChatSession).where(VisionChatSession.project_id == project_id)
+    )
 
     await db.delete(project)
     try:
@@ -132,3 +147,8 @@ async def delete_project(project_id: int, db: AsyncSession = Depends(get_db)):
     except Exception:
         await db.rollback()
         raise
+
+    # Disk cleanup is best-effort and runs after the commit so a permission
+    # error here never rolls back a successful project deletion.
+    for sid in vc_sessions:
+        va.cleanup_session_dir(sid)

--- a/dashboard/backend/app/services/vision_attachments.py
+++ b/dashboard/backend/app/services/vision_attachments.py
@@ -256,8 +256,14 @@ async def delete_attachment(db: AsyncSession, *, attachment_id: str) -> None:
 
 
 def cleanup_session_dir(session_id: str) -> None:
-    """Remove the session's upload dir on disk (no-op if absent)."""
-    d = _upload_root() / session_id
+    """Remove the session's upload dir on disk (no-op if absent or unreadable).
+
+    Reads the upload root directly rather than calling ``_upload_root()`` so
+    cleanup never accidentally creates the parent directory — important when
+    invoked from environments (tests, restricted users) that can't write to
+    the default ``/var/lib/...`` path.
+    """
+    d = Path(_settings.vision_upload_dir) / session_id
     if d.exists():
         shutil.rmtree(d, ignore_errors=True)
 

--- a/dashboard/backend/tests/test_projects.py
+++ b/dashboard/backend/tests/test_projects.py
@@ -18,7 +18,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.database import Base, async_session, engine
 from app.main import app
-from app.models import Plan, Project, Run
+from app.models import BrainstormSession, Plan, Project, Run, VisionChatSession
 
 
 @pytest_asyncio.fixture
@@ -289,6 +289,62 @@ async def test_delete_project_nullifies_run_project_id(mock_sync, client, sample
         )
         run = result.scalar_one()
         assert run.project_id is None
+
+
+@pytest.mark.asyncio
+@patch("app.routers.projects.sync_db_to_config", new_callable=AsyncMock)
+async def test_delete_project_with_vision_chat_session(mock_sync, client, sample_project):
+    """DELETE /api/projects/{id} must succeed even when vision_chat_sessions
+    reference the project. The FK lacks ON DELETE CASCADE so the handler
+    must clean up explicitly.
+    """
+    import uuid
+    async with async_session() as session:
+        vcs = VisionChatSession(
+            id=str(uuid.uuid4()),
+            project_id=sample_project.id,
+            state="cancelled",
+            phase="freeform",
+            coverage="{}",
+            messages="[]",
+        )
+        session.add(vcs)
+        await session.commit()
+        vcs_id = vcs.id
+
+    resp = await client.delete(f"/api/projects/{sample_project.id}")
+    assert resp.status_code == 204
+
+    from sqlalchemy import select as _sel
+    async with async_session() as session:
+        result = await session.execute(
+            _sel(VisionChatSession).where(VisionChatSession.id == vcs_id)
+        )
+        assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+@patch("app.routers.projects.sync_db_to_config", new_callable=AsyncMock)
+async def test_delete_project_with_brainstorm_session(mock_sync, client, sample_project):
+    """DELETE /api/projects/{id} must succeed even when brainstorm_sessions
+    reference the project.
+    """
+    import uuid
+    bs_id = str(uuid.uuid4())
+    async with async_session() as session:
+        bs = BrainstormSession(id=bs_id, project_id=sample_project.id)
+        session.add(bs)
+        await session.commit()
+
+    resp = await client.delete(f"/api/projects/{sample_project.id}")
+    assert resp.status_code == 204
+
+    from sqlalchemy import select as _sel
+    async with async_session() as session:
+        result = await session.execute(
+            _sel(BrainstormSession).where(BrainstormSession.id == bs_id)
+        )
+        assert result.scalar_one_or_none() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `delete_project` previously cleaned `Run` (nullify) and `Plan` (delete) only.
- `vision_chat_sessions` and `brainstorm_sessions` both have a non-cascading FK to `projects.id`. On Postgres this surfaced as HTTP 500 + `ForeignKeyViolationError` when trying to delete a project that had ever started a vision chat or brainstorm.
- Pre-existing bug; freshly exposed by the dashboard's compose deployment on Postgres (SQLite tolerated it silently).

## Fix
- Extend `delete_project` to `sa_delete` from both tables before deleting the project. Cascades to `vision_chat_attachments` via the existing `session_id` FK.
- Capture vision session ids first; scrub their on-disk upload dirs after the DB commit (best-effort — periodic orphan sweep mops up any miss).
- Harden `cleanup_session_dir` to read the configured upload root directly instead of `mkdir`-ing it via `_upload_root()` — the cleanup path should never create directories, especially when invoked from restricted contexts.

## Test plan
- [x] `python -m pytest dashboard/backend/tests/test_projects.py -v -k delete` — 7/7 pass (incl. two new tests for the two missing FK paths)
- [ ] Manual: delete the existing project from the dashboard UI on the live container

🤖 Generated with [Claude Code](https://claude.com/claude-code)