### PR TITLE
fix(verdicts): surface executor failures, override hallucinated repo slug, push integration base to origin

### DIFF
--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -102,6 +102,90 @@ def _eligible(issue: dict[str, Any],
     return not (label_names & skip)
 
 
+def _execute_one_verdict(
+    verdict: Any,
+    *,
+    project_repo: str,
+    workspace_path: str,
+    run_id: str,
+    dev_branch: str,
+    env: dict[str, str],
+) -> dict:
+    """Run one verdict through ``execute_verdict`` and reduce the
+    ``ExecutionResult`` to a digest-shaped dict.
+
+    Two guarantees this helper exists for, both root-causes from the
+    2026-05-21 LCM runs where APPROVE verdicts produced zero PRs:
+
+    1. ``verdict.project`` is overridden with ``project_repo`` *before*
+       dispatch. The manager's free-text output is not a trustworthy
+       source for ``gh --repo`` — live data shows hallucinated slugs
+       like ``claude-agent-station/LCM`` against a real repo of
+       ``laboef1900/LCM``.
+
+    2. A successful return from ``execute_verdict`` is not the same as
+       a successful execution. The executors return
+       ``ExecutionResult(success=False, error=…)`` for git/gh failures
+       without raising. The previous loop discarded that result and
+       recorded APPROVE regardless; this helper surfaces it as ERROR.
+
+    Returns the result dict to append to the digest. Caller is
+    responsible for ``any_real_failure``/``exit_code`` bookkeeping based
+    on the dict's ``"decision"``.
+    """
+    from agent.verdict_execution import execute as execute_verdict
+
+    # Fix #1 of #2: canonicalise the repo slug before the executor sees it.
+    verdict.project = project_repo
+
+    try:
+        result = execute_verdict(
+            verdict,
+            workspace=Path(workspace_path),
+            run_id=run_id,
+            env=env,
+            dev_branch=dev_branch,
+        )
+    except Exception as exc:  # noqa: BLE001 — never crash the loop on one verdict
+        logger.exception(
+            "verdict_execution: %s#%s failed (%s)",
+            verdict.project, verdict.issue_number, verdict.verdict,
+        )
+        return {
+            "project": verdict.project,
+            "issue_number": verdict.issue_number,
+            "decision": "ERROR",
+            "error": f"execute_verdict: {type(exc).__name__}: {exc}",
+        }
+
+    if not getattr(result, "success", False):
+        # Fix #2 of #2: silent-failure mode that produced two APPROVE-but-no-PR
+        # runs on 2026-05-21. Now surfaced as ERROR so the digest, exit code,
+        # and downstream webhook all reflect reality.
+        logger.error(
+            "verdict_execution: %s#%s recorded failure (%s): %s",
+            verdict.project, verdict.issue_number, verdict.verdict,
+            getattr(result, "error", "<no error message>"),
+        )
+        return {
+            "project": verdict.project,
+            "issue_number": verdict.issue_number,
+            "decision": "ERROR",
+            "error": getattr(result, "error", "execute_verdict reported failure"),
+            "intended_decision": verdict.verdict,
+            "branch": getattr(verdict, "branch", ""),
+        }
+
+    return {
+        "project": verdict.project,
+        "issue_number": verdict.issue_number,
+        "decision": verdict.verdict,
+        "branch": getattr(verdict, "branch", ""),
+        "reasoning": getattr(verdict, "reasoning", ""),
+        "pr_url": getattr(result, "pr_url", None),
+    }
+
+
 def pick_issue(
     repo: str,
     *,
@@ -196,7 +280,9 @@ def iterate_projects(
     from agent.run_control import OrchestratorStopRequested
     from agent.workspace_setup import ensure_workspace, WorkspaceError
     from agent.station_orchestrator import orchestrate_project, _read_verdicts_file
-    from agent.verdict_execution import execute as execute_verdict
+    # NOTE: execute_verdict is imported inside _execute_one_verdict (top of
+    # this module) rather than here. Removing the module-scope import
+    # avoids a now-unused symbol after the verdict-handling extraction.
     from agent.integration_branch import merge_to_dev, IntegrationBranchError
     from agent.digest import write_digest
 
@@ -483,37 +569,29 @@ def iterate_projects(
             # silently failing every integration even when the manager
             # approved. (Discovered after live run-20260515T235612Z:
             # verdict file written with 5x APPROVE_INTEGRATION, no PRs
-            # opened, run marked failed.) Catch per-verdict so one bad
-            # executor invocation doesn't cancel the whole queue.
-            try:
-                execute_verdict(
-                    verdict,
-                    workspace=Path(workspace_path),
-                    run_id=run_id,
-                    env=_os.environ.copy(),
-                    dev_branch=dev_branch,
-                )
-            except Exception as exc:  # noqa: BLE001 — must not crash loop
-                logger.exception(
-                    "verdict_execution: %s#%s failed (%s)",
-                    verdict.project, verdict.issue_number, verdict.verdict,
-                )
+            # opened, run marked failed.)
+            #
+            # 2026-05-21 follow-up: a *returned* failure (success=False on
+            # the ExecutionResult) was also being silently swallowed. The
+            # executor catches its own subprocess errors and returns them
+            # in the result; the loop must not discard that. Both the
+            # raise path and the returned-failure path are now handled in
+            # :func:`_execute_one_verdict`. The verdict's ``project`` field
+            # is also coerced to ``project["repo"]`` there to defeat the
+            # manager's free-text hallucination of the GitHub repo slug.
+            result_dict = _execute_one_verdict(
+                verdict,
+                project_repo=project["repo"],
+                workspace_path=workspace_path,
+                run_id=run_id,
+                dev_branch=dev_branch,
+                env=_os.environ.copy(),
+            )
+            results.append(result_dict)
+            if result_dict.get("decision") == "ERROR":
                 exit_code = max(exit_code, 7)
                 any_real_failure = True
-                results.append({
-                    "project": verdict.project,
-                    "issue_number": verdict.issue_number,
-                    "decision": "ERROR",
-                    "error": f"execute_verdict: {type(exc).__name__}: {exc}",
-                })
                 continue
-            results.append({
-                "project": verdict.project,
-                "issue_number": verdict.issue_number,
-                "decision": verdict.verdict,
-                "branch": getattr(verdict, "branch", ""),
-                "reasoning": getattr(verdict, "reasoning", ""),
-            })
             if getattr(verdict, "action", "") == "merge_dev":
                 try:
                     merge_to_dev(

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -198,6 +198,63 @@ def _render_vision_for_splitter(vision: dict[str, str] | None) -> str:
 
 # ── Configuration ──────────────────────────────────────────────
 
+def ensure_integration_base_on_origin(workspace: str, base_branch: str) -> None:
+    """Ensure the integration base branch exists *on origin*, not just locally.
+
+    The orchestrator branches every worktree from this ref, and verdict
+    execution opens PRs with ``--base <base_branch>``. If the branch is
+    only local, ``gh pr create`` fails with a 404 on every approve.
+
+    Behavior:
+
+    - ``git fetch origin`` to refresh refs.
+    - If ``origin/<base_branch>`` already exists: checkout, ``git pull``.
+    - Else: create locally from HEAD and ``git push -u origin <base_branch>``.
+      A failed push (branch protection / perms) is logged at WARNING and
+      the function returns — the run continues, but downstream PR
+      creation will surface the failure via ``_execute_one_verdict``.
+
+    Why the bug existed: the previous flow created the local branch but
+    never pushed it. Two live runs against laboef1900/LCM on 2026-05-21
+    produced zero PRs because ``--base claude-agent-station`` resolved
+    only locally; the executor's silent-failure swallow then recorded
+    every verdict as APPROVE. Fixed jointly with that swallow in
+    :func:`agent.project_loop._execute_one_verdict`.
+    """
+    subprocess.run(
+        ["git", "fetch", "origin"],
+        cwd=workspace, capture_output=True, timeout=30,
+    )
+    has_remote = subprocess.run(
+        ["git", "rev-parse", "--verify", f"origin/{base_branch}"],
+        cwd=workspace, capture_output=True,
+    )
+    if has_remote.returncode == 0:
+        subprocess.run(
+            ["git", "checkout", base_branch],
+            cwd=workspace, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "pull", "origin", base_branch],
+            cwd=workspace, capture_output=True,
+        )
+        return
+
+    subprocess.run(
+        ["git", "checkout", "-b", base_branch],
+        cwd=workspace, capture_output=True,
+    )
+    push = subprocess.run(
+        ["git", "push", "-u", "origin", base_branch],
+        cwd=workspace, capture_output=True, text=True,
+    )
+    if push.returncode != 0:
+        logger.warning(
+            "could not push integration base branch %r to origin: %s",
+            base_branch, push.stderr.strip()[:200],
+        )
+
+
 def load_config(config_file: str) -> dict:
     """Load manager-config.json."""
     with open(config_file) as f:
@@ -2395,30 +2452,7 @@ async def orchestrate_project(
         integration = config.get("integration", {})
         base_branch = integration.get("dev_branch", "autonomous/dev")
 
-        # Ensure base branch exists locally
-        subprocess.run(
-            ["git", "fetch", "origin"],
-            cwd=workspace, capture_output=True, timeout=30,
-        )
-        # Try checking out base branch; create if missing
-        result = subprocess.run(
-            ["git", "rev-parse", "--verify", f"origin/{base_branch}"],
-            cwd=workspace, capture_output=True,
-        )
-        if result.returncode != 0:
-            subprocess.run(
-                ["git", "checkout", "-b", base_branch],
-                cwd=workspace, capture_output=True,
-            )
-        else:
-            subprocess.run(
-                ["git", "checkout", base_branch],
-                cwd=workspace, capture_output=True,
-            )
-            subprocess.run(
-                ["git", "pull", "origin", base_branch],
-                cwd=workspace, capture_output=True,
-            )
+        ensure_integration_base_on_origin(workspace, base_branch)
 
         # Create one worktree per teammate role
         worktree_paths: dict[str, str] = {}

--- a/dashboard/backend/tests/test_ensure_integration_base.py
+++ b/dashboard/backend/tests/test_ensure_integration_base.py
@@ -1,0 +1,113 @@
+"""Tests for :func:`agent.station_orchestrator.ensure_integration_base_on_origin`.
+
+Uses a real bare repo + clone (no network) to verify the branch actually
+lands on ``origin`` — mocking subprocess here would only re-spec what we
+already broke once. Reproduces the 2026-05-21 LCM bug where the
+integration base branch was created locally but never pushed, causing
+every ``gh pr create --base <base_branch>`` to 404.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(cwd),
+        capture_output=True, text=True, check=check,
+    )
+
+
+@pytest.fixture
+def repo_pair(tmp_path: Path):
+    """Create a bare ``origin`` repo plus a working clone with one commit
+    on ``main``. Returns (origin_path, workspace_path)."""
+    origin = tmp_path / "origin.git"
+    workspace = tmp_path / "workspace"
+
+    _git(tmp_path, "init", "--bare", "-b", "main", str(origin))
+
+    workspace.mkdir()
+    _git(workspace, "init", "-b", "main")
+    _git(workspace, "config", "user.email", "t@t")
+    _git(workspace, "config", "user.name", "t")
+    (workspace / "README.md").write_text("hi\n")
+    _git(workspace, "add", "README.md")
+    _git(workspace, "commit", "-m", "init")
+    _git(workspace, "remote", "add", "origin", str(origin))
+    _git(workspace, "push", "-u", "origin", "main")
+
+    return origin, workspace
+
+
+def _remote_branches(origin: Path) -> set[str]:
+    out = _git(origin, "for-each-ref", "--format=%(refname:short)", "refs/heads/")
+    return {line.strip() for line in out.stdout.splitlines() if line.strip()}
+
+
+def test_creates_and_pushes_base_branch_when_missing_on_origin(repo_pair):
+    """The 2026-05-21 regression case: ``claude-agent-station`` exists
+    locally only. After the helper runs, it must be on origin too."""
+    from agent.station_orchestrator import ensure_integration_base_on_origin
+
+    origin, workspace = repo_pair
+    assert "claude-agent-station" not in _remote_branches(origin)
+
+    ensure_integration_base_on_origin(str(workspace), "claude-agent-station")
+
+    assert "claude-agent-station" in _remote_branches(origin), (
+        "integration base branch must be pushed to origin so PRs can target it"
+    )
+
+
+def test_pulls_existing_base_branch_without_force_push(repo_pair):
+    """When the branch already exists on origin, the helper must check
+    out and pull — not re-create or force-push."""
+    from agent.station_orchestrator import ensure_integration_base_on_origin
+
+    origin, workspace = repo_pair
+    # Seed an existing remote branch with an extra commit.
+    _git(workspace, "checkout", "-b", "autonomous/dev")
+    (workspace / "extra.txt").write_text("x\n")
+    _git(workspace, "add", "extra.txt")
+    _git(workspace, "commit", "-m", "extra")
+    _git(workspace, "push", "-u", "origin", "autonomous/dev")
+    upstream_sha = _git(workspace, "rev-parse", "autonomous/dev").stdout.strip()
+
+    # Drop the local branch so the helper has to pull from origin.
+    _git(workspace, "checkout", "main")
+    _git(workspace, "branch", "-D", "autonomous/dev")
+
+    ensure_integration_base_on_origin(str(workspace), "autonomous/dev")
+
+    # Local now matches origin and origin is untouched.
+    local_sha = _git(workspace, "rev-parse", "autonomous/dev").stdout.strip()
+    assert local_sha == upstream_sha
+    origin_sha = _git(origin, "rev-parse", "autonomous/dev").stdout.strip()
+    assert origin_sha == upstream_sha
+
+
+def test_push_failure_is_logged_not_raised(repo_pair, caplog, monkeypatch):
+    """If origin rejects the push (e.g. branch protection), the helper
+    must warn and return — never raise into the orchestrator."""
+    from agent import station_orchestrator as orch
+
+    _, workspace = repo_pair
+
+    # Simulate push rejection by pointing the remote at a path that
+    # doesn't accept writes.
+    _git(workspace, "remote", "set-url", "origin", "/nonexistent-path.git")
+
+    with caplog.at_level("WARNING", logger="agent.station_orchestrator"):
+        orch.ensure_integration_base_on_origin(
+            str(workspace), "claude-agent-station",
+        )
+
+    assert any(
+        "could not push integration base branch" in rec.message
+        for rec in caplog.records
+    ), "push failure must be surfaced as a WARNING"

--- a/dashboard/backend/tests/test_project_loop_verdict_failures.py
+++ b/dashboard/backend/tests/test_project_loop_verdict_failures.py
@@ -1,0 +1,144 @@
+"""Tests for :func:`agent.project_loop._execute_one_verdict`.
+
+Background: two live runs against ``laboef1900/LCM`` on 2026-05-21
+(run-20260521T142800Z, run-20260521T151955Z) recorded verdict APPROVE for
+every issue while opening zero PRs. Root cause was two-fold:
+
+- the manager hallucinated ``project="claude-agent-station/LCM"`` (or
+  just ``"LCM"``), so ``gh pr create --repo <that>`` 404'd; and
+- the executor returned ``ExecutionResult(success=False, error=…)`` for
+  that 404 but the loop discarded the result, recording APPROVE anyway.
+
+The helper extracted in :func:`_execute_one_verdict` exists to fix both.
+These tests pin that behavior so a future refactor cannot quietly
+regress to "all green, no PRs".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _verdict(verdict_kind: str = "APPROVE", project: str = "wrong-owner/wrong"):
+    from agent.verdict_execution import Verdict
+
+    return Verdict(
+        project=project,
+        issue_number=42,
+        verdict=verdict_kind,
+        branch="autonomous/issue-42",
+        base_branch="main",
+        reasoning="ok",
+        mode="full",
+    )
+
+
+def _result(success: bool, **overrides):
+    from agent.verdict_execution import ExecutionResult
+
+    fields = dict(
+        verdict="APPROVE",
+        project="ignored-here",
+        issue_number=42,
+        success=success,
+    )
+    fields.update(overrides)
+    return ExecutionResult(**fields)
+
+
+def test_returned_failure_is_surfaced_as_error_decision(tmp_path: Path):
+    """``ExecutionResult.success=False`` must produce an ERROR dict, not
+    a quiet APPROVE. Reproduces the 2026-05-21 silent failure."""
+    from agent.project_loop import _execute_one_verdict
+
+    captured = _result(False, error="gh pr create failed: 404 repo")
+
+    with patch("agent.verdict_execution.execute", return_value=captured):
+        out = _execute_one_verdict(
+            _verdict("APPROVE"),
+            project_repo="laboef1900/LCM",
+            workspace_path=str(tmp_path),
+            run_id="run-test",
+            dev_branch="autonomous/dev",
+            env={},
+        )
+
+    assert out["decision"] == "ERROR"
+    assert "404" in out["error"]
+    # Preserve the intended verdict so the digest can show what was attempted.
+    assert out["intended_decision"] == "APPROVE"
+
+
+def test_successful_execution_records_verdict_with_pr_url(tmp_path: Path):
+    """``success=True`` keeps the manager's verdict (APPROVE/PR/etc.) and
+    carries the ``pr_url`` for downstream reporting."""
+    from agent.project_loop import _execute_one_verdict
+
+    captured = _result(True, pr_url="https://github.com/laboef1900/LCM/pull/7")
+
+    with patch("agent.verdict_execution.execute", return_value=captured):
+        out = _execute_one_verdict(
+            _verdict("APPROVE"),
+            project_repo="laboef1900/LCM",
+            workspace_path=str(tmp_path),
+            run_id="run-test",
+            dev_branch="autonomous/dev",
+            env={},
+        )
+
+    assert out["decision"] == "APPROVE"
+    assert out["pr_url"] == "https://github.com/laboef1900/LCM/pull/7"
+    assert "error" not in out
+
+
+def test_project_slug_is_overridden_before_executor_dispatch(tmp_path: Path):
+    """The manager's ``verdict.project`` is replaced by the canonical
+    ``project_repo`` before ``execute_verdict`` sees it. Defeats the
+    "claude-agent-station/LCM" hallucination from 2026-05-21."""
+    from agent.project_loop import _execute_one_verdict
+
+    seen: dict = {}
+
+    def _spy(verdict, **kwargs):  # noqa: ANN001
+        seen["project"] = verdict.project
+        return _result(True, pr_url="https://x/pr/1", project=verdict.project)
+
+    bad = _verdict("APPROVE", project="claude-agent-station/LCM")
+
+    with patch("agent.verdict_execution.execute", side_effect=_spy):
+        _execute_one_verdict(
+            bad,
+            project_repo="laboef1900/LCM",
+            workspace_path=str(tmp_path),
+            run_id="run-test",
+            dev_branch="autonomous/dev",
+            env={},
+        )
+
+    assert seen["project"] == "laboef1900/LCM"
+    # And the mutation persists on the verdict object so later callers
+    # (digest, webhook) see the canonical slug too.
+    assert bad.project == "laboef1900/LCM"
+
+
+def test_raised_exception_is_caught_and_recorded_as_error(tmp_path: Path):
+    """Existing behavior preserved: a raise from the executor (e.g.
+    TypeError from a kwarg mismatch — the 2026-05-15 incident) is caught
+    and recorded as ERROR rather than crashing the loop."""
+    from agent.project_loop import _execute_one_verdict
+
+    with patch("agent.verdict_execution.execute",
+               side_effect=TypeError("missing kwarg")):
+        out = _execute_one_verdict(
+            _verdict("APPROVE"),
+            project_repo="laboef1900/LCM",
+            workspace_path=str(tmp_path),
+            run_id="run-test",
+            dev_branch="autonomous/dev",
+            env={},
+        )
+
+    assert out["decision"] == "ERROR"
+    assert "TypeError" in out["error"]
+    assert "missing kwarg" in out["error"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -300,7 +300,7 @@ These keys live under `integration.*` and apply to every project:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | boolean | `false` | Turns on the integration-branch flow. |
-| `dev_branch` | string | `"autonomous/dev"` | Branch name created in each target repo (e.g. `claude-agent-station`). |
+| `dev_branch` | string | `"autonomous/dev"` | Branch name created in each target repo (e.g. `claude-agent-station`). The orchestrator pushes this branch to `origin` on first use so `gh pr create --base <dev_branch>` resolves; a push failure (branch protection / perms) is logged at WARNING and subsequent verdict execution surfaces the resulting PR-creation failure as ERROR instead of silently recording APPROVE. |
 | `promotion_strategy` | string | `"batch"` | `batch` opens one meta-PR with N commits; `individual` opens one PR per cherry-picked commit. |
 | `auto_validate` | boolean | `true` | Run the project's test suite on the integration branch after each merge (`agent/scripts/integration-branch.sh::validate_dev`). |
 | `auto_promote` | boolean | `false` | When validation passes, open the meta-PR automatically. |


### PR DESCRIPTION
## Summary

Fixes the silent-failure mode that caused two live LCM runs on 2026-05-21 to record `verdict=APPROVE` for every issue while opening zero PRs.

Three compounding root causes — all addressed:

1. **Returned failures were discarded.** `agent.verdict_execution.execute_approve` returns `ExecutionResult(success=False, error=…)` for git/gh failures without raising; the project loop only handled the raise path. Extracted `_execute_one_verdict` to honor `success=False`, append an ERROR result with `intended_decision`/error, and flip `any_real_failure`.

2. **Manager hallucinated the repo slug.** Verdicts emitted `project="claude-agent-station/LCM"` against a real repo of `laboef1900/LCM`, so every `gh pr create --repo …` 404'd. `_execute_one_verdict` now overrides `verdict.project` with `project["repo"]` from manager-config before dispatch — free-text is no longer trusted for `gh --repo`.

3. **Integration base branch was never on origin.** The orchestrator created `integration.dev_branch` locally only, so `gh pr create --base claude-agent-station` resolved to a non-existent ref. Extracted `ensure_integration_base_on_origin` which pushes the branch with `-u origin`; rejected pushes (branch protection / perms) are logged at WARNING and the run continues — fix (1) guarantees the resulting PR-creation failure is now visible instead of swallowed.

## Test plan
- [x] `pytest dashboard/backend/tests/test_project_loop_verdict_failures.py` — unit tests for returned-failure / success / slug override / raised exception
- [x] `pytest dashboard/backend/tests/test_ensure_integration_base.py` — real-git integration test (bare origin + clone) for the base-branch push
- [x] Existing `test_verdict_execution.py` + `test_project_loop_pick_issue.py` + `test_orchestrator_wiring.py` still green (146 passed)
- [x] Backend suite has no regressions vs. dev (the 12 vision-attachment/postgres failures pre-exist on `dev`)
- [ ] Live: trigger a run against a configured project and confirm an APPROVE verdict opens a PR against the pushed integration branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)