### PR TITLE
fix(manager-review): build review package in-session + scrub stale workspace state

### DIFF
--- a/agent/build_review_package.py
+++ b/agent/build_review_package.py
@@ -1,0 +1,72 @@
+"""CLI shim that calls :func:`station_orchestrator._ensure_review_package`.
+
+Why this exists: the lead spawns the manager sibling mid-session, but
+the orchestrator's post-session ``_ensure_review_package`` only runs
+*after* the lead session ends. On 2026-05-21 two LCM runs hit the
+resulting failure mode — the manager read ``run-<id>-review.md``,
+found no file, fell back to globbing the base workspace, and picked up
+last run's stale ``.claude-employee-report-*.json`` files.
+
+The lead now invokes this CLI via Bash immediately before spawning the
+manager. Iterating worktree paths at *that* moment captures the work
+the current run's teammates actually produced, and the resulting
+review package lands at the path the manager-paths sidecar already
+names. Both the in-session call and the existing post-session
+finally-block call use the same idempotent helper, so a second
+invocation is a cheap no-op when the file is already populated.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m agent.build_review_package",
+        description=(
+            "Compose the manager review package for the current run from "
+            "worktree employee reports + diff summaries. Idempotent: a "
+            "non-empty file at the target path is left untouched."
+        ),
+    )
+    parser.add_argument(
+        "--run-id", required=True,
+        help="Run id without the 'run-' prefix (e.g. 20260521T151955Z).",
+    )
+    parser.add_argument(
+        "--log-dir", required=True,
+        help="Directory where run-<id>-review.md will be written.",
+    )
+    parser.add_argument(
+        "--workspaces", required=True, nargs="+",
+        help="One or more worktree paths to scan for "
+             ".claude-employee-report-*.json files.",
+    )
+    parser.add_argument(
+        "--mode", default="full",
+        help="Project mode tag for the package header. Default: full.",
+    )
+    args = parser.parse_args(argv)
+
+    # Imported lazily so ``python -m agent.build_review_package --help`` is
+    # cheap and does not pull in the full SDK/asyncio stack.
+    from agent.station_orchestrator import _ensure_review_package
+
+    workspaces = [Path(p) for p in args.workspaces]
+    out = _ensure_review_package(
+        run_id=args.run_id,
+        log_dir=Path(args.log_dir),
+        workspaces=workspaces,
+        mode=args.mode,
+    )
+    # Print the absolute path so the lead can Bash-capture it and pass it
+    # forward without parsing prose.
+    print(str(out))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — module CLI entry
+    sys.exit(main())

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -993,13 +993,43 @@ doesn't satisfy every acceptance item.
     # the wrong write path.
     manager_section = ""
     if review_package_path and verdicts_file_path:
+        log_dir = os.path.dirname(review_package_path) or "."
+        # Worktree paths the lead must point the builder at. Quoted so
+        # paths with spaces (unlikely but possible) survive the shell.
+        worktree_arg_list = " ".join(
+            f"'{p}'" for p in (worktree_paths or {}).values()
+        )
+        if not worktree_arg_list:
+            # No worktrees → no real teammates. The builder still runs
+            # but produces a header-only file; the manager will see it
+            # and report no work to review rather than hallucinate.
+            worktree_arg_list = f"'{workspace}'"
         manager_section = f"""
 ## Manager review (spawn the manager sibling)
 
 After every teammate has emitted `.claude-employee-report-<index>.json` (or
 the 20-minute timeout elapses with whichever reports exist), you MUST:
 
