### PR TITLE
fix(workspace): unify orchestrator and verdict-executor workspace paths

### DIFF
--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -366,6 +366,16 @@ def iterate_projects(
                 orchestrate_project(
                     project, config, run_id, workspaces_dir,
                     prior_verdicts_summary=prior_summary,
+                    # Single source of truth for the workspace path:
+                    # ``ensure_workspace`` already resolved it above via
+                    # ``_slug(repo)`` and cloned/refreshed the tree.
+                    # Without passing it through, ``orchestrate_project``
+                    # falls back to a bare-repo-name derivation
+                    # (``LCM`` vs ``laboef1900__LCM``) and the SDK
+                    # session, its worktrees, and verdict execution end
+                    # up on different filesystem clones. See
+                    # run-20260521T192218Z post-mortem.
+                    workspace_path=workspace_path,
                 )
             )
             if proj_state is not None:

--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -2213,6 +2213,7 @@ async def orchestrate_project(
     project: dict, config: dict, run_id: str, workspaces_dir: str,
     *,
     prior_verdicts_summary: str | None = None,
+    workspace_path: str | None = None,
 ) -> tuple[int, "_StreamState | None", bool]:
     """Run the Agent Teams session for a single project.
 
@@ -2226,6 +2227,19 @@ async def orchestrate_project(
       failure signals (manager_no_verdicts, exit_code bumps) are preserved.
       Idle-run-semantics discriminator — see #446 / #447 / spec
       ``docs/superpowers/specs/2026-05-17-idle-run-semantics-design.md``.
+
+    ``workspace_path`` is the absolute path to the per-project working tree.
+    Callers — ``iterate_projects`` in particular — compute this via
+    ``ensure_workspace`` (which uses ``_slug(repo)``) and pass it in so the
+    SDK session, the worktrees it creates, and the post-session verdict
+    executor all operate on the same filesystem path. If ``None``, the path
+    falls back to a deprecated bare-repo-name derivation kept only for
+    direct callers that still drive this function without first invoking
+    ``ensure_workspace``; mixing the two paths produced the 2026-05-21
+    run-20260521T192218Z failure where teammates committed in
+    ``workspaces/LCM/<role>`` worktrees while verdict execution pushed
+    from a separate ``workspaces/laboef1900__LCM`` clone, hence
+    ``src refspec does not match any``.
 
     Extracted from orchestrate() in #383 so iterate_projects (Python-only)
     can drive per-project work directly without delegating the outer loop
@@ -2287,7 +2301,28 @@ async def orchestrate_project(
     if True:  # single-project body (formerly the `for project in enabled_projects:` loop body) noqa
         repo = project["repo"]
         repo_name = repo.split("/")[-1] if "/" in repo else repo
-        workspace = os.path.join(workspaces_dir, repo_name)
+        if workspace_path is not None:
+            # Caller (iterate_projects) already resolved the path via
+            # ensure_workspace → _slug(repo). Use it verbatim so the SDK
+            # session, the worktrees, and verdict execution all share one
+            # working tree on disk.
+            workspace = workspace_path
+        else:
+            # Deprecated fallback for direct callers that don't first
+            # invoke ensure_workspace. Kept only so external tooling that
+            # imports orchestrate_project directly doesn't break — the
+            # production driver always supplies workspace_path. Mixing
+            # this fallback with ensure_workspace produced the
+            # workspaces/LCM vs workspaces/laboef1900__LCM split that
+            # caused run-20260521T192218Z to ERROR on every push.
+            logger.warning(
+                "orchestrate_project called without workspace_path; "
+                "falling back to bare repo_name derivation for %s. "
+                "Production callers should pass workspace_path from "
+                "ensure_workspace.",
+                repo,
+            )
+            workspace = os.path.join(workspaces_dir, repo_name)
         project_branch = project.get("branch") or "main"
 
         # Refresh the workspace to the tip of the project's default branch

--- a/dashboard/backend/tests/test_workspace_path_unification.py
+++ b/dashboard/backend/tests/test_workspace_path_unification.py
@@ -1,0 +1,170 @@
+"""Tests for the workspace-path unification in
+:func:`agent.station_orchestrator.orchestrate_project`.
+
+Background: before this change, ``orchestrate_project`` derived the
+workspace path from ``repo.split('/')[-1]`` (the bare repo name, e.g.
+``LCM``) while ``project_loop.iterate_projects`` independently resolved
+it via ``ensure_workspace`` which uses ``_slug(repo)`` (e.g.
+``laboef1900__LCM``). The two paths pointed at *different clones on
+disk*: teammates committed their feature branches in the bare-name
+clone's worktrees, but ``execute_verdict`` then ran ``git push`` from
+the slug-name clone — which had no such branches and failed with
+``src refspec does not match any``. Run-20260521T192218Z hit this on
+every verdict.
+
+The fix makes ``iterate_projects`` pass its already-resolved
+``workspace_path`` through to ``orchestrate_project`` so both halves
+of the run share one working tree.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_orchestrate_project_accepts_workspace_path_kwarg():
+    """The signature must accept ``workspace_path`` as a keyword arg
+    so callers can pin the path explicitly."""
+    from agent.station_orchestrator import orchestrate_project
+
+    sig = inspect.signature(orchestrate_project)
+    assert "workspace_path" in sig.parameters, (
+        "orchestrate_project must accept workspace_path so the caller "
+        "can keep the SDK session and verdict execution on one path"
+    )
+    param = sig.parameters["workspace_path"]
+    assert param.kind == inspect.Parameter.KEYWORD_ONLY
+    assert param.default is None
+
+
+def test_iterate_projects_passes_resolved_workspace_path():
+    """``iterate_projects`` must forward the ``ensure_workspace`` result
+    into ``orchestrate_project`` as ``workspace_path``. Without this the
+    two halves of the run resolve to different filesystem paths."""
+    import textwrap
+    from agent import project_loop
+
+    src = inspect.getsource(project_loop.iterate_projects)
+    # Trim leading indentation so the assertions are about lexical
+    # ordering, not column alignment.
+    src = textwrap.dedent(src)
+
+    # ``workspace_path`` is assigned from ``ensure_workspace`` and then
+    # passed as a kwarg into ``orchestrate_project``.
+    assert "workspace_path = ensure_workspace(" in src
+    assert "workspace_path=workspace_path" in src
+
+
+def test_orchestrate_project_uses_supplied_path_not_repo_name(
+    tmp_path, monkeypatch,
+):
+    """When workspace_path is supplied, the function MUST use it verbatim
+    — not re-derive from ``repo.split('/')[-1]``. Stub ``_ensure_workspace``
+    (the first function called after path selection) and inspect the
+    path argument it receives."""
+    from agent import station_orchestrator as so
+
+    seen: dict = {}
+
+    def _spy(workspace, repo, branch):  # noqa: ANN001
+        seen["workspace"] = workspace
+        seen["repo"] = repo
+        # Raise to short-circuit the rest of orchestrate_project.
+        raise RuntimeError("stop-here")
+
+    monkeypatch.setattr(so, "_ensure_workspace", _spy)
+
+    project = {"repo": "laboef1900/LCM", "branch": "main"}
+    supplied = str(tmp_path / "explicit_slug" / "laboef1900__LCM")
+
+    try:
+        import asyncio
+        asyncio.run(so.orchestrate_project(
+            project, config={}, run_id="t",
+            workspaces_dir=str(tmp_path / "wsdir"),
+            workspace_path=supplied,
+        ))
+    except Exception:
+        pass
+
+    assert seen.get("workspace") == supplied, (
+        f"orchestrate_project must hand the supplied workspace_path "
+        f"to _ensure_workspace; got {seen.get('workspace')!r} "
+        f"(expected {supplied!r})"
+    )
+    # Sanity: this is the right repo so we know the spy actually fired.
+    assert seen.get("repo") == "laboef1900/LCM"
+
+
+def test_orchestrate_project_falls_back_to_repo_name_when_path_missing(
+    tmp_path, monkeypatch,
+):
+    """Without ``workspace_path``, the deprecated derivation must still
+    work — but with the WARNING (asserted in the next test). Pin the
+    derivation shape so future refactors don't silently switch to
+    ``_slug``."""
+    from agent import station_orchestrator as so
+
+    seen: dict = {}
+
+    def _spy(workspace, repo, branch):  # noqa: ANN001
+        seen["workspace"] = workspace
+        raise RuntimeError("stop-here")
+
+    monkeypatch.setattr(so, "_ensure_workspace", _spy)
+
+    project = {"repo": "laboef1900/LCM", "branch": "main"}
+    wsdir = str(tmp_path / "wsdir")
+
+    try:
+        import asyncio
+        asyncio.run(so.orchestrate_project(
+            project, config={}, run_id="t", workspaces_dir=wsdir,
+        ))
+    except Exception:
+        pass
+
+    import os
+    assert seen.get("workspace") == os.path.join(wsdir, "LCM"), (
+        "without workspace_path, fallback must use bare repo_name "
+        "for backward compatibility"
+    )
+
+
+def test_orchestrate_project_warns_when_workspace_path_missing(
+    monkeypatch, caplog,
+):
+    """The bare-repo-name fallback is deprecated — calling without
+    ``workspace_path`` must emit a WARNING so tooling that hasn't been
+    migrated is visible in logs."""
+    from agent import station_orchestrator as so
+
+    # Same short-circuit trick as the previous test.
+    original_run = so.subprocess.run
+
+    def _capture(cmd, *args, **kwargs):  # noqa: ANN001
+        if "fetch" in (cmd if isinstance(cmd, list) else []):
+            raise RuntimeError("stop-here")
+        return original_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(so.subprocess, "run", _capture)
+
+    project = {"repo": "laboef1900/LCM", "branch": "main"}
+
+    try:
+        import asyncio
+        with caplog.at_level("WARNING", logger="agent.station_orchestrator"):
+            asyncio.run(so.orchestrate_project(
+                project, config={}, run_id="t",
+                workspaces_dir="/tmp/x",
+            ))
+    except Exception:
+        pass
+
+    assert any(
+        "without workspace_path" in rec.message
+        and "laboef1900/LCM" in rec.message
+        for rec in caplog.records
+    ), "missing workspace_path must produce a deprecation WARNING"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -417,6 +417,28 @@ teammates committed straight on `worktree/<role>-20260521`, the manager
 echoed those branches into the verdict, and three pushes failed at
 verdict execution time.
 
