### PR TITLE
feat(verdicts): collapse APPROVE and APPROVE_INTEGRATION into one auto-merging verdict

### DIFF
--- a/agent/agents/manager.md
+++ b/agent/agents/manager.md
@@ -190,19 +190,18 @@ Evaluate:
 
 ### APPROVE
 - All requirements fully implemented, tests pass, code quality acceptable.
-- Action: Push branch, merge to integration branch (autonomous/dev) if enabled, or merge to base branch. Issue is labeled, NOT closed immediately -- it closes when promoted to main.
+- Action: Push branch, open a non-draft PR against the employee's reported `base_branch` (integration/dev branch when integration is enabled, otherwise the project's trunk), and arm `gh pr merge --auto --squash`. Branch protection on the base ref decides when the PR lands — required checks + reviewers + status gates all behave normally; the auto-merge just means "merge the moment those gates pass." Issue is commented + closed via the PR.
 
 ### APPROVE_INTEGRATION
-- Work is complete and tested, but touches sensitive code (auth, payments, config) or is large enough to want CI-as-gate before landing.
-- Action: Push branch, open non-draft PR against the integration/dev branch, enable auto-merge (`gh pr merge --auto --squash`). CI gates the merge; no human review required.
-- Use this in preference to PR whenever tests pass and the only reason for human review would be "sensitivity". Reserve PR for cases where a human must actually look.
+- **Deprecated alias for APPROVE.** Behaves identically — kept only so stored verdicts and external tooling that still emit it keep working. Prefer `APPROVE` for new verdicts.
 
 ### PR
-- Work is solid but needs human review:
-  - Large scope (>10 files)
-  - Tests pass but coverage is uncertain
-  - Requirements are ambiguous
-- Action: Push branch, create PR for human review (do NOT close issue).
+- Work is solid but needs *human* review (not just CI):
+  - Large scope (>30 files) where a human should eyeball the shape
+  - Tests pass but coverage is uncertain enough that you want a human read
+  - Requirements are ambiguous and you want a human to confirm the interpretation
+- Action: Push branch, create draft PR for human review (do NOT close issue, do NOT arm auto-merge).
+- Reserve PR for cases where a human must actually look. If CI is sufficient gating, prefer APPROVE.
 
 ### REJECT
 - Requirements partially or not implemented, tests fail, code quality issues (bugs, security problems), scope creep.
@@ -215,14 +214,13 @@ Evaluate:
 
 **Decision tree:**
 - Work incomplete? → **REJECT**
-- Work complete + normal scope + non-sensitive? → **APPROVE**
-- Work complete + sensitive (auth/payments/config) + tests pass? → **APPROVE_INTEGRATION**
-- Work complete + ambiguous requirements OR tests skipped OR scope > 30 files? → **PR**
+- Work complete + tests pass? → **APPROVE** (auto-merge armed; branch protection gates)
+- Work complete + needs human eyes (scope > 30 files, ambiguous requirements, uncertain coverage)? → **PR**
 - No work to do? → **SKIP**
 
 Use **SKIP** instead of REJECT when the employee did nothing wrong — there was simply nothing to do.
 
-Use **APPROVE_INTEGRATION** instead of **PR** whenever tests pass: a human-review PR that nobody clicks merges nothing; an auto-merge PR lands the moment CI passes.
+Use **APPROVE** in preference to **PR** whenever tests pass: a human-review PR that nobody clicks merges nothing; an APPROVE arms auto-merge and lands the moment CI passes. The only reason to prefer PR is "a human really must look."
 
 ### Confidence-Based Verdict Modifiers
 
@@ -230,9 +228,8 @@ When the employee report includes a `confidence` score, use it as an additional 
 
 | Confidence | Tests Pass? | Guidance |
 |-----------|------------|---------|
-| >= 0.9 | Yes | Strong candidate for APPROVE |
-| 0.7-0.9 | Yes | APPROVE_INTEGRATION (auto-merge to dev once CI passes) |
-| 0.5-0.7 | Any | Lean toward REJECT or PR |
+| >= 0.7 | Yes | APPROVE (auto-merge armed; branch protection gates) |
+| 0.5-0.7 | Any | Lean toward REJECT or PR (human read warranted) |
 | < 0.5 | Any | Lean toward REJECT |
 
 **Important**: Confidence is an input, not a decision override. A high-confidence report with failing tests should still be REJECTED. A low-confidence report with passing tests and complete requirements might still be APPROVED. Use your judgment.

