### PR TITLE
fix(vision-analyst): retry once with repair prompt on malformed JSON

### DIFF
--- a/agent/vision_analyst.py
+++ b/agent/vision_analyst.py
@@ -178,6 +178,29 @@ Output ONLY a JSON array, no prose:
 """
 
 
+_REPAIR_PROMPT = """Your previous response to a vision-analyst prompt was not valid JSON.
+
+Parse error: {error}
+
+Return the SAME proposals as a STRICT JSON array. Output ONLY the array — no
+prose, no markdown fences, no commentary. Make sure every string is properly
+escaped: backslashes as ``\\\\``, double quotes inside strings as ``\\"``,
+newlines as ``\\n``.
+
+Schema:
+[{{"title": "...", "body": "...", "labels": ["..."], "priority": "low|medium|high|critical"}}]
+
+Your previous (malformed) response:
+{raw}
+"""
+
+# Cap the raw output we feed back into the repair prompt. The original
+# response can be a few KB of markdown bodies; we don't need every byte to
+# get the model to reformat, and very large prompts increase the chance the
+# repair itself runs into latency / cost limits.
+_REPAIR_RAW_CAP = 8000
+
+
 def _call_model(prompt: str, model: str) -> str:
     proc = subprocess.run(
         ["claude", "--print", "--model", model, "--no-session-persistence",
@@ -241,27 +264,82 @@ def propose_gaps(workspace: str, vision: dict, repo: str, model: str) -> list[di
         logger.error("vision_analyst model call failed: %s", e)
         raise VisionAnalystError(f"model call failed: {e}") from e
 
-    raw = raw.strip()
-    if raw.startswith("```"):
-        raw = raw.split("\n", 1)[1] if "\n" in raw else raw
-        raw = raw.rstrip("` \n")
-    if not raw:
-        raise VisionAnalystError("model returned empty response")
-    try:
-        proposals = _parse_proposal_list(raw)
-    except json.JSONDecodeError as e:
-        # Log a truncated preview so operators can see what the model
-        # actually produced without dumping kilobytes of prose into the log.
-        logger.error(
-            "vision_analyst response not JSON: %s | preview=%r",
-            e, raw[:300],
-        )
-        raise VisionAnalystError(f"response not JSON: {e}") from e
+    proposals = _parse_or_repair(raw, model)
     if not isinstance(proposals, list):
         raise VisionAnalystError(
             f"model returned non-list JSON: {type(proposals).__name__}"
         )
     return proposals[:MAX_PROPOSALS]
+
+
+def _clean_fences(raw: str) -> str:
+    """Strip surrounding ```...``` markdown fences from a model response.
+
+    The model sometimes wraps its array in a fenced code block despite the
+    'no markdown' instruction. We tolerate it by peeling the fence; if no
+    fence is present this is a no-op.
+    """
+    raw = raw.strip()
+    if raw.startswith("```"):
+        raw = raw.split("\n", 1)[1] if "\n" in raw else raw
+        raw = raw.rstrip("` \n")
+    return raw
+
+
+def _parse_or_repair(raw: str, model: str) -> list:
+    """Parse the model output as a JSON array, with one repair retry.
+
+    Sonnet occasionally emits a valid-looking JSON array whose string bodies
+    contain unescaped quotes or stray control characters (observed in
+    run-vb-49a7ff80ae91: ``Expecting ',' delimiter: line 10 column 778``).
+    A single follow-up call asking the model to re-emit the same proposals
+    as strict JSON recovers from that class of failure cheaply.
+
+    Raises :class:`VisionAnalystError` if either attempt yields no parseable
+    array. The repair attempt's error is logged but the *original* parse
+    error is surfaced — operators care which output the model produced
+    first, not the repaired-and-still-broken second attempt.
+    """
+    raw = _clean_fences(raw)
+    if not raw:
+        raise VisionAnalystError("model returned empty response")
+    first_err: json.JSONDecodeError
+    try:
+        return _parse_proposal_list(raw)
+    except json.JSONDecodeError as exc:
+        # Python 3 unbinds the ``except`` variable when the block exits, so
+        # we copy it into the enclosing scope before falling through to the
+        # repair attempt below.
+        first_err = exc
+        logger.warning(
+            "vision_analyst response not JSON: %s | preview=%r | retrying with repair prompt",
+            first_err, raw[:300],
+        )
+
+    repair_prompt = _REPAIR_PROMPT.format(
+        error=str(first_err),
+        raw=raw[:_REPAIR_RAW_CAP],
+    )
+    try:
+        repaired = _call_model(repair_prompt, model)
+    except Exception as exc:
+        logger.error("vision_analyst repair call failed: %s", exc)
+        # Surface the ORIGINAL parse error, not the repair call's stderr —
+        # the first-attempt failure is what operators need to triage.
+        raise VisionAnalystError(f"response not JSON: {first_err}") from first_err
+
+    repaired = _clean_fences(repaired)
+    if not repaired:
+        logger.error("vision_analyst repair returned empty response")
+        raise VisionAnalystError(f"response not JSON: {first_err}") from first_err
+    try:
+        return _parse_proposal_list(repaired)
+    except json.JSONDecodeError as repair_err:
+        logger.error(
+            "vision_analyst repair also not JSON: %s | preview=%r",
+            repair_err, repaired[:300],
+        )
+        raise VisionAnalystError(f"response not JSON: {first_err}") from first_err
 
 
 def _list_vision_refs(repo_root: Path) -> str:

--- a/dashboard/backend/tests/test_vision_analyst.py
+++ b/dashboard/backend/tests/test_vision_analyst.py
@@ -204,6 +204,78 @@ def test_create_proposed_issues_calls_ensure_labels_first():
     assert call_log.index("issue:create") > call_log.index("label:critical")
 
 
+def test_propose_gaps_repairs_malformed_json_via_retry():
+    """Mirrors run-vb-49a7ff80ae91: first call returns a JSON array whose
+    string bodies contain an unescaped quote (``Expecting ',' delimiter``).
+    A repair retry must be issued and its valid output used."""
+    # Unescaped quote inside body breaks the JSON at column ~30 of line 3.
+    bad = '[\n  {\n    "title": "Scaffold monorepo",\n    "body": "use "fastify" here",\n    "labels": [],\n    "priority": "medium"\n  }\n]'
+    good = json.dumps([
+        {"title": "Scaffold monorepo", "body": 'use "fastify" here',
+         "labels": [], "priority": "medium"},
+    ])
+    calls: list[str] = []
+
+    def fake_call(prompt: str, model: str) -> str:
+        calls.append(prompt)
+        # First call: malformed. Second call (repair): valid.
+        return bad if len(calls) == 1 else good
+
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", side_effect=fake_call):
+            proposals = propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+
+    assert len(calls) == 2, "repair retry must invoke the model a second time"
+    assert "previous response" in calls[1].lower() and "strict json" in calls[1].lower(), (
+        "repair prompt must reference the previous response and require strict JSON"
+    )
+    assert len(proposals) == 1
+    assert proposals[0]["title"] == "Scaffold monorepo"
+
+
+def test_propose_gaps_surfaces_original_error_when_repair_also_fails():
+    """If both the first call AND the repair retry produce malformed JSON,
+    the operator-visible error must be the ORIGINAL parse error (which
+    describes what the model produced first), not the repair-call error."""
+    bad_first = '[{"title": "A", "body": "x" "y", "labels": [], "priority": "low"}]'
+    bad_repair = "still not json"
+    calls: list[str] = []
+
+    def fake_call(prompt: str, model: str) -> str:
+        calls.append(prompt)
+        return bad_first if len(calls) == 1 else bad_repair
+
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", side_effect=fake_call):
+            with pytest.raises(VisionAnalystError, match="not JSON") as exc_info:
+                propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+
+    assert len(calls) == 2, "repair retry must still be attempted before giving up"
+    # The chained __cause__ is the FIRST parse error, not the repair's.
+    assert isinstance(exc_info.value.__cause__, json.JSONDecodeError)
+
+
+def test_propose_gaps_surfaces_original_error_when_repair_call_raises():
+    """If the repair retry's _call_model itself raises (CLI timeout, etc.),
+    the analyst must still surface the original JSON parse error so the
+    operator sees the underlying class of failure, not a secondary CLI
+    error that's unrelated to the root cause."""
+    bad_first = '[{"title": "A", "body": "x" "y", "labels": [], "priority": "low"}]'
+    calls: list[int] = []
+
+    def fake_call(prompt: str, model: str) -> str:
+        calls.append(1)
+        if len(calls) == 1:
+            return bad_first
+        raise RuntimeError("claude CLI: timeout after 300s")
+
+    with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):
+        with patch("agent.vision_analyst._call_model", side_effect=fake_call):
+            with pytest.raises(VisionAnalystError, match="not JSON"):
+                propose_gaps(workspace="/x", vision=VISION, repo="o/r", model="m")
+    assert len(calls) == 2
+
+
 def test_propose_gaps_raises_when_no_array_present():
     """Pure prose with no JSON array at all must surface as an error."""
     with patch("agent.vision_analyst._gather_repo_state", return_value={"tree": [], "readme": "", "commits": [], "open_issues": [], "closed_issues": []}):