+#### Workspace path unification
+
+`iterate_projects` resolves the per-project workspace via
+`ensure_workspace` (which uses `_slug(repo)` → e.g.
+`laboef1900__LCM`) and threads the resolved absolute path through to
+`orchestrate_project` as the `workspace_path` kwarg. The SDK session,
+the per-role worktrees it creates, and the post-session
+`execute_verdict` push all use this single path.
+
+Before this fix, `orchestrate_project` independently derived the
+workspace via `repo.split("/")[-1]` (e.g. `LCM`). The two halves of
+the run ended up on *different clones on disk* — teammates committed
+feature branches in the bare-name clone's worktrees, while
+`execute_verdict` ran `git push` from the slug-name clone where those
+branches didn't exist, producing `src refspec does not match any`.
+The 2026-05-21 run-20260521T192218Z hit this on every verdict.
+
+`orchestrate_project` accepts `workspace_path=None` as a deprecated
+fallback so external tooling and tests that don't first invoke
+`ensure_workspace` keep working, but it emits a WARNING when used so
+the drift is visible in logs.
+
 ### Sibling-teammate coordination (#456)
 
 The lead agent writes `.claude-team-contracts.md` to the workspace


### PR DESCRIPTION
## Summary

run-20260521T192218Z failed with \`src refspec ... does not match any\` on every verdict despite all the fixes from #470/#471/#472 working correctly (review.md before verdicts.json, feature branches not worktree refs, ERROR rows in the digest). The root cause was a structural inconsistency older than this incident: \`orchestrate_project\` and \`iterate_projects\` independently derived the per-project workspace path with two different conventions, producing two parallel clones on disk:

| Path | Computed by | Used by |
|---|---|---|
| \`workspaces/LCM/\` | \`orchestrate_project\` — \`repo.split(\"/\")[-1]\` | SDK session, teammate worktrees, branch creation |
| \`workspaces/laboef1900__LCM/\` | \`ensure_workspace\` — \`_slug(repo)\` | \`execute_verdict\` \`git push\` |

Teammates created \`feat/issue-1-2-backend\` (etc.) in the first clone's \`.git\`. \`execute_verdict\` then ran \`git push\` in the second clone, which is a separate \`.git\` with no such refs.

## Fix

Thread the \`ensure_workspace\`-resolved path through to \`orchestrate_project\` via a new \`workspace_path\` keyword arg. Both halves of the run now operate on one filesystem path. When \`workspace_path=None\` (legacy direct callers and tests), the function falls back to the deprecated bare-repo-name derivation and emits a WARNING so the drift is visible.

## Test plan
- [x] \`pytest test_workspace_path_unification.py\` — 5 new: signature contract, iterate_projects forwards the kwarg, supplied path reaches \`_ensure_workspace\`, fallback derivation pinned, WARNING fires
- [x] Broader related suite (221 tests) all green; the deprecated-fallback WARNING surfaces in legacy test runs but does not break them
- [ ] Live: re-run LCM and verify a single workspace dir at \`/var/lib/.../laboef1900__LCM\` carries both the SDK session and the post-session \`git push\` to origin

## Related

Builds on #470 (silent-failure surfacing), #471 (review-package timing), #472 (worktree-isolation safety net). With this PR, every failure mode I've observed in the 2026-05-21 incidents is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)