-1. Spawn a `manager` sibling agent via the Agent tool. The manager is a
+1. **Build the review package first** — before spawning the manager — by
+   running this Bash command exactly once:
+
+   ```bash
+   python3 -m agent.build_review_package \\
+     --run-id '{run_id}' \\
+     --log-dir '{log_dir}' \\
+     --mode '{project_mode}' \\
+     --workspaces {worktree_arg_list}
+   ```
+
+   This concatenates each worktree's `.claude-employee-report-*.json` plus
+   a diff summary into the file the manager will read. The command is
+   idempotent and prints the absolute path on stdout. If you skip this
+   step the manager will find the review file missing, fall back to
+   reading whatever stale reports happen to sit in the workspace, and
+   write verdicts for the wrong run — that exact failure produced two
+   bad LCM runs on 2026-05-21.
+
+2. Spawn a `manager` sibling agent via the Agent tool. The manager is a
    separate Agent Teams sibling — same SDK session, separate role/prompt/model.
    The orchestrator has already written `.claude-manager-paths.json` to
    the workspace; the manager reads it on its first turn to discover where
@@ -1016,10 +1046,6 @@ the 20-minute timeout elapses with whichever reports exist), you MUST:
    on completeness — never approve partial implementations.
    ```
 
-2. The orchestrator (Python) composes the review package contents and
-   writes the sidecar before your turn began. If the sidecar is missing
-   or the manager reports a parse error, surface it in your final summary
-   and end the turn — do not guess paths.
 3. **Do NOT attempt to review the work yourself.** You are the orchestrator;
    the manager is the quality gate. Spawn the manager and wait for it to
    finish — when its turn ends, the verdicts file must exist and contain

--- a/agent/workspace_setup.py
+++ b/agent/workspace_setup.py
@@ -131,6 +131,50 @@ def _prune_stale_branches(
                                branch, del_result.stderr.strip()[:200])
 
 
+def _clean_stale_manager_state(workspace: Path) -> None:
+    """Delete prior-run manager-review state from the base workspace.
+
+    Removes ``.claude-employee-report-*.json`` (synthesized fallback
+    reports left behind by :func:`_synthesize_employee_report`) and
+    ``.claude-manager-paths.json`` (last run's sidecar).
+
+    Why this is load-bearing: the lead's prompt promises that the
+    orchestrator pre-writes the per-run review package, but historically
+    it only wrote the file *post-session*. When the manager spawned
+    mid-session, ``run-<run_id>-review.md`` was missing and the manager
+    fell back to globbing ``.claude-employee-report-*.json`` in CWD —
+    which is the base workspace, and which carries last run's
+    synthesized reports because the per-role worktrees are torn down at
+    run end while the base workspace persists.
+
+    On 2026-05-21 this fallback caused two LCM runs to emit verdicts
+    for the *previous* run's branches (``feature/issue-3-rest-api``,
+    etc.) while the current run worked on entirely different issues.
+
+    Belt-and-braces alongside the in-session ``build_review_package``
+    helper: even if the lead skips the pre-manager build, there is now
+    nothing stale on disk for the manager to mistake for current work.
+    Fresh worktree reports written during the current run live in the
+    worktree paths, not the base workspace, so cleanup here does not
+    touch live data.
+    """
+    patterns = (
+        ".claude-employee-report-*.json",
+        ".claude-employee-report.json",
+        ".claude-manager-paths.json",
+    )
+    for pattern in patterns:
+        for stale in workspace.glob(pattern):
+            try:
+                stale.unlink()
+                logger.info("workspace: removed stale %s", stale.name)
+            except OSError as exc:
+                logger.warning(
+                    "workspace: could not remove stale %s: %s",
+                    stale.name, exc,
+                )
+
+
 def ensure_workspace(project: dict, workspaces_dir: str) -> str:
     """Clone or refresh the project workspace. Returns the absolute path.
 
@@ -188,5 +232,10 @@ def ensure_workspace(project: dict, workspaces_dir: str) -> str:
         _prune_stale_branches(workspace, repo, base, env=None)
     except Exception:  # noqa: BLE001 — best-effort cleanup
         logger.exception("prune: _prune_stale_branches failed (non-fatal)")
+
+    # Cross-run staleness: delete prior-run manager state from the base
+    # workspace so the manager-sibling's mid-session fallback cannot read
+    # last run's reports. See ``_clean_stale_manager_state`` docstring.
+    _clean_stale_manager_state(workspace)
 
     return str(workspace)

--- a/dashboard/backend/tests/test_build_review_package_cli.py
+++ b/dashboard/backend/tests/test_build_review_package_cli.py
@@ -1,0 +1,96 @@
+"""Tests for the ``python -m agent.build_review_package`` CLI.
+
+The CLI exists so the lead can build the review package *before* it
+spawns the manager sibling. Without it, the manager read a missing
+review.md and silently picked up stale reports from a prior run — the
+2026-05-21 LCM bug. These tests pin the contract the lead's prompt
+depends on: given worktree paths, the CLI produces the same file the
+in-process post-session helper produces, and emits the absolute path
+on stdout so Bash can chain it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _seed_worktree(wt: Path, role: str, branch: str, issues: list[int]) -> None:
+    """Drop a minimal employee report into a worktree directory."""
+    wt.mkdir(parents=True, exist_ok=True)
+    (wt / f".claude-employee-report-{role}.json").write_text(
+        json.dumps({
+            "agent": role, "branch": branch, "issue_numbers": issues,
+            "status": "complete",
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_cli_writes_review_package_and_prints_path(
+    tmp_path: Path, capsys,
+):
+    """Happy path: three worktrees, three reports, one review.md."""
+    from agent import build_review_package
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    backend = tmp_path / "wt-backend"
+    frontend = tmp_path / "wt-frontend"
+    qa = tmp_path / "wt-qa"
+    _seed_worktree(backend, "backend", "feature/x", [1, 2])
+    _seed_worktree(frontend, "frontend", "feature/x-ui", [1])
+    _seed_worktree(qa, "qa", "feature/x-tests", [1, 2])
+
+    rc = build_review_package.main([
+        "--run-id", "20260521T151955Z",
+        "--log-dir", str(log_dir),
+        "--workspaces", str(backend), str(frontend), str(qa),
+    ])
+    out = capsys.readouterr().out.strip()
+
+    assert rc == 0
+    assert out == str(log_dir / "run-20260521T151955Z-review.md")
+    body = (log_dir / "run-20260521T151955Z-review.md").read_text()
+    assert "MODE: FULL" in body
+    assert "feature/x" in body
+    assert "feature/x-ui" in body
+    assert "feature/x-tests" in body
+
+
+def test_cli_is_idempotent_when_review_file_already_exists(
+    tmp_path: Path, capsys,
+):
+    """Second invocation must not overwrite an already-populated file —
+    matches the in-process helper's contract so the post-session
+    finally-block call stays a cheap no-op."""
+    from agent import build_review_package
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    target = log_dir / "run-XYZ-review.md"
+    target.write_text("USER_AUTHORED_CONTENT\n", encoding="utf-8")
+
+    wt = tmp_path / "wt"
+    _seed_worktree(wt, "backend", "feature/y", [3])
+
+    rc = build_review_package.main([
+        "--run-id", "XYZ", "--log-dir", str(log_dir),
+        "--workspaces", str(wt),
+    ])
+
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == str(target)
+    assert target.read_text() == "USER_AUTHORED_CONTENT\n"
+
+
+def test_cli_help_does_not_import_sdk(tmp_path: Path, capsys):
+    """``--help`` must be cheap. If a future refactor moves the heavy
+    SDK import to module scope, this test fails."""
+    from agent import build_review_package
+    import pytest
+
+    with pytest.raises(SystemExit) as excinfo:
+        build_review_package.main(["--help"])
+    assert excinfo.value.code == 0
+    assert "build_review_package" in capsys.readouterr().out

--- a/dashboard/backend/tests/test_manager_sibling.py
+++ b/dashboard/backend/tests/test_manager_sibling.py
@@ -131,6 +131,65 @@ def test_lead_prompt_instructs_lead_to_spawn_manager(tmp_path):
     )
 
 
+def test_lead_prompt_instructs_lead_to_build_review_package_before_spawn(tmp_path):
+    """The lead prompt MUST tell the lead to invoke
+    ``python -m agent.build_review_package`` before spawning the
+    manager. The previous wording claimed "the orchestrator (Python)
+    composes the review package... before your turn began", which was
+    false — the orchestrator only wrote the package post-session, so
+    the manager read an empty review and fell back to stale CWD globs.
+    Pin the new contract: the lead does the build itself, and the
+    Bash command names each worktree path so reports from this run
+    are what land in the file.
+    """
+    from agent.station_orchestrator import build_team_prompt
+
+    teammates = {
+        "backend": "/var/lib/claude-agent-station/workspaces/repo-backend",
+        "frontend": "/var/lib/claude-agent-station/workspaces/repo-frontend",
+        "qa": "/var/lib/claude-agent-station/workspaces/repo-qa",
+    }
+    prompt = build_team_prompt(
+        repo="owner/repo",
+        issues=[{"number": 1, "title": "t", "body": ""}],
+        config={"projects": []},
+        run_id="20260521T151955Z",
+        workspace="/var/lib/claude-agent-station/workspaces/repo",
+        worktree_paths=teammates,
+        review_package_path="/var/log/claude-agent/run-20260521T151955Z-review.md",
+        verdicts_file_path="/var/log/claude-agent/run-20260521T151955Z-verdicts.json",
+        manager_max_turns=60,
+    )
+
+    # The Bash command must appear before the spawn-prompt block so the
+    # lead runs it first.
+    build_idx = prompt.find("python3 -m agent.build_review_package")
+    spawn_idx = prompt.find("Pass this spawn prompt verbatim:")
+    assert build_idx != -1, "lead prompt missing build_review_package invocation"
+    assert spawn_idx != -1, "lead prompt missing manager spawn block"
+    assert build_idx < spawn_idx, (
+        "build_review_package must be invoked BEFORE the manager is spawned "
+        "or the manager will read an empty review.md and fall back to stale state"
+    )
+
+    # Both run-id and log-dir must be interpolated correctly.
+    assert "--run-id '20260521T151955Z'" in prompt
+    assert "--log-dir '/var/log/claude-agent'" in prompt
+
+    # All three worktree paths must be passed so the package reflects
+    # the *current* run's reports — the bug the fix is preventing.
+    for path in teammates.values():
+        assert f"'{path}'" in prompt, (
+            f"lead prompt must pass worktree {path} to build_review_package"
+        )
+
+    # The deprecated false promise must NOT remain in the prompt.
+    assert "orchestrator (Python) composes the review package" not in prompt, (
+        "old prompt wording lied about orchestrator pre-writing the package; "
+        "remove it so the lead actually runs build_review_package itself"
+    )
+
+
 def test_orchestrator_builds_review_package_before_manager_spawn(tmp_path, monkeypatch):
     """The orchestrator must produce the review package file before the
     lead's session is asked to spawn the manager. We don't run a live

--- a/dashboard/backend/tests/test_workspace_stale_cleanup.py
+++ b/dashboard/backend/tests/test_workspace_stale_cleanup.py
@@ -1,0 +1,102 @@
+"""Tests for the cross-run stale-state cleanup in workspace_setup.
+
+Background: the base workspace (``/var/lib/.../workspaces/<repo>``)
+persists between runs while per-role worktrees are torn down post-run.
+``_synthesize_employee_report`` writes role-named report files into
+*the base workspace*, so prior-run reports sit there indefinitely. The
+manager-sibling's mid-session fallback (when the per-run review.md
+doesn't exist yet) used to glob those files and produce verdicts for
+the wrong run. These tests pin the new behavior: every run start
+deletes the prior-run state so the fallback path can't see it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _touch(p: Path, content: str = "{}") -> None:
+    p.write_text(content, encoding="utf-8")
+
+
+def test_clean_stale_manager_state_removes_known_files(tmp_path: Path):
+    """Synthesized reports, the sidecar, and the legacy single-file
+    report must all be deleted."""
+    from agent.workspace_setup import _clean_stale_manager_state
+
+    _touch(tmp_path / ".claude-employee-report-backend.json", '{"branch": "stale"}')
+    _touch(tmp_path / ".claude-employee-report-frontend.json")
+    _touch(tmp_path / ".claude-employee-report-qa.json")
+    _touch(tmp_path / ".claude-employee-report-0.json")
+    _touch(tmp_path / ".claude-employee-report.json")  # legacy single-file form
+    _touch(tmp_path / ".claude-manager-paths.json", '{"verdicts_file": "old"}')
+
+    _clean_stale_manager_state(tmp_path)
+
+    leftovers = sorted(p.name for p in tmp_path.iterdir())
+    assert leftovers == [], f"expected empty workspace, got {leftovers}"
+
+
+def test_clean_stale_manager_state_preserves_unrelated_files(tmp_path: Path):
+    """Source files, lockfiles, and other dotfiles must not be touched —
+    only the manager-review state files."""
+    from agent.workspace_setup import _clean_stale_manager_state
+
+    _touch(tmp_path / "README.md", "# hi")
+    _touch(tmp_path / ".gitignore", "node_modules/")
+    _touch(tmp_path / ".claude-team-contracts.md", "# contracts")
+    _touch(tmp_path / ".claude-run-mode", "full")
+    _touch(tmp_path / ".claude-employee-report-backend.json", '{"branch": "stale"}')
+
+    _clean_stale_manager_state(tmp_path)
+
+    leftovers = sorted(p.name for p in tmp_path.iterdir())
+    assert leftovers == [
+        ".claude-run-mode",
+        ".claude-team-contracts.md",
+        ".gitignore",
+        "README.md",
+    ]
+
+
+def test_clean_stale_manager_state_no_op_on_empty_workspace(tmp_path: Path):
+    """Running on a fresh workspace must not raise or create anything."""
+    from agent.workspace_setup import _clean_stale_manager_state
+
+    _clean_stale_manager_state(tmp_path)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_clean_stale_manager_state_survives_unlink_error(
+    tmp_path: Path, monkeypatch, caplog,
+):
+    """A locked or read-only file must produce a WARNING and let the
+    cleanup continue — never raise into the orchestrator."""
+    from agent import workspace_setup
+
+    _touch(tmp_path / ".claude-employee-report-backend.json")
+    _touch(tmp_path / ".claude-employee-report-frontend.json")
+
+    real_unlink = Path.unlink
+    calls: list[Path] = []
+
+    def _raising_unlink(self, *args, **kwargs):  # noqa: ANN001
+        calls.append(self)
+        if "backend" in self.name:
+            raise OSError("permission denied")
+        return real_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _raising_unlink)
+
+    with caplog.at_level("WARNING", logger="agent.workspace_setup"):
+        workspace_setup._clean_stale_manager_state(tmp_path)
+
+    # Both files were attempted; the frontend one succeeded.
+    assert len(calls) == 2
+    assert (tmp_path / ".claude-employee-report-frontend.json").exists() is False
+    # The failed unlink was logged.
+    assert any(
+        "could not remove stale" in rec.message
+        and "backend" in rec.message
+        for rec in caplog.records
+    )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -354,6 +354,31 @@ unparseable the manager refuses to guess paths — the orchestrator's
 `manager_no_verdicts` webhook + `exit_code=6` path then fires and surfaces
 the failure for triage.
 
+#### Review-package build (in-session, before manager spawn)
+
+The lead's prompt instructs it to run
+`python3 -m agent.build_review_package` via Bash **before** spawning the
+manager. The CLI concatenates each worktree's
+`.claude-employee-report-*.json` plus a `git diff --stat` summary into
+the `review_package` path the sidecar names. The same helper
+(`_ensure_review_package`) runs again in the orchestrator's per-project
+`finally` block as a belt-and-braces fallback — it is idempotent, so the
+second invocation is a no-op when the file already exists.
+
+Why the build is now an in-session step instead of an orchestrator
+pre-write: prior to this change the prompt told the lead "the
+orchestrator already wrote the review package", but the orchestrator's
+write only happened post-session. The manager spawned mid-session,
+found the review file missing, and fell back to globbing
+`.claude-employee-report-*.json` in its CWD — the base workspace, which
+carries the previous run's synthesized reports from
+`_synthesize_employee_report`. Two LCM runs on 2026-05-21 produced
+verdicts for the *previous* run's branches as a result. The combined
+fix is the in-session build (this section) plus
+`workspace_setup._clean_stale_manager_state`, which deletes prior-run
+`.claude-employee-report-*.json` and `.claude-manager-paths.json` at
+workspace setup so the fallback path has no stale data to find.
+
 See `_write_manager_paths_sidecar` in `agent/station_orchestrator.py` and
 the `# --- #411` test block in
 `dashboard/backend/tests/test_manager_sibling.py`.


