### PR TITLE
fix(branches): reject worktree-isolation refs across teammate, manager, executor

### DIFF
--- a/agent/agents/issue-worker.md
+++ b/agent/agents/issue-worker.md
@@ -50,10 +50,16 @@ This narration is streamed to the operator's Bridge in real time. Never skip it.
 ### Step 0: Set Up Your Worktree
 1. `cd` into the worktree path provided in your spawn prompt. This is MANDATORY.
 2. Check if `CLAUDE.md` or `.claude/CLAUDE.md` exists. If so, **read it fully** and follow all conventions.
-3. Set up the base branch:
-   - `git fetch origin`
-   - If `autonomous/dev` exists on remote: `git checkout autonomous/dev && git pull`
-   - If not: `git checkout -b autonomous/dev`
+3. Verify the worktree's pre-set branch (do NOT change it):
+   - The orchestrator has already created this worktree on a private isolation branch
+     named `worktree/<role>-<run_id_prefix>` (e.g. `worktree/backend-20260521`), branched
+     from the project's integration branch. Do **NOT** `git checkout` a different branch
+     here — that defeats the worktree isolation and may conflict with another teammate.
+   - Confirm with `git branch --show-current`. The output MUST start with `worktree/`.
+     If it does not, STOP and message the lead — your worktree was set up incorrectly
+     and pushing later will fail.
+   - Do **NOT** run `git pull`, `git fetch`, or any branch-switching command here. The
+     orchestrator already fetched origin and pinned the worktree to the right base.
 
 ### Step 1: Claim and Understand Your Tasks
 1. Review the shared task list for tasks matching your specialization.
@@ -127,11 +133,30 @@ any source file was modified — you may produce a plan-quality output but
 must stay read-only.
 
 ### Step 4: Implement
-1. Create feature branch: `git checkout -b autonomous/issue-<number>`
+
+**Precondition:** you are currently on the worktree-private branch
+`worktree/<role>-<run_id_prefix>` (verified in Step 0.3). That branch is an
+isolation primitive, **not the deliverable**. Before any code change, branch off
+it onto a real feature branch.
+
+1. **Create the feature branch on top of the worktree branch** — pick the name
+   from CLAUDE.md's convention, falling back to `autonomous/issue-<number>`:
+   ```bash
+   git checkout -b autonomous/issue-<number>
+   # or, if CLAUDE.md prefers feature/<description>:
+   # git checkout -b feature/issue-<number>-<slug>
+   ```
 2. Implement changes following your plan.
 3. Write or update tests as appropriate.
 4. Run the project's linter and test suite.
 5. Fix any failures before committing.
+
+**HARD RULE — never commit on a `worktree/...` branch.** If you forgot Step 4.1
+and made a commit already, do not push. Instead: `git checkout -b
+autonomous/issue-<number>` (which carries your commits onto the new branch),
+verify with `git log --oneline -3`, then continue. The manager will reject any
+verdict whose branch matches `worktree/<role>-<run_id_prefix>` because such a
+ref exists only inside this worktree and cannot be pushed to origin.
 
 ### Step 5: Commit, Push & Report
 1. Stage and commit with conventional format: `feat|fix|refactor(scope): description`

--- a/agent/agents/manager.md
+++ b/agent/agents/manager.md
@@ -119,6 +119,20 @@ For each employee's work, evaluate these criteria in order:
 - No changes to deployment config, CI/CD, or infrastructure.
 - No dependency changes that could introduce vulnerabilities.
 
