### PR TITLE
fix(lead-prompt): reinforce branch hygiene in per-teammate spawn prompt

### DIFF
--- a/agent/station_orchestrator.py
+++ b/agent/station_orchestrator.py
@@ -1214,6 +1214,21 @@ READ FIRST: `.claude-team-contracts.md` in your worktree root. It documents the 
 contracts (field names, route ownership, response shapes, enum values) you MUST follow.
 Manager review will reject any branch that violates the contract.
 
+BRANCH HYGIENE — non-negotiable: your worktree's current branch is the
+orchestrator's isolation primitive (`worktree/<role>-<run_id_prefix>`).
+That branch is local-only and CANNOT be pushed. Before any code change
+you MUST create a feature branch on top of it:
+
+    git checkout -b autonomous/issue-<number>
+    # or feature/issue-<number>-<slug> if the project's CLAUDE.md prefers it
+
+Never commit on a `worktree/...` branch. The manager hard-rejects any
+verdict whose reported branch matches that pattern with reason
+BRANCH_ISOLATION_LEAK — losing the entire run's work. If you forgot
+this step and a commit already landed: `git checkout -b
+autonomous/issue-<number>` carries it forward, then continue from
+there.
+
 For the QA teammate specifically: when writing or modifying tests,
 every assertion on an API response field MUST match the contract's
 Response Shapes section. If your test expects a field name that