--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -162,16 +162,25 @@ def execute_approve(
     env: dict[str, str] | None = None,
     dev_branch: str | None = None,  # noqa: ARG001 — kept for dispatcher symmetry
 ) -> ExecutionResult:
-    """Push the branch, open a PR, comment on the issue.
+    """Push the branch, open a non-draft PR, arm auto-merge, close the issue.
 
-    ``dev_branch`` is accepted but ignored — the dispatcher passes the
-    same kwargs to every executor, and only ``execute_approve_integration``
-    consumes it. Without the parameter here, the dispatcher's blind
-    ``**kwargs`` passthrough raises TypeError and every APPROVE silently
-    failed before this fix.
+    APPROVE = "ready to land." The executor opens a PR and arms
+    ``gh pr merge --auto --squash``. Branch protection on the base ref
+    decides whether the merge happens immediately (no required checks)
+    or waits on CI/required reviews. Either way the operator's branch
+    protection rules — not the verdict logic — gate the merge.
 
-    Does NOT auto-merge, does NOT close the issue — those decisions live
-    in the bash path that consumes this module (deferred follow-up).
+    Before 2026-05-21 there was a separate ``APPROVE_INTEGRATION`` verdict
+    that did the auto-merge while ``APPROVE`` only opened the PR. The
+    manager prompt's decision tree, verdict description, and confidence
+    table all conspired to pick ``APPROVE`` for routine completed work,
+    which meant PRs piled up open with no one to merge them. The two
+    verdicts have been collapsed: APPROVE_INTEGRATION is now an alias
+    that delegates to this function (preserved for backward compat with
+    stored verdicts and the executor dispatch table).
+
+    ``dev_branch`` is accepted but ignored — kept for dispatcher symmetry.
+    Missing-kwarg failures here used to crash the loop (#470).
     """
     result = ExecutionResult(
         verdict="APPROVE",
@@ -195,7 +204,9 @@ def execute_approve(
         return result
     result.with_action("git push")
 
-    # 2. gh pr create
+    # 2. gh pr create — non-draft, base from the verdict (the manager has
+    # already chosen integration vs. trunk via the employee's base_branch
+    # report).
     pr = gh_run(
         [
             "pr", "create",
@@ -213,7 +224,27 @@ def execute_approve(
     result.pr_url = pr.stdout.strip()
     result.with_action(f"gh pr create → {result.pr_url}")
 
-    # 3. issue comment (best-effort; do not fail the verdict on this)
+    # 3. gh pr merge --auto --squash. Best-effort: a failure to arm
+    # auto-merge (branch protection misconfigured, repo doesn't allow
+    # squash, etc.) does not invalidate the PR. The operator's branch
+    # protection rules are the merge gate; --auto just means "merge
+    # when those rules allow."
+    merge = gh_run(
+        ["pr", "merge", "--auto", "--squash", result.pr_url],
+        env=env,
+    )
+    if merge.ok:
+        result.with_action("gh pr merge --auto --squash")
+    else:
+        logger.warning(
+            "verdict_execution: auto-merge arm failed for %s: %s",
+            result.pr_url, merge.stderr.strip()[:200],
+        )
+        result.with_action(
+            f"gh pr merge --auto failed: {merge.stderr.strip()[:80]}"
+        )
+
+    # 4. issue comment (best-effort; do not fail the verdict on this)
     if verdict.issue_number is not None:
         _post_issue_comment(verdict, body_prefix="## Manager verdict: APPROVED",
                             run_id=run_id, env=env, into=result)
@@ -365,104 +396,33 @@ def execute_approve_integration(
     workspace: Path,
     run_id: str | None = None,
     env: dict[str, str] | None = None,
-    dev_branch: str | None = None,
+    dev_branch: str | None = None,  # noqa: ARG001 — retained for caller-API stability
 ) -> ExecutionResult:
-    """Push the branch, open a non-draft PR against the integration/dev
-    branch, then arm GitHub auto-merge (``gh pr merge --auto --squash``).
+    """**Deprecated.** Alias for :func:`execute_approve`.
 
-    If ``dev_branch`` is None or empty, the executor degrades to
-    :func:`execute_approve` with a warning — the manager should not have
-    emitted this verdict against a project without integration enabled,
-    but we accept rather than fail the run.
+    APPROVE and APPROVE_INTEGRATION used to be distinct verdicts: the
+    former opened a PR without arming auto-merge, the latter armed it.
+    The manager prompt's decision tree + verdict description + confidence
+    table all conspired to pick APPROVE for routine work, leaving PRs
+    open with no one to merge them (run-20260521T210606Z produced #6
+    and #7 in laboef1900/LCM that sat untouched). The two verdicts have
+    been collapsed: APPROVE now always arms auto-merge, branch
+    protection on the base ref gates the actual merge.
+
+    This shim preserves the old verdict name for backward compatibility
+    with stored verdicts, the executor dispatch table, and any tooling
+    that still emits APPROVE_INTEGRATION. The returned
+    ``ExecutionResult.verdict`` is patched back to ``"APPROVE_INTEGRATION"``
+    so telemetry consumers can still distinguish them.
     """
-    if not dev_branch:
-        logger.warning(
-            "APPROVE_INTEGRATION emitted without dev_branch for %s — "
-            "degrading to APPROVE",
-            verdict.project,
-        )
-        # Intentionally re-passes only the kwargs execute_approve accepts.
-        # If the dispatcher gains new kwargs in the future, they are not
-        # forwarded here — degradation drops them on purpose so we don't
-        # surface APPROVE_INTEGRATION-specific options through APPROVE.
-        return execute_approve(
-            verdict, workspace=workspace, run_id=run_id, env=env,
-        )
-
-    result = ExecutionResult(
-        verdict="APPROVE_INTEGRATION",
-        project=verdict.project,
-        issue_number=verdict.issue_number,
-        success=False,
-    )
-
-    if _is_worktree_isolation_branch(verdict.branch):
-        result.error = _WORKTREE_BRANCH_ERROR.format(branch=verdict.branch)
-        return result
-
-    # 1. git push -u origin <branch>
-    push = subprocess.run(
-        ["git", "push", "-u", "origin", verdict.branch],
-        cwd=str(workspace), capture_output=True, text=True, env=env,
-    )
-    if push.returncode != 0:
-        result.error = f"git push failed: {push.stderr.strip()[:200]}"
-        return result
-    result.with_action("git push")
-
-    # 2. gh pr create — NO --draft; base = integration/dev branch.
-    pr = gh_run(
-        [
-            "pr", "create",
-            "--repo", verdict.project,
-            "--head", verdict.branch,
-            "--base", dev_branch,
-            "--title", _pr_title(verdict),
-            "--body", _build_pr_body(verdict, run_id=run_id),
-        ],
+    result = execute_approve(
+        verdict,
+        workspace=workspace,
+        run_id=run_id,
         env=env,
+        dev_branch=dev_branch,
     )
-    if not pr.ok:
-        result.error = f"gh pr create failed: {pr.stderr.strip()[:200]}"
-        return result
-    result.pr_url = pr.stdout.strip()
-    result.with_action(f"gh pr create (non-draft) → {result.pr_url}")
-
-    # 3. gh pr merge --auto --squash <pr_url>. Best-effort: a failure to
-    # arm auto-merge (e.g. branch protection misconfigured) does not
-    # invalidate the PR itself.
-    merge = gh_run(
-        [
-            "pr", "merge", "--auto", "--squash", result.pr_url,
-        ],
-        env=env,
-    )
-    if merge.ok:
-        result.with_action("gh pr merge --auto --squash")
-    else:
-        logger.warning(
-            "verdict_execution: auto-merge arm failed for %s: %s",
-            result.pr_url, merge.stderr.strip()[:200],
-        )
-        result.with_action(f"gh pr merge --auto failed: {merge.stderr.strip()[:80]}")
-
-    # 4. Issue comment (best-effort).
-    if verdict.issue_number is not None:
-        _post_issue_comment(
-            verdict,
-            body_prefix=(
-                f"## Manager verdict: APPROVE_INTEGRATION — "
-                f"auto-merge armed against `{dev_branch}`. CI gates merge."
-            ),
-            run_id=run_id, env=env, into=result,
-        )
-
-    # 5. Issue close (best-effort; #460).
-    if result.pr_url:
-        _close_issues(verdict, pr_url=result.pr_url, run_id=run_id,
-                      env=env, into=result)
-
-    result.success = True
+    result.verdict = "APPROVE_INTEGRATION"
     return result
 
 

--- a/dashboard/backend/tests/test_approve_arms_auto_merge.py
+++ b/dashboard/backend/tests/test_approve_arms_auto_merge.py
@@ -1,0 +1,159 @@
+"""Tests pinning the APPROVE / APPROVE_INTEGRATION collapse.
+
+Before this change, APPROVE only opened a PR while APPROVE_INTEGRATION
+also armed ``gh pr merge --auto --squash``. The manager's decision
+tree picked APPROVE for routine completed work, so PRs piled up open
+(run-20260521T210606Z produced PRs #6 and #7 in laboef1900/LCM that
+sat untouched). The two verdicts have been collapsed: APPROVE now
+arms auto-merge unconditionally; branch protection on the base ref
+gates whether the merge happens immediately or waits on CI.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+
+def _verdict(branch: str = "autonomous/issue-42"):
+    from agent.verdict_execution import Verdict
+
+    return Verdict(
+        project="owner/repo",
+        issue_number=42,
+        verdict="APPROVE",
+        branch=branch,
+        base_branch="claude-agent-station",
+        reasoning="ok",
+        mode="full",
+    )
+
+
+def _ok_subprocess():
+    cp = MagicMock()
+    cp.returncode = 0
+    cp.stdout = ""
+    cp.stderr = ""
+    return cp
+
+
+def _gh_ok(stdout: str = ""):
+    from agent.gh_client import GhResult
+
+    return GhResult(cmd=["gh"], returncode=0, stdout=stdout, stderr="")
+
+
+def _gh_fail(stderr: str = "boom"):
+    from agent.gh_client import GhResult
+
+    return GhResult(cmd=["gh"], returncode=1, stdout="", stderr=stderr)
+
+
+def test_approve_arms_auto_merge_squash_against_pr_url(tmp_path: Path):
+    """The PR URL returned from ``gh pr create`` must be passed verbatim
+    to ``gh pr merge --auto --squash``."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/100"
+
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_ok_subprocess()), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_ok(stdout=pr_url),  # pr create
+            _gh_ok(""),              # pr merge --auto
+            _gh_ok(""),              # issue comment
+            _gh_ok(""),              # issue close
+        ]
+        result = execute(_verdict(), workspace=tmp_path)
+
+    assert result.success
+    merge_args = mock_gh.call_args_list[1].args[0]
+    assert merge_args[:4] == ["pr", "merge", "--auto", "--squash"]
+    assert pr_url in merge_args
+
+
+def test_approve_continues_when_auto_merge_arm_fails(tmp_path: Path, caplog):
+    """If ``gh pr merge --auto`` fails (branch protection misconfigured,
+    repo doesn't allow squash, etc.), the verdict must still report
+    success — the PR exists, only the merge gate didn't get armed.
+    Failure must be logged at WARNING so operators can see it."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/100"
+
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_ok_subprocess()), \
+         patch("agent.verdict_execution.gh_run") as mock_gh, \
+         caplog.at_level("WARNING", logger="agent.verdict_execution"):
+        mock_gh.side_effect = [
+            _gh_ok(stdout=pr_url),                          # pr create
+            _gh_fail("auto-merge is not allowed for this repository"),
+            _gh_ok(""),                                      # issue comment
+            _gh_ok(""),                                      # issue close
+        ]
+        result = execute(_verdict(), workspace=tmp_path)
+
+    assert result.success is True, (
+        "auto-merge arm failure must not invalidate the verdict — "
+        "the PR exists and branch protection still decides the merge"
+    )
+    assert any(
+        "auto-merge arm failed" in rec.message for rec in caplog.records
+    ), "auto-merge failure must surface as WARNING"
+    # Result actions record the failure so the digest shows it.
+    assert any("auto failed" in a for a in result.actions)
+
+
+def test_approve_integration_alias_produces_identical_call_sequence(tmp_path: Path):
+    """APPROVE_INTEGRATION must hit the same git/gh calls in the same
+    order as APPROVE — anything else means the alias is leaking the old
+    divergent code path."""
+    from agent.verdict_execution import execute
+    from agent.verdict_execution import Verdict
+
+    pr_url = "https://x/pr/1"
+    seen_a, seen_b = [], []
+
+    for kind, log in [("APPROVE", seen_a), ("APPROVE_INTEGRATION", seen_b)]:
+        v = Verdict(
+            project="o/r", issue_number=1, verdict=kind,
+            branch="autonomous/issue-1",
+            base_branch="claude-agent-station",
+            reasoning="r",
+        )
+        with patch("agent.verdict_execution.subprocess.run",
+                   return_value=_ok_subprocess()), \
+             patch("agent.verdict_execution.gh_run") as mock_gh:
+            mock_gh.side_effect = [
+                _gh_ok(stdout=pr_url), _gh_ok(""), _gh_ok(""), _gh_ok(""),
+            ]
+            execute(v, workspace=tmp_path)
+        log.extend([tuple(c.args[0][:2]) for c in mock_gh.call_args_list])
+
+    assert seen_a == seen_b, (
+        f"APPROVE and APPROVE_INTEGRATION must produce the same gh call "
+        f"sequence. APPROVE={seen_a}, APPROVE_INTEGRATION={seen_b}"
+    )
+
+
+def test_approve_integration_alias_patches_result_verdict_label(tmp_path: Path):
+    """For telemetry continuity, the alias keeps ``result.verdict =
+    "APPROVE_INTEGRATION"`` even though execution is identical to APPROVE."""
+    from agent.verdict_execution import execute, Verdict
+
+    pr_url = "https://x/pr/1"
+    v = Verdict(
+        project="o/r", issue_number=1, verdict="APPROVE_INTEGRATION",
+        branch="autonomous/issue-1",
+        base_branch="claude-agent-station",
+        reasoning="r",
+    )
+    with patch("agent.verdict_execution.subprocess.run",
+               return_value=_ok_subprocess()), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [_gh_ok(stdout=pr_url), _gh_ok(""), _gh_ok(""), _gh_ok("")]
+        result = execute(v, workspace=tmp_path)
+
+    assert result.verdict == "APPROVE_INTEGRATION"
+    assert result.success is True

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -65,7 +65,11 @@ def _fail_subprocess(stderr: str = "permission denied"):
 # ── APPROVE ────────────────────────────────────────────────────────────
 
 
-def test_approve_pushes_branch_then_creates_pr_then_comments(tmp_path):
+def test_approve_pushes_branch_then_creates_pr_then_arms_auto_merge_then_comments(tmp_path):
+    """APPROVE collapsed with APPROVE_INTEGRATION (2026-05-21 follow-up):
+    every approve now arms ``gh pr merge --auto --squash`` so branch
+    protection on the base ref decides when the PR actually lands.
+    Pin the four gh calls in order."""
     from agent.verdict_execution import execute
 
     pr_url = "https://github.com/owner/repo/pull/100"
@@ -74,6 +78,7 @@ def test_approve_pushes_branch_then_creates_pr_then_comments(tmp_path):
                return_value=_ok_subprocess()) as mock_sp, \
          patch("agent.verdict_execution.gh_run") as mock_gh:
         mock_gh.side_effect = [_ok_gh_result(stdout=pr_url),
+                               _ok_gh_result(stdout=""),   # gh pr merge --auto
                                _ok_gh_result(stdout=""),   # issue comment
                                _ok_gh_result(stdout="")]   # gh issue close (#460)
         result = execute(_verdict("APPROVE"), workspace=tmp_path, run_id="run-1")
@@ -90,10 +95,17 @@ def test_approve_pushes_branch_then_creates_pr_then_comments(tmp_path):
     assert pr_args[pr_args.index("--repo") + 1] == "owner/repo"
     assert pr_args[pr_args.index("--head") + 1] == "autonomous/issue-42"
     assert pr_args[pr_args.index("--base") + 1] == "main"
-    # gh issue comment second
-    comment_args = mock_gh.call_args_list[1].args[0]
+    # gh pr merge --auto --squash second
+    merge_args = mock_gh.call_args_list[1].args[0]
+    assert merge_args[:2] == ["pr", "merge"]
+    assert "--auto" in merge_args and "--squash" in merge_args
+    assert pr_url in merge_args
+    # gh issue comment third
+    comment_args = mock_gh.call_args_list[2].args[0]
     assert comment_args[:2] == ["issue", "comment"]
     assert "42" in comment_args
+    # Result records the auto-merge action so the digest reflects it
+    assert any("gh pr merge --auto --squash" in a for a in result.actions)
 
 
 def test_approve_records_failure_when_git_push_fails(tmp_path):
@@ -132,6 +144,7 @@ def test_approve_body_includes_closes_keyword_when_issue_present(tmp_path):
                return_value=_ok_subprocess()), \
          patch("agent.verdict_execution.gh_run",
                side_effect=[_ok_gh_result(stdout=pr_url),
+                            _ok_gh_result(),   # gh pr merge --auto (collapse #475)
                             _ok_gh_result(),   # issue comment
                             _ok_gh_result()]) as mock_gh:  # gh issue close (#460)
         execute(_verdict("APPROVE"), workspace=tmp_path, run_id="run-1")
@@ -313,7 +326,12 @@ def _stub_gh_ok(stdout: str = "https://github.com/owner/repo/pull/99") -> MagicM
 
 
 def test_execute_approve_integration_happy_path(tmp_path: Path):
-    """Push, non-draft PR against dev branch, auto-merge armed, comment posted."""
+    """APPROVE_INTEGRATION is now an alias for APPROVE (collapse #475).
+    The behavior is the four-call APPROVE sequence; only the result's
+    ``verdict`` field is patched back to ``APPROVE_INTEGRATION`` for
+    telemetry. The PR base comes from ``verdict.base_branch``, not the
+    ``dev_branch`` kwarg, since the manager already chose integration
+    via the employee's reported base."""
     from agent.verdict_execution import execute_approve_integration, Verdict
 
     workspace = tmp_path / "ws"
@@ -323,7 +341,7 @@ def test_execute_approve_integration_happy_path(tmp_path: Path):
         issue_number=42,
         verdict="APPROVE_INTEGRATION",
         branch="autonomous/issue-42",
-        base_branch="main",
+        base_branch="dev",  # employee reported the dev branch as base
         reasoning="Auth change; tests pass; CI gates merge.",
     )
 