### PR DESCRIPTION
## Summary

Fixes the stale-verdicts failure from the 2026-05-21 LCM runs (companion to #470). Two LCM runs emitted verdicts for the *previous* run's branches while actually working on different issues — root cause was a cascade:

- The lead prompt told the lead "the orchestrator (Python) composes the review package... before your turn began", but \`_ensure_review_package\` only ran post-session (per-project \`finally\` block). The manager spawned mid-session and read a missing review file.
- With review.md missing, the manager-sibling's CWD glob fallback picked up \`.claude-employee-report-*.json\` from the base workspace.
- The base workspace persists between runs and carries last run's reports synthesized by \`_synthesize_employee_report\`, so the fallback returned stale data and produced wrong-branch verdicts.

Confirmed by file timestamps (run 2 verdicts written 15:42:28, review.md written 15:47:02 — 4m34s later in the finally block) and the lead's own session output: *"The orchestrator did not generate a review package... for this run, so the manager evaluated the previous run's context."*

## Fixes

1. **In-session build.** New \`python -m agent.build_review_package\` CLI wraps \`_ensure_review_package\`. The lead prompt now runs it via Bash, pointing at this run's worktree paths, immediately before the manager Task spawn. The post-session finally-block call stays as a safety net (idempotent helper). Deprecated the false "orchestrator already wrote it" wording.

2. **Stale-state scrub.** \`workspace_setup.ensure_workspace\` now deletes prior-run \`.claude-employee-report-*.json\` and \`.claude-manager-paths.json\` from the base workspace before any teammates start. Even if the lead skips step 1, the manager's fallback path has no stale reports to mistake for current work.

## Test plan
- [x] \`pytest test_build_review_package_cli.py\` — CLI happy path / idempotency / cheap-import contract
- [x] \`pytest test_workspace_stale_cleanup.py\` — known stale files removed; unrelated files preserved; unlink errors logged not raised
- [x] \`pytest test_manager_sibling.py\` — new pin that the lead prompt invokes the builder before the spawn block and embeds each worktree path; 22/22 existing pass
- [x] Broader related suite (179 tests across manager-sibling, orchestrator-wiring, verdict-execution, project-loop, workspace-cleanup, build-cli) all green
- [ ] Live: trigger a run and verify \`run-<id>-review.md\` exists *before* the manager writes verdicts (timestamps in \`/var/log/claude-agent/\`)

## Related

Stacked on #470 (silent-failure surfacing + repo-slug override + integration base push). Together these prevent both the "no PRs at all" and "PRs for the wrong branches" failure modes from the same 2026-05-21 LCM incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)