### PR TITLE
fix(conflict-resolver): stream prompt as AsyncIterable so can_use_tool works

### DIFF
--- a/agent/conflict_resolver/sdk_runner.py
+++ b/agent/conflict_resolver/sdk_runner.py
@@ -60,6 +60,28 @@ class ResolverOutcome:
     error: str | None              # set when SDK errored
 
 
+async def _single_user_message_stream(prompt: str):
+    """Wrap a single user prompt as the streaming-mode async iterable the
+    SDK requires when ``can_use_tool`` is set.
+
+    The SDK refuses a plain string prompt + ``can_use_tool`` callback with::
+
+        can_use_tool callback requires streaming mode. Please provide
+        prompt as an AsyncIterable instead of a string.
+
+    (see ``claude_agent_sdk/_internal/client.py`` ~line 55). The shape the
+    SDK expects per its docstring at ``claude_agent_sdk/query.py:46-53`` is
+    ``{"type": "user", "message": {"role": "user", "content": ...}}``.
+
+    Wrapping at the runner seam keeps the public ``run_resolver`` API
+    string-only — callers still pass a rendered prompt string.
+    """
+    yield {
+        "type": "user",
+        "message": {"role": "user", "content": prompt},
+    }
+
+
 async def run_resolver(
     *,
     prompt: str,
@@ -104,7 +126,14 @@ async def run_resolver(
         # model that produced the work — review finding #5. To fix, capture
         # `getattr(message, "model", None)` on each assistant message and
         # plumb the most-recent value back to record_attempt_finish.
-        async for message in query(prompt=prompt, options=options):
+        #
+        # Stream the prompt as an AsyncIterable because ``can_use_tool``
+        # above pins us into streaming mode — see
+        # :func:`_single_user_message_stream` for the shape.
+        async for message in query(
+            prompt=_single_user_message_stream(prompt),
+            options=options,
+        ):
             mtype = getattr(message, "type", None)
             if mtype == "assistant":
                 usage = getattr(message, "usage", None) or {}

--- a/dashboard/backend/tests/test_conflict_resolver_sdk_runner.py
+++ b/dashboard/backend/tests/test_conflict_resolver_sdk_runner.py
@@ -1,11 +1,26 @@
-"""Source-level test pinning the localised stream-close timeout setter.
+"""Source-level + behavior tests for the conflict-resolver SDK runner.
 
 After issue #392 the launcher stops setting CLAUDE_CODE_STREAM_CLOSE_TIMEOUT
 globally. Modules that still use SDK `query()` must own the setter
 themselves.
+
+2026-05-22: the runner uses ``can_use_tool`` (via ``make_audited_policy``)
+which pins it into streaming mode. The SDK rejects a plain string prompt
+in that mode with::
+
+    can_use_tool callback requires streaming mode. Please provide prompt
+    as an AsyncIterable instead of a string.
+
+(see ``claude_agent_sdk/_internal/client.py`` ~line 55). The runner must
+wrap the string prompt as an async iterable yielding a single user
+message dict. Pinned here so a future refactor cannot regress to the
+bug that crashed Phase 3 on run-20260521T220747Z's PR #7 attempt.
 """
 
 import inspect
+from unittest.mock import patch, MagicMock
+
+import pytest
 
 from agent.conflict_resolver import sdk_runner
 
@@ -18,3 +33,82 @@ def test_sdk_runner_sets_stream_close_timeout_locally():
     )
     # And the comment must explain why so future-us doesn't yank it again.
     assert "PR #371" in src or "stream-close" in src.lower()
+
+
+@pytest.mark.asyncio
+async def test_run_resolver_passes_async_iterable_prompt_not_string():
+    """The SDK rejects a string prompt when ``can_use_tool`` is set. The
+    runner must wrap the prompt in an async iterable that yields one
+    user-message dict matching the SDK's streaming-mode shape."""
+    captured: dict = {}
+
+    async def _fake_query(*, prompt, options):  # noqa: ANN001
+        captured["prompt"] = prompt
+        captured["options"] = options
+        # Drain the prompt iterable so we can assert its contents.
+        if hasattr(prompt, "__aiter__"):
+            messages = [m async for m in prompt]
+            captured["yielded"] = messages
+        # No messages — return immediately so the runner records
+        # ``completed=False`` and exits cleanly.
+        if False:
+            yield None
+        return
+
+    with patch("agent.conflict_resolver.sdk_runner.query", _fake_query), \
+         patch("agent.conflict_resolver.sdk_runner.make_audited_policy",
+               return_value=MagicMock()):
+        await sdk_runner.run_resolver(
+            prompt="please resolve",
+            workspace="/tmp",
+            run_id="r1",
+            model="claude-sonnet-4-6",
+            max_turns=5,
+        )
+
+    # Prompt must be an async iterable, not the raw string.
+    assert not isinstance(captured["prompt"], str), (
+        "prompt was passed as a string — SDK would reject this when "
+        "can_use_tool is set"
+    )
+    assert hasattr(captured["prompt"], "__aiter__")
+
+    # And the yielded payload must match the SDK's streaming-mode shape.
+    yielded = captured["yielded"]
+    assert len(yielded) == 1
+    msg = yielded[0]
+    assert msg["type"] == "user"
+    assert msg["message"]["role"] == "user"
+    assert msg["message"]["content"] == "please resolve"
+
+
+@pytest.mark.asyncio
+async def test_run_resolver_still_passes_can_use_tool_callback():
+    """Streaming the prompt must not have collateral-dropped the audit
+    callback — it's the whole reason we needed streaming mode."""
+    async def _fake_query(*, prompt, options):  # noqa: ANN001
+        # Drain so the resolver doesn't hang.
+        if hasattr(prompt, "__aiter__"):
+            async for _ in prompt:
+                pass
+        if False:
+            yield None
+        return
+
+    sentinel = MagicMock()
+    with patch("agent.conflict_resolver.sdk_runner.query", _fake_query), \
+         patch("agent.conflict_resolver.sdk_runner.make_audited_policy",
+               return_value=sentinel) as policy_mock:
+        await sdk_runner.run_resolver(
+            prompt="x", workspace="/tmp", run_id="r1",
+            model="claude-sonnet-4-6", max_turns=5,
+        )
+
+    policy_mock.assert_called_once()
+    # And the policy got attached to the ClaudeAgentOptions we built.
+    # (Reconstruct via inspecting the call_args from query — we don't
+    # have direct access, so assert that make_audited_policy was wired
+    # with the runner's identity fields, which is the load-bearing part.)
+    kwargs = policy_mock.call_args.kwargs
+    assert kwargs["run_id"] == "r1"
+    assert kwargs["agent_id"] == "conflict-resolver"


### PR DESCRIPTION
## Summary

Phase 3 (LLM resolution) of the conflict resolver crashed on the first real invocation (manual run against \`laboef1900/LCM\` PR #7 on 2026-05-21) with:

\`\`\`
conflict resolver SDK error: can_use_tool callback requires streaming mode.
Please provide prompt as an AsyncIterable instead of a string.
\`\`\`

The SDK refuses a plain string prompt when \`can_use_tool\` is set on \`ClaudeAgentOptions\`. The resolver wires up \`make_audited_policy\` (so every git/edit/bash call lands in \`audit_log\` with \`actor='conflict-resolver'\`) but was still passing the string prompt directly into \`query()\`.

## Fix

Wrap the prompt in an async generator yielding one \`{"type": "user", "message": {"role": "user", "content": prompt}}\` dict — the streaming-mode shape documented in \`claude_agent_sdk/query.py:46-53\`. Public API of \`run_resolver\` stays string-only; the wrapper lives behind it.

## Scope notes

This unblocks Phase 3 only. Two related gaps remain out-of-scope for this PR:

- The conflict resolver still isn't wired into the autonomous flow. No caller in \`station_orchestrator.py\` / \`project_loop.py\` / \`verdict_execution.py\`. When an APPROVE PR opens in CONFLICTING state, the agent does nothing automatically.
- The harness \`resolve-conflicts.sh\` assumes the workspace HEAD is already on the target feature branch; it doesn't \`git checkout\` itself.

Worth a follow-up PR or two.

## Test plan
- [x] \`pytest test_conflict_resolver_sdk_runner.py\` — 2 new: prompt arrives as an async iterable in the SDK's expected shape, and \`make_audited_policy\` still wires up
- [x] Broader conflict-resolver suite (25 tests) all green
- [ ] Live: re-create a conflicting PR and confirm Phase 3 reaches the model

🤖 Generated with [Claude Code](https://claude.com/claude-code)