@@ -334,10 +352,6 @@ def test_execute_approve_integration_happy_path(tmp_path: Path):
         call_log.append(("gh", tuple(args)))
         if args[:2] == ["pr", "create"]:
             return _stub_gh_ok(pr_url)
-        if args[:3] == ["pr", "merge", "--auto"]:
-            return _stub_gh_ok("")
-        if args[:2] == ["issue", "comment"]:
-            return _stub_gh_ok("")
         return _stub_gh_ok("")
 
     def subprocess_run_spy(args, **kwargs):  # noqa: ARG001
@@ -359,16 +373,17 @@ def test_execute_approve_integration_happy_path(tmp_path: Path):
 
     assert result.success is True
     assert result.pr_url == pr_url
+    # Telemetry: alias preserves the verdict label
     assert result.verdict == "APPROVE_INTEGRATION"
 
-    # Order: git push, gh pr create (no --draft), gh pr merge --auto --squash, issue comment.
+    # Order: git push, gh pr create (no --draft), gh pr merge --auto --squash, issue comment, issue close.
     kinds = [c[0] for c in call_log]
     assert kinds[:4] == ["sub", "gh", "gh", "gh"], call_log
 
     # 1) git push -u origin <branch>
     assert call_log[0][1][:5] == ("git", "push", "-u", "origin", "autonomous/issue-42")
 
