### PR TITLE
fix(vision-preflight): probe GitHub App auth, not the gh CLI

### DIFF
--- a/dashboard/backend/app/routers/vision.py
+++ b/dashboard/backend/app/routers/vision.py
@@ -23,6 +23,7 @@ from app.services.vision_render import render_vision_doc
 from app.services import vision_chat as vc_service
 from app.services import vision_attachments as va
 from app.services import service_control
+from app.services.github_app import get_installation_token
 from app.services.vision_chat import (
     create_session, get_active_session, mark_cancelled,
     SessionAlreadyActive, SessionNotFound,
@@ -428,25 +429,31 @@ async def delete_chat_attachment(
     await db.commit()
 
 
-def _check_gh_auth() -> bool:
-    """Return True iff `gh auth status` exits cleanly.
+async def _check_github_auth() -> bool:
+    """Return True iff the dashboard can mint a fresh GitHub App installation
+    token.
 
-    Best-effort probe: a non-zero exit means the agent's gh token is
-    invalid/expired and a vision-analyst dispatch will spin up only to
-    crash on the first GitHub API call. Cheap to run (a few hundred ms)
-    and infinitely cheaper than a doomed analyst run.
+    This is the same auth path the analyst itself relies on at runtime:
+    ``agent.vision_analyst._fetch_gh_token`` calls
+    ``GET /api/github/app/token``, which in turn calls
+    :func:`get_installation_token`. Probing the mint here lets the
+    preflight short-circuit a doomed analyst dispatch and lines the check
+    up with the GitHub Settings page (the green chip there reflects the
+    same call).
+
+    Replaces the previous ``gh auth status`` shell-out, which was broken
+    in compose deploys because ``gh`` isn't installed in the dashboard
+    image (the subprocess raised ``FileNotFoundError``, was caught by a
+    bare ``except``, and unconditionally returned False — so every
+    dispatch hit a 409 regardless of actual App auth state).
     """
     try:
-        result = subprocess.run(
-            ["gh", "auth", "status"],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        return result.returncode == 0
-    except Exception:
-        # Treat any subprocess failure (gh not installed, OS error, timeout)
-        # as auth-broken — the agent can't dispatch anyway.
+        return bool(await get_installation_token())
+    except Exception as exc:
+        # Network blip, malformed credentials on disk, etc. We log so
+        # operators can spot a flapping mint, but the preflight return
+        # stays binary — caller raises a single 409 either way.
+        logger.warning("preflight GitHub App auth probe failed: %s", exc)
         return False
 
 
@@ -459,18 +466,20 @@ async def _vision_preflight(
     may dispatch; when False, raise HTTPException(status_code, detail).
 
     Two layers (issue #272):
-    1. ``gh`` CLI auth health — short-circuits invalid-token dispatches.
+    1. GitHub App auth health — probes the same installation-token mint
+       the analyst uses at runtime, so a green chip in Settings and a
+       passing preflight refer to the same thing.
     2. Last vision-bootstrap run failed for the *current* vision SHA AND
        no later success exists → block re-runs until the operator either
        fixes auth or commits a new vision.
     """
-    # Layer A: gh auth health — run in a thread so we don't block the loop
-    auth_ok = await asyncio.to_thread(_check_gh_auth)
+    # Layer A: can the dashboard mint an App installation token?
+    auth_ok = await _check_github_auth()
     if not auth_ok:
         return (
             False,
             409,
-            "GitHub CLI is not authenticated — visit Settings → GitHub to reconnect.",
+            "GitHub App is not installed or unreachable — visit Settings → GitHub to reconnect.",
         )
 
     # Layer B: stale-failure guard. Find the most-recent vision-bootstrap

--- a/dashboard/backend/tests/test_vision_router.py
+++ b/dashboard/backend/tests/test_vision_router.py
@@ -216,7 +216,7 @@ async def test_find_gaps_calls_service_control(project):
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
-        with patch("app.routers.vision._check_gh_auth", return_value=True), \
+        with patch("app.routers.vision._check_github_auth", new=AsyncMock(return_value=True)), \
              patch("app.services.service_control.start_vision_analyst",
                    new=AsyncMock(return_value={"success": True, "status_code": 200, "pid": 99})):
             r = await c.post(f"/api/projects/{project.id}/vision/find-gaps")
@@ -225,8 +225,12 @@ async def test_find_gaps_calls_service_control(project):
 
 
 @pytest.mark.asyncio
-async def test_find_gaps_409_when_gh_auth_broken(project):
-    """Preflight: invalid gh auth → 409 before dispatch (issue #272)."""
+async def test_find_gaps_409_when_github_app_unavailable(project):
+    """Preflight: App-token mint fails → 409 before dispatch (issue #272).
+
+    Replaces the old `gh auth status` probe — the analyst's runtime auth is
+    the App installation token, so the preflight now mirrors that.
+    """
     async with async_session() as db:
         proj = await db.get(Project, project.id)
         proj.vision_cached_body = "# Vision — o/r\n\n## Problem\nP\n"
@@ -236,12 +240,52 @@ async def test_find_gaps_409_when_gh_auth_broken(project):
     dispatch_mock = AsyncMock(return_value={"success": True, "status_code": 200, "pid": 1})
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
-        with patch("app.routers.vision._check_gh_auth", return_value=False), \
+        with patch("app.routers.vision._check_github_auth", new=AsyncMock(return_value=False)), \
              patch("app.services.service_control.start_vision_analyst", new=dispatch_mock):
             r = await c.post(f"/api/projects/{project.id}/vision/find-gaps")
     assert r.status_code == 409
-    assert "GitHub CLI" in r.json()["detail"]
+    assert "GitHub App" in r.json()["detail"]
     dispatch_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_check_github_auth_returns_true_when_token_minted(project):
+    """_check_github_auth delegates to get_installation_token and returns True
+    when a token is minted — proving the preflight tracks the same auth path
+    as the dashboard's GitHub Settings green chip."""
+    from app.routers import vision as vision_router
+    with patch(
+        "app.routers.vision.get_installation_token",
+        new=AsyncMock(return_value="ghs_FAKE"),
+    ):
+        assert await vision_router._check_github_auth() is True
+
+
+@pytest.mark.asyncio
+async def test_check_github_auth_returns_false_when_mint_returns_none(project):
+    """When the App is unconfigured, get_installation_token returns None;
+    _check_github_auth must surface that as False rather than truthy."""
+    from app.routers import vision as vision_router
+    with patch(
+        "app.routers.vision.get_installation_token",
+        new=AsyncMock(return_value=None),
+    ):
+        assert await vision_router._check_github_auth() is False
+
+
+@pytest.mark.asyncio
+async def test_check_github_auth_returns_false_when_mint_raises(project, caplog):
+    """A network blip or malformed credentials must not propagate as a 500;
+    the probe swallows the exception, logs a warning, and returns False so
+    the preflight raises a clean 409."""
+    from app.routers import vision as vision_router
+    with patch(
+        "app.routers.vision.get_installation_token",
+        new=AsyncMock(side_effect=RuntimeError("network down")),
+    ):
+        with caplog.at_level("WARNING"):
+            assert await vision_router._check_github_auth() is False
+    assert any("preflight" in rec.message.lower() for rec in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -265,7 +309,7 @@ async def test_find_gaps_409_when_recent_failure_for_current_sha(project):
     dispatch_mock = AsyncMock(return_value={"success": True, "status_code": 200, "pid": 1})
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
-        with patch("app.routers.vision._check_gh_auth", return_value=True), \
+        with patch("app.routers.vision._check_github_auth", new=AsyncMock(return_value=True)), \
              patch("app.services.service_control.start_vision_analyst", new=dispatch_mock):
             r = await c.post(f"/api/projects/{project.id}/vision/find-gaps")
     assert r.status_code == 409
@@ -305,7 +349,7 @@ async def test_find_gaps_recovers_when_success_follows_failure(project):
     dispatch_mock = AsyncMock(return_value={"success": True, "status_code": 200, "pid": 1})
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as c:
-        with patch("app.routers.vision._check_gh_auth", return_value=True), \
+        with patch("app.routers.vision._check_github_auth", new=AsyncMock(return_value=True)), \
              patch("app.services.service_control.start_vision_analyst", new=dispatch_mock):
             r = await c.post(f"/api/projects/{project.id}/vision/find-gaps")
     assert r.status_code == 200


### PR DESCRIPTION
## Summary
- Preflight ran `gh auth status` inside the dashboard container — but `gh` isn't installed there. The subprocess raised `FileNotFoundError`, a bare `except` returned False, and every dispatch 409'd as *"GitHub CLI is not authenticated"* even with the green chip showing the App was installed.
- The probe was testing the wrong dependency anyway. The analyst's runtime auth is the App installation token minted by `get_installation_token`; the `gh` CLI is irrelevant to that path.
- Switch the preflight to `await get_installation_token()` directly. Green chip in Settings, dispatch preflight, and the analyst's runtime mint now all reflect the same call.

## Implementation
- `_check_gh_auth` → `_check_github_auth` (now async). Implementation is a single `await get_installation_token()` with a swallow-and-log around `Exception` so network blips return False rather than 500.
- `_vision_preflight` awaits it directly (no more `asyncio.to_thread`).
- Error message updated: `"GitHub App is not installed or unreachable — visit Settings → GitHub to reconnect."`

## Test plan
- [x] `test_check_github_auth_returns_true_when_token_minted` — happy path delegates to the mint.
- [x] `test_check_github_auth_returns_false_when_mint_returns_none` — unconfigured App surfaces as False, not truthy.
- [x] `test_check_github_auth_returns_false_when_mint_raises` — network blip swallowed, warning logged, no 500.
- [x] `test_find_gaps_409_when_github_app_unavailable` — renamed/rewritten preflight-blocks-dispatch test.
- [x] All 21 `tests/test_vision_router.py` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)