--- a/dashboard/backend/tests/test_lead_prompt_branch_reminder.py
+++ b/dashboard/backend/tests/test_lead_prompt_branch_reminder.py
@@ -1,0 +1,100 @@
+"""Tests for the lead's per-teammate spawn-prompt branch reminder.
+
+Background: ``agent/agents/issue-worker.md`` Step 4 already mandates
+``git checkout -b autonomous/issue-<n>`` before any commit. That file
+is the teammate's *system prompt*; under load the model can drift past
+it if no other signal reinforces the rule.
+
+Run-20260521T203532Z confirmed the drift: all three teammates
+committed straight on ``worktree/<role>-20260521`` despite the
+issue-worker prompt mandate, and the manager (correctly) hard-rejected
+every verdict with ``BRANCH_ISOLATION_LEAK``. A stream-log grep showed
+the lead's per-spawn user prompt never mentioned branches at all.
+
+This test pins the new contract: the lead's spawn-prompt template in
+``build_team_prompt`` must instruct the lead to include a branch
+reminder in every teammate spawn prompt, so the rule appears in *both*
+the agent system prompt and the per-spawn user prompt.
+"""
+
+from __future__ import annotations
+
+
+def test_lead_prompt_includes_branch_hygiene_paragraph_for_teammates():
+    """The lead's spawn-prompt template must carry a branch-hygiene
+    paragraph that names the worktree branch pattern, the recovery
+    path, and the BRANCH_ISOLATION_LEAK rejection reason."""
+    from agent.station_orchestrator import build_team_prompt
+
+    prompt = build_team_prompt(
+        repo="owner/repo",
+        issues=[{"number": 1, "title": "t", "body": ""}],
+        config={"projects": []},
+        run_id="20260521T203532Z",
+        workspace="/ws",
+        worktree_paths={
+            "backend": "/ws-backend",
+            "frontend": "/ws-frontend",
+            "qa": "/ws-qa",
+        },
+        review_package_path="/log/r.md",
+        verdicts_file_path="/log/v.json",
+        manager_max_turns=30,
+    )
+
+    # The paragraph must come inside the spawn-prompt block the lead
+    # passes to each teammate. The block opens with "When spawning a
+    # teammate, include in their prompt:".
+    open_marker = "When spawning a teammate, include in their prompt:"
+    assert open_marker in prompt
+    block_start = prompt.index(open_marker)
+    # The block extends through to the next top-level heading.
+    block_end = prompt.find("\n## ", block_start)
+    block = prompt[block_start:block_end if block_end > 0 else len(prompt)]
+
+    # Required content of the reinforcement paragraph.
+    assert "BRANCH HYGIENE" in block, (
+        "spawn-prompt template missing the BRANCH HYGIENE reinforcement"
+    )
+    assert "worktree/" in block, (
+        "spawn-prompt template must name the worktree branch pattern"
+    )
+    assert "git checkout -b" in block, (
+        "spawn-prompt template must show the recovery command"
+    )
+    assert "BRANCH_ISOLATION_LEAK" in block, (
+        "spawn-prompt template must name the manager's rejection reason "
+        "so teammates know the consequence"
+    )
+    # And the rule must appear BEFORE the QA-specific paragraph so the
+    # ordering reflects priority — branch hygiene applies to every
+    # teammate, the QA rules are role-specific.
+    bh_idx = block.find("BRANCH HYGIENE")
+    qa_idx = block.find("For the QA teammate")
+    assert bh_idx != -1 and qa_idx != -1
+    assert bh_idx < qa_idx, (
+        "branch-hygiene paragraph must precede the QA-specific paragraph "
+        "in the spawn-prompt template"
+    )
+
+
+def test_lead_prompt_branch_reminder_offers_both_naming_conventions():
+    """The reminder shows ``autonomous/issue-<n>`` and mentions the
+    ``feature/issue-<n>-<slug>`` alternative so teammates pick whatever
+    the project's CLAUDE.md prefers."""
+    from agent.station_orchestrator import build_team_prompt
+
+    prompt = build_team_prompt(
+        repo="owner/repo",
+        issues=[{"number": 1, "title": "t", "body": ""}],
+        config={"projects": []},
+        run_id="r",
+        workspace="/ws",
+        worktree_paths={"backend": "/x"},
+        review_package_path="/r",
+        verdicts_file_path="/v",
+        manager_max_turns=30,
+    )
+
+    assert "autonomous/issue-<number>" in prompt
+    assert "feature/issue-<number>" in prompt

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -394,17 +394,23 @@ expected to `git checkout -b autonomous/issue-<n>` (or
 `feature/issue-<n>` per the project's `CLAUDE.md`) before committing,
 so the verdict carries a real feature branch name.
 
-Three layers enforce this:
+Four layers enforce this:
 
 1. **`agent/agents/issue-worker.md` Step 0/Step 4** — teammates verify the
    pre-set worktree branch with `git branch --show-current`, then
    create a feature branch on top before any commit. The prompt also
    carries an explicit "HARD RULE — never commit on a `worktree/...`
-   branch" with the recovery path.
-2. **`agent/agents/manager.md` §6 Branch hygiene** — manager hard-rejects
+   branch" with the recovery path. (Teammate system prompt.)
+2. **`agent/station_orchestrator.build_team_prompt` BRANCH HYGIENE paragraph** —
+   the lead's prompt instructs it to include a branch-hygiene
+   paragraph in every teammate spawn prompt, so the rule appears in
+   the per-spawn *user prompt* as well as the agent system prompt.
+   Added after run-20260521T203532Z confirmed teammates can drift past
+   the system-prompt-only mandate.
+3. **`agent/agents/manager.md` §6 Branch hygiene** — manager hard-rejects
    any verdict whose `branch` matches `worktree/<role>-<run_id_prefix>`
    with reason `BRANCH_ISOLATION_LEAK`.
-3. **`agent/verdict_execution._is_worktree_isolation_branch`** — the
+4. **`agent/verdict_execution._is_worktree_isolation_branch`** — the
    `execute_approve`, `execute_pr`, and `execute_approve_integration`
    executors refuse to push such branches and return
    `ExecutionResult(success=False)` with a structured error. Pairs with


### PR DESCRIPTION
## Summary

Closes the teammate-drift failure observed in run-20260521T203532Z. The fixes from #470/#471/#472/#473 all worked correctly — \`status=completed\`, review.md written before verdicts.json, manager hard-rejected with \`BRANCH_ISOLATION_LEAK\` 3×, no false APPROVE — but the run still produced zero PRs because teammates committed on the worktree-isolation branch instead of a feature branch.

\`issue-worker.md\` Step 4's HARD RULE already mandates \`git checkout -b autonomous/issue-<n>\` before any commit. That file is the **system prompt** for each teammate. A stream-log grep showed the lead's **per-spawn user prompt** never mentioned branches at all — the rule lived in one place, and the model under load drifted past it.

## Fix

Add a "BRANCH HYGIENE" paragraph to the spawn-prompt template the lead is asked to pass to every teammate (in \`build_team_prompt\`, immediately after the worktree path / contracts paragraph). The rule now appears in **both** the agent system prompt and the per-spawn user prompt — belt-and-braces against the same failure class.

## Test plan
- [x] \`pytest test_lead_prompt_branch_reminder.py\` — 2 new: paragraph contents + ordering, both naming conventions present
- [x] Broader related suite (142 tests across manager-sibling, verdict-worktree-safety, orchestrator-wiring) all green
- [ ] Live: re-run LCM and verify teammates create \`autonomous/issue-<n>\` / \`feature/issue-<n>\` instead of committing on \`worktree/...\`

## Related

Completes the four-layer enforcement (#472 set up layers 1, 3, 4 — this PR adds layer 2). Architecture docs updated to describe all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)