-    # 2) gh pr create — base = dev, no --draft anywhere
+    # 2) gh pr create — base = verdict.base_branch ("dev"), no --draft
     create_args = call_log[1][1]
     assert create_args[:2] == ("pr", "create")
     assert "--base" in create_args
@@ -388,9 +403,13 @@ def test_execute_approve_integration_happy_path(tmp_path: Path):
     assert "42" in comment_args
 
 
-def test_execute_approve_integration_degrades_when_dev_branch_missing(tmp_path, caplog):
-    """No dev_branch → degrade to execute_approve and emit a warning."""
-    from agent.verdict_execution import execute_approve_integration, Verdict, ExecutionResult
+def test_execute_approve_integration_is_alias_for_approve(tmp_path):
+    """Collapse #475: the alias must produce the same actions as APPROVE
+    and only patch the verdict label. No more "degrade to APPROVE on
+    missing dev_branch" branch — APPROVE itself is now the single path."""
+    from agent.verdict_execution import (
+        execute_approve_integration, Verdict, ExecutionResult,
+    )
 
     workspace = tmp_path / "ws"
     workspace.mkdir()
@@ -399,26 +418,35 @@ def test_execute_approve_integration_degrades_when_dev_branch_missing(tmp_path, 
         issue_number=7,
         verdict="APPROVE_INTEGRATION",
         branch="autonomous/issue-7",
-        base_branch="main",
-        reasoning="Manager misemitted; integration disabled.",
+        base_branch="claude-agent-station",
+        reasoning="ok",
     )
 