+#### 6. Branch hygiene (HARD reject)
+- The employee report's `"branch"` field MUST NOT match
+  `worktree/<role>-<run_id_prefix>` (e.g. `worktree/backend-20260521`).
+  Those are the orchestrator's per-role isolation branches — they exist
+  only inside the worktree checkout and cannot be pushed to origin.
+- If the reported branch matches that pattern, REJECT immediately with
+  reason `BRANCH_ISOLATION_LEAK`. Tell the employee to re-run on a
+  proper feature branch:
+  `git checkout -b autonomous/issue-<number>` (or `feature/issue-<number>`
+  per the project's CLAUDE.md), carrying the commits forward.
+- This is non-negotiable. The verdict executor refuses to push these
+  branches; approving anyway just produces an ERROR row in the digest
+  instead of a PR.
+
 ### Analyze Mode Review
 
 **Analyst agents read code and create/refine GitHub issues but make NO code changes. There will be NO branch, NO diff, NO commits — this is correct and expected.**

--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -55,6 +55,38 @@ VerdictKind = Literal[
 ]
 
 
+# The orchestrator creates one worktree per role on a private branch named
+# ``worktree/<role>-<run_id_prefix>`` (see
+# ``station_orchestrator.py`` ``git worktree add -b``). These branches are
+# isolation primitives — teammates are expected to ``git checkout -b`` a
+# feature branch on top before committing. When teammates skip that step
+# the manager echoes the worktree branch into the verdict, and pushing it
+# from the base workspace fails with a confusing "src refspec does not
+# match any" because the branch lives only inside the worktree's checkout.
+#
+# Reject such verdicts up-front with a clear cause so operators don't
+# have to decode the push stderr to understand what happened. The check
+# is conservative: it only catches the orchestrator's own naming
+# convention, which matches ``worktree/<role>-<8 hex chars>``.
+_WORKTREE_BRANCH_RE = re.compile(r"^worktree/[a-z]+-[0-9a-fA-F]{4,}$")
+
+
+def _is_worktree_isolation_branch(branch: str) -> bool:
+    """Return True iff ``branch`` matches the orchestrator's per-role
+    worktree-isolation naming. Used by every push-capable executor to
+    refuse pushes that would 404 against origin."""
+    return bool(_WORKTREE_BRANCH_RE.match(branch or ""))
+
+
+_WORKTREE_BRANCH_ERROR = (
+    "branch '{branch}' is the worktree's private isolation ref "
+    "(orchestrator-created via ``git worktree add -b``). Teammates must "
+    "``git checkout -b <feature-branch>`` before committing; pushing this "
+    "ref from the base workspace would 404. Reject the verdict so the "
+    "teammate re-runs on a proper feature branch."
+)
+
+
 @dataclass
 class Verdict:
     """Parsed verdict from the manager's verdicts JSON. Mirrors the
@@ -148,6 +180,11 @@ def execute_approve(
         success=False,
     )
 
+    # 0. Safety net: refuse to push worktree-isolation branches.
+    if _is_worktree_isolation_branch(verdict.branch):
+        result.error = _WORKTREE_BRANCH_ERROR.format(branch=verdict.branch)
+        return result
+
     # 1. git push origin <branch>
     push = subprocess.run(
         ["git", "push", "-u", "origin", verdict.branch],
@@ -210,6 +247,10 @@ def execute_pr(
         issue_number=verdict.issue_number,
         success=False,
     )
+
+    if _is_worktree_isolation_branch(verdict.branch):
+        result.error = _WORKTREE_BRANCH_ERROR.format(branch=verdict.branch)
+        return result
 
     push = subprocess.run(
         ["git", "push", "-u", "origin", verdict.branch],
@@ -354,6 +395,10 @@ def execute_approve_integration(
         issue_number=verdict.issue_number,
         success=False,
     )
+
+    if _is_worktree_isolation_branch(verdict.branch):
+        result.error = _WORKTREE_BRANCH_ERROR.format(branch=verdict.branch)
+        return result
 
     # 1. git push -u origin <branch>
     push = subprocess.run(

--- a/dashboard/backend/tests/test_verdict_worktree_branch_safety.py
+++ b/dashboard/backend/tests/test_verdict_worktree_branch_safety.py
@@ -1,0 +1,141 @@
+"""Tests for the worktree-isolation-branch safety net in
+:mod:`agent.verdict_execution`.
+
+Background: the orchestrator creates one worktree per teammate role on a
+private branch named ``worktree/<role>-<run_id_prefix>``. Those branches
+exist only inside the per-role worktree checkout — pushing them from the
+base workspace fails with a confusing ``src refspec does not match any``.
+The 2026-05-21 run-20260521T175359Z hit this when teammates skipped
+``git checkout -b <feature-branch>`` and committed straight on the
+worktree branch.
+
+These tests pin the helper that refuses such verdicts up-front with a
+clear error string instead of letting them flow through to the
+opaque-git-error path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def _verdict(branch: str, kind: str = "APPROVE"):
+    from agent.verdict_execution import Verdict
+
+    return Verdict(
+        project="owner/repo",
+        issue_number=42,
+        verdict=kind,
+        branch=branch,
+        base_branch="claude-agent-station",
+        reasoning="ok",
+        mode="full",
+    )
+
+
+# ── _is_worktree_isolation_branch ──────────────────────────────────────
+
+
+@pytest.mark.parametrize("branch", [
+    "worktree/backend-20260521",
+    "worktree/frontend-20260521",
+    "worktree/qa-20260521",
+    "worktree/backend-abcdef12",
+    "worktree/qa-12345678",
+])
+def test_detects_orchestrator_worktree_branches(branch):
+    from agent.verdict_execution import _is_worktree_isolation_branch
+
+    assert _is_worktree_isolation_branch(branch) is True
+
+
+@pytest.mark.parametrize("branch", [
+    "autonomous/issue-42",
+    "feature/issue-3-rest-api",
+    "fix/login-bug",
+    "main",
+    "claude-agent-station",
+    "worktree/notaroleshape",          # missing dash + id segment
+    "feature/worktree-isolation",      # not in worktree/ namespace
+    "worktree/backend-",               # trailing-empty id
+    "",
+])
+def test_does_not_flag_normal_branches(branch):
+    from agent.verdict_execution import _is_worktree_isolation_branch
+
+    assert _is_worktree_isolation_branch(branch) is False
+
+
+# ── execute_approve / execute_pr / execute_approve_integration ─────────
+
+
+def test_execute_approve_refuses_worktree_branch_without_calling_git(tmp_path):
+    """APPROVE on a worktree-isolation branch must fail fast with the
+    canonical error message and never invoke git or gh."""
+    from agent.verdict_execution import execute
+
+    v = _verdict("worktree/backend-20260521", "APPROVE")
+    with patch("agent.verdict_execution.subprocess.run") as mock_sp, \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        result = execute(v, workspace=tmp_path)
+
+    assert result.success is False
+    assert "worktree" in (result.error or "").lower()
+    assert "isolation" in (result.error or "").lower()
+    assert "worktree/backend-20260521" in (result.error or "")
+    mock_sp.assert_not_called()
+    mock_gh.assert_not_called()
+
+
+def test_execute_pr_refuses_worktree_branch_without_calling_git(tmp_path):
+    """Same guarantee for PR (draft) verdicts."""
+    from agent.verdict_execution import execute
+
+    v = _verdict("worktree/frontend-20260521", "PR")
+    with patch("agent.verdict_execution.subprocess.run") as mock_sp, \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        result = execute(v, workspace=tmp_path)
+
+    assert result.success is False
+    assert "worktree/frontend-20260521" in (result.error or "")
+    mock_sp.assert_not_called()
+    mock_gh.assert_not_called()
+
+
+def test_execute_approve_integration_refuses_worktree_branch(tmp_path):
+    """APPROVE_INTEGRATION pushes against the dev branch with auto-merge
+    armed — same isolation check applies before the push."""
+    from agent.verdict_execution import execute
+
+    v = _verdict("worktree/qa-20260521", "APPROVE_INTEGRATION")
+    with patch("agent.verdict_execution.subprocess.run") as mock_sp, \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        result = execute(v, workspace=tmp_path, dev_branch="claude-agent-station")
+
+    assert result.success is False
+    assert "worktree/qa-20260521" in (result.error or "")
+    mock_sp.assert_not_called()
+    mock_gh.assert_not_called()
+
+
+def test_execute_approve_still_pushes_normal_branches(tmp_path):
+    """Sanity: the safety net must not block legitimate feature branches.
+    Mirrors the existing happy-path test in test_verdict_execution.py."""
+    from agent.verdict_execution import execute
+    from agent.gh_client import GhResult
+
+    ok_sp = MagicMock(returncode=0, stdout="", stderr="")
+    ok_gh = GhResult(cmd=["gh"], returncode=0, stdout="https://x/pr/1", stderr="")
+
+    with patch("agent.verdict_execution.subprocess.run", return_value=ok_sp), \
+         patch("agent.verdict_execution.gh_run",
+               return_value=ok_gh) as mock_gh:
+        result = execute(_verdict("autonomous/issue-42", "APPROVE"),
+                         workspace=tmp_path)
+
+    assert result.success is True
+    # First gh call is pr create — confirms the safety net did NOT short-circuit.
+    assert mock_gh.call_args_list[0].args[0][:2] == ["pr", "create"]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -383,6 +383,40 @@ See `_write_manager_paths_sidecar` in `agent/station_orchestrator.py` and
 the `# --- #411` test block in
 `dashboard/backend/tests/test_manager_sibling.py`.
 
+#### Branch hygiene (worktree-isolation safety net)
+
+The orchestrator creates each per-role worktree on a private isolation
+branch named `worktree/<role>-<run_id_prefix>` (e.g.
+`worktree/backend-20260521`) via `git worktree add -b`. That branch is
+an isolation primitive — it lives only inside the worktree's checkout
+and cannot be pushed to origin from the base workspace. Teammates are
+expected to `git checkout -b autonomous/issue-<n>` (or
+`feature/issue-<n>` per the project's `CLAUDE.md`) before committing,
+so the verdict carries a real feature branch name.
+
+Three layers enforce this:
+
+1. **`agent/agents/issue-worker.md` Step 0/Step 4** — teammates verify the
+   pre-set worktree branch with `git branch --show-current`, then
+   create a feature branch on top before any commit. The prompt also
+   carries an explicit "HARD RULE — never commit on a `worktree/...`
+   branch" with the recovery path.
+2. **`agent/agents/manager.md` §6 Branch hygiene** — manager hard-rejects
+   any verdict whose `branch` matches `worktree/<role>-<run_id_prefix>`
+   with reason `BRANCH_ISOLATION_LEAK`.
+3. **`agent/verdict_execution._is_worktree_isolation_branch`** — the
+   `execute_approve`, `execute_pr`, and `execute_approve_integration`
+   executors refuse to push such branches and return
+   `ExecutionResult(success=False)` with a structured error. Pairs with
+   the silent-failure surfacing in `_execute_one_verdict` so the run
+   row flips to `failed` with the cause instead of the opaque
+   `src refspec does not match any` git error.
+
+The 2026-05-21 run-20260521T175359Z hit this without the safety net:
+teammates committed straight on `worktree/<role>-20260521`, the manager
+echoed those branches into the verdict, and three pushes failed at
+verdict execution time.
+
 ### Sibling-teammate coordination (#456)
 
 The lead agent writes `.claude-team-contracts.md` to the workspace


### PR DESCRIPTION
## Summary

Plugs the workflow gap exposed by run-20260521T175359Z. Teammates committed straight on the orchestrator's per-role worktree-isolation branch (\`worktree/<role>-<run_id_prefix>\`); the manager dutifully echoed those branch names into APPROVE verdicts; \`git push\` then failed with an opaque \`src refspec does not match any\` from the base workspace, because that branch only exists inside the worktree checkout.

Three reinforcing layers plus a hard safety net.

## Fixes

1. **\`agent/agents/issue-worker.md\` Step 0.3** — replace the obsolete \"checkout autonomous/dev\" block with a verification that the pre-set worktree branch starts with \`worktree/\`. Teammates no longer get told to switch off it.

2. **\`agent/agents/issue-worker.md\` Step 4** — open with the precondition that the current branch is the isolation primitive, mandate \`git checkout -b <feature>\` before any code change, and add a HARD RULE plus recovery path for accidental commits on the wrong branch.

3. **\`agent/agents/manager.md\` §6 Branch hygiene** — hard-reject any verdict whose \`branch\` matches \`worktree/<role>-<run_id_prefix>\`, citing reason \`BRANCH_ISOLATION_LEAK\`.

4. **Safety net:** \`_is_worktree_isolation_branch\` short-circuits \`execute_approve\`, \`execute_pr\`, and \`execute_approve_integration\` before any git/gh call. Pairs with the silent-failure surfacing in \`_execute_one_verdict\` (PR #470) so the run row flips to \`failed\` with the cause attached.

## Test plan
- [x] \`pytest test_verdict_worktree_branch_safety.py\` — 18 new tests: pattern matcher (5 positive, 8 negative), executor short-circuit (3), sanity (1), legit feature branches still push
- [x] Broader related suite (175 tests across verdict-execution, manager-sibling, orchestrator-wiring, project-loop) all green
- [ ] Live: re-run the LCM run and confirm verdicts now carry \`autonomous/issue-<n>\` (or \`feature/issue-<n>\`) and PRs open

## Related

Stacks on #470 (silent-failure surfacing) and #471 (review-package timing + stale scrub). Together these close every failure mode we observed in the 2026-05-21 incidents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)