### PR DESCRIPTION
## Summary
- Run `run-vb-49a7ff80ae91` failed when Sonnet 4.6 emitted a proposal array whose `body` contained an unescaped quote (`Expecting ',' delimiter: line 10 column 778`). The analyst surfaced the parse error and dropped the whole run.
- Add a single bounded repair retry: when the first response can't be parsed, re-call the same model with the malformed output and ask for strict JSON only.
- If the repair attempt itself fails (either by raising or by producing more malformed output), surface the **original** parse error — operators triage what the model produced first, not the secondary failure.

## Implementation
- `_parse_or_repair(raw, model)` in `agent/vision_analyst.py` owns the parse + retry logic; `propose_gaps` delegates to it.
- `_REPAIR_PROMPT` shows the model its previous output (capped at 8 KB) and the parse error, demands strict JSON only.
- `_clean_fences` extracted so both attempts can strip stray markdown fences.

## Test plan
- [x] `test_propose_gaps_repairs_malformed_json_via_retry` — mirrors run-vb-49a7ff80ae91 (unescaped quote inside body), asserts a second call happens with a "previous response / strict JSON" prompt and that the repaired output is used.
- [x] `test_propose_gaps_surfaces_original_error_when_repair_also_fails` — both attempts broken; surfaced `__cause__` is the first `JSONDecodeError`.
- [x] `test_propose_gaps_surfaces_original_error_when_repair_call_raises` — repair `_call_model` raises (e.g. CLI timeout); analyst still surfaces the original parse error.
- [x] All 29 `tests/test_vision_analyst.py` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)