-    with patch("agent.verdict_execution.execute_approve") as approve_mock, \
-         caplog.at_level("WARNING", logger="agent.verdict_execution"):
-        approve_mock.return_value = ExecutionResult(
-            verdict="APPROVE",
-            project=verdict.project,
-            issue_number=7,
-            success=True,
-            pr_url="https://github.com/owner/repo/pull/12",
-        )
+    base_result = ExecutionResult(
+        verdict="APPROVE",
+        project=verdict.project,
+        issue_number=7,
+        success=True,
+        pr_url="https://github.com/owner/repo/pull/12",
+        actions=["git push", "gh pr create", "gh pr merge --auto --squash"],
+    )
+
+    with patch(
+        "agent.verdict_execution.execute_approve",
+        return_value=base_result,
+    ) as approve_mock:
         result = execute_approve_integration(
             verdict, workspace=workspace, run_id="r1", dev_branch=None,
         )
 
-    assert approve_mock.called
+    # Delegated to execute_approve once.
+    approve_mock.assert_called_once()
+    # All other fields preserved from the delegate's return.
     assert result.success is True
-    assert any("degrading to APPROVE" in rec.message for rec in caplog.records)
+    assert result.pr_url == "https://github.com/owner/repo/pull/12"
+    assert "gh pr merge --auto --squash" in result.actions
+    # Only the verdict label is patched.
+    assert result.verdict == "APPROVE_INTEGRATION"
 
 
 def test_execute_approve_integration_push_failure_short_circuits(tmp_path):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -384,16 +384,16 @@ The manager produces one of four verdicts per project/issue:
 
 | Verdict | Action | When |
 |---|---|---|
-| `APPROVE` | Direct merge to base branch (or to integration's dev branch when enabled) | Tests pass, scope is normal, no sensitive code touched. |
-| `APPROVE_INTEGRATION` | Non-draft PR against the integration/dev branch with `gh pr merge --auto --squash` armed | Work is complete and tested but touches sensitive code (auth, payments, config), or scope is large enough to want CI as the gate before landing. CI passes → PR auto-merges with no human click. |
-| `PR` | Draft PR for human review | Ambiguous requirements, tests skipped, or scope > 30 files. A human must look. |
+| `APPROVE` | Push branch, open non-draft PR against the employee-reported base (integration/dev branch when enabled, otherwise trunk), arm `gh pr merge --auto --squash`. Branch protection on the base ref gates the merge. | Tests pass, requirements complete, code quality acceptable. **Default verdict for completed work** — branch protection (not the verdict) decides when the PR lands. |
+| `APPROVE_INTEGRATION` | **Deprecated alias for `APPROVE`** — kept only so stored verdicts and external tooling that still emit it keep working. Identical behavior. | Prefer `APPROVE` for new verdicts. |
+| `PR` | Push branch, open draft PR. No auto-merge. Issue stays open. | A human really must look — large scope (>30 files), ambiguous requirements, or coverage uncertain enough that CI alone isn't sufficient gating. |
 | `REJECT` / `SKIP` | No merge | Work incomplete (`REJECT`) or no eligible work (`SKIP`). |
 
-### Prerequisite for `APPROVE_INTEGRATION`
+### Auto-merge prerequisites
 
-`APPROVE_INTEGRATION` arms GitHub's auto-merge feature. Auto-merge only meaningfully gates when the integration/dev branch has **at least one required check** in its branch protection rules. If no checks are required, `gh pr merge --auto --squash` will merge immediately. Configure required checks at `Settings → Branches → Branch protection rules → <dev_branch>` on each project before relying on this verdict.
+`APPROVE` arms GitHub's auto-merge feature. Auto-merge only meaningfully *gates* when the base branch has **at least one required check** in its branch protection rules. If no checks are required, `gh pr merge --auto --squash` will merge immediately. Configure required checks at `Settings → Branches → Branch protection rules → <branch>` on each project before relying on this verdict for sensitive paths.
 
-If the project does not have integration enabled (`integration.enabled = false`), the verdict degrades to `APPROVE` and a warning is logged — the manager should not have emitted `APPROVE_INTEGRATION` in that case, but the system accepts rather than failing the run.
+The collapse of `APPROVE` and `APPROVE_INTEGRATION` shipped after run-20260521T210606Z, where the manager picked `APPROVE` for completed work and the PRs sat open with no merge path. The previous prompt's decision tree, verdict description, and confidence table all pushed the manager toward `APPROVE` for routine work; now both verdicts produce the same auto-merge-armed PR.
 
 ## SQLite → Postgres migration playbook
 


### PR DESCRIPTION
## Summary

Closes the prompt/code mismatch surfaced by run-20260521T210606Z. The manager picked \`APPROVE\` for completed work, the executor opened PRs but didn't arm auto-merge, and the PRs sat open (#6 and #7 in laboef1900/LCM still open as of this PR). Three pieces of the manager prompt all conspired to choose \`APPROVE\` over \`APPROVE_INTEGRATION\` for routine work — and \`APPROVE\`'s own description falsely claimed it auto-merges.

Rather than rewrite the decision criteria, the cleaner fix is to collapse the two verdicts.

## Change

**\`APPROVE\` now arms \`gh pr merge --auto --squash\`** on every approval. Branch protection on the base ref decides when the PR actually merges:
- Required checks + reviewers → auto-merge waits for them
- No protection → merges immediately

\`APPROVE_INTEGRATION\` retained as a deprecated alias for backward compat (stored verdicts, external tooling, telemetry). The shim delegates to \`execute_approve\` then patches \`result.verdict\` back to \`APPROVE_INTEGRATION\`.

## Files
- \`agent/verdict_execution.py\` — \`execute_approve\` now arms auto-merge; \`execute_approve_integration\` becomes a thin alias (~30 lines down from ~100).
- \`agent/agents/manager.md\` — decision tree simplified; confidence table fixed (was inverted); APPROVE description tells the truth about what it does; PR description tightened to "a human really must look."
- \`dashboard/backend/tests/test_approve_arms_auto_merge.py\` — 4 new tests.
- \`dashboard/backend/tests/test_verdict_execution.py\` — updated APPROVE happy-path to expect 4 gh calls; converted "degrades on missing dev_branch" to "is alias for APPROVE."
- \`docs/configuration.md\` — verdict-tiers table rewritten.

## Test plan
- [x] \`pytest test_approve_arms_auto_merge.py\` — 4 new
- [x] \`pytest test_verdict_execution.py\` — 49 passing (was 49, 4 updated)
- [x] Broader related suite (177 tests across manager-sibling, orchestrator-wiring, project-loop, lead-prompt) all green
- [ ] Live: trigger a run and verify the resulting PR has auto-merge armed (\`gh pr view <n> --json autoMergeRequest\` returns non-null)

## Related

Caps the 2026-05-21 series (#470, #471, #472, #473, #474). After this lands, an APPROVE verdict produces a PR that actually merges — closing the loop the original investigation set out to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)