### PR TITLE
feat(verdicts): auto-invoke conflict resolver on CONFLICTING PRs

### DIFF
--- a/agent/scripts/resolve-conflicts.sh
+++ b/agent/scripts/resolve-conflicts.sh
@@ -58,6 +58,22 @@ if ! git fetch origin "$BASE" >&2; then
     log "git fetch failed; aborting"
     exit 1
 fi
+
+# Ensure we're on the feature branch before rebasing. Without this,
+# 'git rebase origin/<base>' silently rebases whatever HEAD happens to
+# be — on 2026-05-21 a manual invocation rebased 'main' by accident
+# because the workspace had been left on main from a prior task.
+# Skip silently when already there; abort if the branch can't be
+# checked out (no caller-side cleanup we can do here).
+current_branch=$(git branch --show-current 2>/dev/null || echo "")
+if [ "$current_branch" != "$BRANCH" ]; then
+    log "checking out $BRANCH (was on '$current_branch')"
+    if ! git checkout "$BRANCH" >&2; then
+        log "git checkout $BRANCH failed; aborting"
+        exit 1
+    fi
+fi
+
 if git rebase "origin/$BASE" >&2; then
     log "Phase 1 clean — pushing"
     git push --force-with-lease origin "$BRANCH" >&2 || { log "push failed"; exit 1; }

--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import logging
 import re
 import subprocess
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
@@ -45,6 +46,24 @@ from typing import Any, Literal
 from agent.gh_client import gh_run
 
 logger = logging.getLogger(__name__)
+
+# Path to the conflict-resolution harness (rebase → optional LLM →
+# push). The harness assumes HEAD is on the feature branch already;
+# :func:`_resolve_pr_conflict_if_needed` does the checkout before
+# invoking it.
+_RESOLVE_CONFLICTS_SCRIPT = (
+    Path(__file__).resolve().parent / "scripts" / "resolve-conflicts.sh"
+)
+
+# Polling parameters for the post-PR-create mergeability check. GitHub
+# computes ``mergeable`` asynchronously; freshly-created PRs spend a few
+# seconds in UNKNOWN before settling. Two attempts at 3s spacing means
+# at most 3s of added latency on the happy path (the first response is
+# usually definitive once the PR has commits behind it) and worst-case
+# 6s when the PR genuinely lands in UNKNOWN. Tunable via the module
+# constants for test/operator overrides.
+_PR_MERGEABILITY_POLL_ATTEMPTS = 2
+_PR_MERGEABILITY_POLL_DELAY_S = 3.0
 
 VerdictKind = Literal[
     "APPROVE",              # Direct merge to base (today's APPROVE)
@@ -85,6 +104,138 @@ _WORKTREE_BRANCH_ERROR = (
     "ref from the base workspace would 404. Reject the verdict so the "
     "teammate re-runs on a proper feature branch."
 )
+
+
+def _pr_number_from_url(pr_url: str) -> int | None:
+    """Extract the PR number from a ``gh pr create`` URL.
+
+    Returns ``None`` when the URL doesn't match the canonical
+    ``/pull/<n>`` shape — the harness only needs the number for richer
+    comments, so missing it is non-fatal.
+    """
+    m = re.search(r"/pull/(\d+)\b", pr_url or "")
+    return int(m.group(1)) if m else None
+
+
+def _poll_pr_mergeable(
+    pr_url: str,
+    *,
+    env: dict[str, str] | None,
+    max_attempts: int = _PR_MERGEABILITY_POLL_ATTEMPTS,
+    delay_s: float = _PR_MERGEABILITY_POLL_DELAY_S,
+) -> str | None:
+    """Return the PR's settled ``mergeable`` state, or ``None`` on error.
+
+    GitHub computes ``mergeable`` asynchronously after a PR is opened —
+    the first ``gh pr view`` call against a fresh PR almost always
+    returns ``"UNKNOWN"``. Poll a small number of times with a short
+    delay until the state settles or attempts run out.
+
+    Returns one of ``"MERGEABLE"`` / ``"CONFLICTING"`` / ``"UNKNOWN"``
+    (when polling timed out) or ``None`` when ``gh`` failed. The caller
+    is expected to act only on ``"CONFLICTING"`` — any other value
+    means "leave the PR alone."
+    """
+    state: str | None = None
+    for attempt in range(max_attempts):
+        if attempt > 0:
+            time.sleep(delay_s)
+        res = gh_run(
+            ["pr", "view", pr_url,
+             "--json", "mergeable", "-q", ".mergeable"],
+            env=env,
+        )
+        if not res.ok:
+            return None
+        state = (res.stdout or "").strip() or None
+        if state and state != "UNKNOWN":
+            return state
+    return state
+
+
+def _resolve_pr_conflict_if_needed(
+    verdict: "Verdict",
+    *,
+    pr_url: str,
+    workspace: Path,
+    run_id: str | None,
+    env: dict[str, str] | None,
+    into: "ExecutionResult",
+) -> None:
+    """If the just-opened PR is CONFLICTING, invoke ``resolve-conflicts.sh``
+    to rebase + (optionally) LLM-resolve + push.
+
+    Best-effort: any failure is logged and recorded in
+    ``into.actions`` so operators can see what happened, but the
+    verdict itself stays successful. The PR remains open for manual
+    intervention if the resolver can't recover; auto-merge is armed
+    independently in the caller, so a later operator-driven resolve
+    will re-trigger evaluation.
+
+    The harness assumes ``workspace`` HEAD is already on the feature
+    branch; we run ``git checkout`` first.
+    """
+    mergeable = _poll_pr_mergeable(pr_url, env=env)
+    if mergeable != "CONFLICTING":
+        # MERGEABLE, UNKNOWN (poll timed out), or gh-error — nothing
+        # actionable. Recording the state helps the digest show that
+        # we checked.
+        if mergeable:
+            into.with_action(f"mergeable={mergeable}; resolver not invoked")
+        return
+
+    into.with_action("mergeable=CONFLICTING; invoking conflict resolver")
+
+    # The harness ``cd``s into workspace then ``git rebase origin/<base>``
+    # without checking out the feature branch — see
+    # ``agent/scripts/resolve-conflicts.sh`` and our 2026-05-21 manual
+    # run where rebasing-while-on-main produced a wrong-branch attempt.
+    co = subprocess.run(
+        ["git", "checkout", verdict.branch],
+        cwd=str(workspace), capture_output=True, text=True, env=env,
+    )
+    if co.returncode != 0:
+        logger.warning(
+            "verdict_execution: checkout %s failed before conflict-resolve: %s",
+            verdict.branch, co.stderr.strip()[:200],
+        )
+        into.with_action(
+            f"resolver skipped: checkout {verdict.branch} failed"
+        )
+        return
+
+    args = [
+        "bash", str(_RESOLVE_CONFLICTS_SCRIPT),
+        "--workspace", str(workspace),
+        "--branch", verdict.branch,
+        "--base", verdict.base_branch,
+        "--repo", verdict.project,
+        "--triggered-by", "at_merge",
+    ]
+    if run_id:
+        args.extend(["--run-id", run_id])
+    pr_num = _pr_number_from_url(pr_url)
+    if pr_num is not None:
+        args.extend(["--pr", str(pr_num)])
+
+    proc = subprocess.run(args, capture_output=True, text=True, env=env)
+    if proc.returncode == 0:
+        # The harness pushed the resolved branch; the armed auto-merge
+        # (caller's step 3) will re-evaluate and land the PR once
+        # branch protection is satisfied.
+        into.with_action("conflict resolver: resolved + pushed")
+    else:
+        # Exit codes from the harness: 10=tests-failed, 11=manager-rejected,
+        # 99=budget-exhausted, 1=unrecoverable. None of these invalidate
+        # the verdict — the PR exists and a human can take over.
+        logger.warning(
+            "verdict_execution: conflict resolver exited %d for %s: %s",
+            proc.returncode, pr_url,
+            (proc.stderr or "").strip()[:200],
+        )
+        into.with_action(
+            f"conflict resolver exit={proc.returncode}"
+        )
 
 
 @dataclass
@@ -223,6 +374,23 @@ def execute_approve(
         return result
     result.pr_url = pr.stdout.strip()
     result.with_action(f"gh pr create → {result.pr_url}")
+
+    # 2.5. If the PR is conflicting against the base, invoke the
+    # conflict resolver to rebase + (optionally) LLM-resolve + push.
+    # Done BEFORE arming auto-merge so the auto-merge picks up the
+    # resolved branch on its first re-evaluation rather than stalling
+    # on the original conflict. Best-effort — failures are recorded in
+    # ``result.actions`` but do not invalidate the verdict; a human
+    # can take over via the open PR. See
+    # :func:`_resolve_pr_conflict_if_needed`.
+    _resolve_pr_conflict_if_needed(
+        verdict,
+        pr_url=result.pr_url,
+        workspace=workspace,
+        run_id=run_id,
+        env=env,
+        into=result,
+    )
 
     # 3. gh pr merge --auto --squash. Best-effort: a failure to arm
     # auto-merge (branch protection misconfigured, repo doesn't allow

--- a/dashboard/backend/tests/test_approve_arms_auto_merge.py
+++ b/dashboard/backend/tests/test_approve_arms_auto_merge.py
@@ -60,15 +60,16 @@ def test_approve_arms_auto_merge_squash_against_pr_url(tmp_path: Path):
                return_value=_ok_subprocess()), \
          patch("agent.verdict_execution.gh_run") as mock_gh:
         mock_gh.side_effect = [
-            _gh_ok(stdout=pr_url),  # pr create
-            _gh_ok(""),              # pr merge --auto
-            _gh_ok(""),              # issue comment
-            _gh_ok(""),              # issue close
+            _gh_ok(stdout=pr_url),       # pr create
+            _gh_ok("MERGEABLE"),          # pr view --json mergeable (#477)
+            _gh_ok(""),                   # pr merge --auto
+            _gh_ok(""),                   # issue comment
+            _gh_ok(""),                   # issue close
         ]
         result = execute(_verdict(), workspace=tmp_path)
 
     assert result.success
-    merge_args = mock_gh.call_args_list[1].args[0]
+    merge_args = mock_gh.call_args_list[2].args[0]
     assert merge_args[:4] == ["pr", "merge", "--auto", "--squash"]
     assert pr_url in merge_args
 
@@ -88,6 +89,7 @@ def test_approve_continues_when_auto_merge_arm_fails(tmp_path: Path, caplog):
          caplog.at_level("WARNING", logger="agent.verdict_execution"):
         mock_gh.side_effect = [
             _gh_ok(stdout=pr_url),                          # pr create
+            _gh_ok("MERGEABLE"),                             # pr view (#477)
             _gh_fail("auto-merge is not allowed for this repository"),
             _gh_ok(""),                                      # issue comment
             _gh_ok(""),                                      # issue close
@@ -126,7 +128,9 @@ def test_approve_integration_alias_produces_identical_call_sequence(tmp_path: Pa
                    return_value=_ok_subprocess()), \
              patch("agent.verdict_execution.gh_run") as mock_gh:
             mock_gh.side_effect = [
-                _gh_ok(stdout=pr_url), _gh_ok(""), _gh_ok(""), _gh_ok(""),
+                _gh_ok(stdout=pr_url),
+                _gh_ok("MERGEABLE"),  # pr view (#477)
+                _gh_ok(""), _gh_ok(""), _gh_ok(""),
             ]
             execute(v, workspace=tmp_path)
         log.extend([tuple(c.args[0][:2]) for c in mock_gh.call_args_list])
@@ -152,7 +156,11 @@ def test_approve_integration_alias_patches_result_verdict_label(tmp_path: Path):
     with patch("agent.verdict_execution.subprocess.run",
                return_value=_ok_subprocess()), \
          patch("agent.verdict_execution.gh_run") as mock_gh:
-        mock_gh.side_effect = [_gh_ok(stdout=pr_url), _gh_ok(""), _gh_ok(""), _gh_ok("")]
+        mock_gh.side_effect = [
+            _gh_ok(stdout=pr_url),
+            _gh_ok("MERGEABLE"),  # pr view (#477)
+            _gh_ok(""), _gh_ok(""), _gh_ok(""),
+        ]
         result = execute(v, workspace=tmp_path)
 
     assert result.verdict == "APPROVE_INTEGRATION"

--- a/dashboard/backend/tests/test_verdict_execution.py
+++ b/dashboard/backend/tests/test_verdict_execution.py
@@ -77,10 +77,13 @@ def test_approve_pushes_branch_then_creates_pr_then_arms_auto_merge_then_comment
     with patch("agent.verdict_execution.subprocess.run",
                return_value=_ok_subprocess()) as mock_sp, \
          patch("agent.verdict_execution.gh_run") as mock_gh:
-        mock_gh.side_effect = [_ok_gh_result(stdout=pr_url),
-                               _ok_gh_result(stdout=""),   # gh pr merge --auto
-                               _ok_gh_result(stdout=""),   # issue comment
-                               _ok_gh_result(stdout="")]   # gh issue close (#460)
+        mock_gh.side_effect = [
+            _ok_gh_result(stdout=pr_url),
+            _ok_gh_result(stdout="MERGEABLE"),  # pr view --json mergeable (#477)
+            _ok_gh_result(stdout=""),           # gh pr merge --auto
+            _ok_gh_result(stdout=""),           # issue comment
+            _ok_gh_result(stdout=""),           # gh issue close (#460)
+        ]
         result = execute(_verdict("APPROVE"), workspace=tmp_path, run_id="run-1")
 
     assert result.success
@@ -95,13 +98,16 @@ def test_approve_pushes_branch_then_creates_pr_then_arms_auto_merge_then_comment
     assert pr_args[pr_args.index("--repo") + 1] == "owner/repo"
     assert pr_args[pr_args.index("--head") + 1] == "autonomous/issue-42"
     assert pr_args[pr_args.index("--base") + 1] == "main"
-    # gh pr merge --auto --squash second
-    merge_args = mock_gh.call_args_list[1].args[0]
+    # gh pr view --json mergeable second (#477 conflict-resolver wiring)
+    view_args = mock_gh.call_args_list[1].args[0]
+    assert view_args[:2] == ["pr", "view"]
+    # gh pr merge --auto --squash third
+    merge_args = mock_gh.call_args_list[2].args[0]
     assert merge_args[:2] == ["pr", "merge"]
     assert "--auto" in merge_args and "--squash" in merge_args
     assert pr_url in merge_args
-    # gh issue comment third
-    comment_args = mock_gh.call_args_list[2].args[0]
+    # gh issue comment fourth
+    comment_args = mock_gh.call_args_list[3].args[0]
     assert comment_args[:2] == ["issue", "comment"]
     assert "42" in comment_args
     # Result records the auto-merge action so the digest reflects it
@@ -144,6 +150,7 @@ def test_approve_body_includes_closes_keyword_when_issue_present(tmp_path):
                return_value=_ok_subprocess()), \
          patch("agent.verdict_execution.gh_run",
                side_effect=[_ok_gh_result(stdout=pr_url),
+                            _ok_gh_result(stdout="MERGEABLE"),  # pr view (#477)
                             _ok_gh_result(),   # gh pr merge --auto (collapse #475)
                             _ok_gh_result(),   # issue comment
                             _ok_gh_result()]) as mock_gh:  # gh issue close (#460)
@@ -352,6 +359,10 @@ def test_execute_approve_integration_happy_path(tmp_path: Path):
         call_log.append(("gh", tuple(args)))
         if args[:2] == ["pr", "create"]:
             return _stub_gh_ok(pr_url)
+        # #477: pr view --json mergeable returns the mergeability state.
+        # Use MERGEABLE so the conflict resolver does NOT fire.
+        if args[:2] == ["pr", "view"] and "mergeable" in args:
+            return _stub_gh_ok("MERGEABLE")
         return _stub_gh_ok("")
 
     def subprocess_run_spy(args, **kwargs):  # noqa: ARG001
@@ -376,9 +387,10 @@ def test_execute_approve_integration_happy_path(tmp_path: Path):
     # Telemetry: alias preserves the verdict label
     assert result.verdict == "APPROVE_INTEGRATION"
 
-    # Order: git push, gh pr create (no --draft), gh pr merge --auto --squash, issue comment, issue close.
+    # Order: git push, gh pr create (no --draft), gh pr view (#477),
+    # gh pr merge --auto --squash, issue comment, issue close.
     kinds = [c[0] for c in call_log]
-    assert kinds[:4] == ["sub", "gh", "gh", "gh"], call_log
+    assert kinds[:5] == ["sub", "gh", "gh", "gh", "gh"], call_log
 
     # 1) git push -u origin <branch>
     assert call_log[0][1][:5] == ("git", "push", "-u", "origin", "autonomous/issue-42")
@@ -392,13 +404,18 @@ def test_execute_approve_integration_happy_path(tmp_path: Path):
     assert "--head" in create_args
     assert create_args[create_args.index("--head") + 1] == "autonomous/issue-42"
 
-    # 3) gh pr merge --auto --squash <pr_url>
-    merge_args = call_log[2][1]
+    # 3) gh pr view --json mergeable -q .mergeable (#477)
+    view_args = call_log[2][1]
+    assert view_args[:2] == ("pr", "view")
+    assert "mergeable" in view_args
+
+    # 4) gh pr merge --auto --squash <pr_url>
+    merge_args = call_log[3][1]
     assert merge_args[:4] == ("pr", "merge", "--auto", "--squash")
     assert pr_url in merge_args
 
-    # 4) issue comment
-    comment_args = call_log[3][1]
+    # 5) issue comment
+    comment_args = call_log[4][1]
     assert comment_args[:2] == ("issue", "comment")
     assert "42" in comment_args
 

--- a/dashboard/backend/tests/test_verdict_resolver_wiring.py
+++ b/dashboard/backend/tests/test_verdict_resolver_wiring.py
@@ -1,0 +1,297 @@
+"""Tests for the conflict-resolver wiring in :mod:`agent.verdict_execution`.
+
+Background: PR #6 + #7 in laboef1900/LCM on 2026-05-21 surfaced the
+real failure mode — once one auto-merge-armed APPROVE lands, any
+sibling PR targeting the same base goes CONFLICTING and the
+auto-merge stalls. The conflict resolver exists (#476 fixed Phase 3)
+but wasn't called by the autonomous flow.
+
+These tests pin the new wiring: after ``gh pr create`` and before
+arming auto-merge, the executor checks the PR's mergeability state
+and invokes ``agent/scripts/resolve-conflicts.sh`` when CONFLICTING.
+Best-effort: resolver failures are logged + recorded but do not
+invalidate the verdict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _verdict(branch: str = "autonomous/issue-42"):
+    from agent.verdict_execution import Verdict
+
+    return Verdict(
+        project="owner/repo",
+        issue_number=42,
+        verdict="APPROVE",
+        branch=branch,
+        base_branch="claude-agent-station",
+        reasoning="ok",
+        mode="full",
+    )
+
+
+def _ok_subprocess(stdout: str = "", stderr: str = ""):
+    cp = MagicMock()
+    cp.returncode = 0
+    cp.stdout = stdout
+    cp.stderr = stderr
+    return cp
+
+
+def _fail_subprocess(stderr: str, returncode: int = 1):
+    cp = MagicMock()
+    cp.returncode = returncode
+    cp.stdout = ""
+    cp.stderr = stderr
+    return cp
+
+
+def _gh_ok(stdout: str = ""):
+    from agent.gh_client import GhResult
+
+    return GhResult(cmd=["gh"], returncode=0, stdout=stdout, stderr="")
+
+
+# ── _pr_number_from_url ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("url, expected", [
+    ("https://github.com/owner/repo/pull/100", 100),
+    ("https://github.com/owner/repo/pull/7", 7),
+    ("https://github.com/owner/repo/pull/9999999", 9999999),
+])
+def test_pr_number_extracted_from_canonical_urls(url, expected):
+    from agent.verdict_execution import _pr_number_from_url
+    assert _pr_number_from_url(url) == expected
+
+
+@pytest.mark.parametrize("url", [
+    "",
+    None,
+    "https://github.com/owner/repo",            # no /pull/ segment
+    "https://github.com/owner/repo/issues/42",  # wrong segment
+    "garbage",
+])
+def test_pr_number_returns_none_on_malformed_url(url):
+    from agent.verdict_execution import _pr_number_from_url
+    assert _pr_number_from_url(url) is None
+
+
+# ── _poll_pr_mergeable ─────────────────────────────────────────────────
+
+
+def test_mergeable_returns_state_on_first_definite_response():
+    """Settled state comes back immediately without any sleeping."""
+    from agent.verdict_execution import _poll_pr_mergeable
+
+    with patch("agent.verdict_execution.gh_run",
+               return_value=_gh_ok("MERGEABLE")) as mock_gh, \
+         patch("agent.verdict_execution.time.sleep") as mock_sleep:
+        result = _poll_pr_mergeable("https://x/pull/1", env=None)
+
+    assert result == "MERGEABLE"
+    mock_gh.assert_called_once()
+    mock_sleep.assert_not_called()
+
+
+def test_mergeable_polls_until_state_settles():
+    """UNKNOWN → CONFLICTING across two attempts. Second call must
+    follow a ``time.sleep`` so we're not spinning the gh CLI."""
+    from agent.verdict_execution import _poll_pr_mergeable
+    from agent.gh_client import GhResult
+
+    responses = [
+        GhResult(cmd=["gh"], returncode=0, stdout="UNKNOWN", stderr=""),
+        GhResult(cmd=["gh"], returncode=0, stdout="CONFLICTING", stderr=""),
+    ]
+    with patch("agent.verdict_execution.gh_run", side_effect=responses), \
+         patch("agent.verdict_execution.time.sleep") as mock_sleep:
+        result = _poll_pr_mergeable(
+            "https://x/pull/1", env=None,
+            max_attempts=3, delay_s=0.01,
+        )
+
+    assert result == "CONFLICTING"
+    assert mock_sleep.call_count == 1
+
+
+def test_mergeable_returns_none_on_gh_error():
+    """A non-zero ``gh pr view`` exits the poll immediately with None
+    so the caller can degrade gracefully."""
+    from agent.verdict_execution import _poll_pr_mergeable
+    from agent.gh_client import GhResult
+
+    with patch("agent.verdict_execution.gh_run",
+               return_value=GhResult(cmd=["gh"], returncode=1,
+                                     stdout="", stderr="API down")):
+        result = _poll_pr_mergeable("https://x/pull/1", env=None)
+
+    assert result is None
+
+
+# ── _resolve_pr_conflict_if_needed (end-to-end through execute) ────────
+
+
+def test_approve_skips_resolver_when_pr_is_mergeable(tmp_path: Path):
+    """``mergeable=MERGEABLE`` → resolver script is NEVER invoked."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/100"
+    # Capture subprocess.run to confirm the resolver script never runs.
+    sp_calls: list[list[str]] = []
+
+    def _sp_spy(cmd, *args, **kwargs):  # noqa: ANN001
+        sp_calls.append(list(cmd))
+        return _ok_subprocess()
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=_sp_spy), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_ok(pr_url),       # pr create
+            _gh_ok("MERGEABLE"),   # pr view --json mergeable
+            _gh_ok(""),            # pr merge --auto
+            _gh_ok(""),            # issue comment
+            _gh_ok(""),            # issue close
+        ]
+        result = execute(_verdict(), workspace=tmp_path)
+
+    assert result.success
+    # Subprocess calls: git push only — no resolve-conflicts.sh invocation.
+    sp_kinds = [c[0] for c in sp_calls]
+    assert "bash" not in sp_kinds, (
+        f"resolver script must NOT be invoked on MERGEABLE PRs; "
+        f"subprocess calls were: {sp_calls}"
+    )
+
+
+def test_approve_invokes_resolver_when_pr_is_conflicting(tmp_path: Path):
+    """``mergeable=CONFLICTING`` → executor checks out the feature
+    branch then shells out to ``resolve-conflicts.sh`` with the right
+    argv. Resolver-success records a positive action."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/100"
+    sp_calls: list[list[str]] = []
+
+    def _sp_spy(cmd, *args, **kwargs):  # noqa: ANN001
+        sp_calls.append(list(cmd))
+        return _ok_subprocess()
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=_sp_spy), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [
+            _gh_ok(pr_url),        # pr create
+            _gh_ok("CONFLICTING"),  # pr view --json mergeable
+            _gh_ok(""),             # pr merge --auto
+            _gh_ok(""),             # issue comment
+            _gh_ok(""),             # issue close
+        ]
+        result = execute(
+            _verdict(), workspace=tmp_path, run_id="run-test",
+        )
+
+    # Subprocess sequence: git push, git checkout, bash resolve-conflicts.sh
+    sp_first_args = [c[:3] for c in sp_calls]
+    assert ["git", "push", "-u"] in sp_first_args, "git push must run first"
+    assert any(c[:2] == ["git", "checkout"]
+               and "autonomous/issue-42" in c
+               for c in sp_calls), (
+        f"resolver path must checkout the feature branch first; "
+        f"subprocess calls were: {sp_calls}"
+    )
+
+    resolver_calls = [c for c in sp_calls if c and c[0] == "bash"]
+    assert resolver_calls, (
+        f"resolver script must be invoked on CONFLICTING PRs; "
+        f"subprocess calls were: {sp_calls}"
+    )
+    resolver_argv = resolver_calls[0]
+    # Script path
+    assert resolver_argv[1].endswith("resolve-conflicts.sh")
+    # Flags
+    assert "--branch" in resolver_argv and "autonomous/issue-42" in resolver_argv
+    assert "--base" in resolver_argv and "claude-agent-station" in resolver_argv
+    assert "--repo" in resolver_argv and "owner/repo" in resolver_argv
+    assert "--triggered-by" in resolver_argv and "at_merge" in resolver_argv
+    assert "--pr" in resolver_argv and "100" in resolver_argv
+    assert "--run-id" in resolver_argv and "run-test" in resolver_argv
+
+    assert any("conflict resolver: resolved" in a for a in result.actions)
+    assert result.success
+
+
+def test_approve_records_resolver_failure_but_keeps_verdict_success(
+    tmp_path: Path, caplog,
+):
+    """A non-zero resolver exit code must be logged + recorded in
+    ``result.actions`` but the verdict stays successful — the PR
+    exists, a human can take over."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/100"
+
+    def _sp_spy(cmd, *args, **kwargs):  # noqa: ANN001
+        if cmd and cmd[0] == "bash":
+            # Simulate resolver exit code 10 (tests-failed-after-rounds)
+            return _fail_subprocess("manager rejected", returncode=10)
+        return _ok_subprocess()
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=_sp_spy), \
+         patch("agent.verdict_execution.gh_run") as mock_gh, \
+         caplog.at_level("WARNING", logger="agent.verdict_execution"):
+        mock_gh.side_effect = [
+            _gh_ok(pr_url),
+            _gh_ok("CONFLICTING"),
+            _gh_ok(""), _gh_ok(""), _gh_ok(""),
+        ]
+        result = execute(_verdict(), workspace=tmp_path)
+
+    assert result.success is True, (
+        "resolver failure must not invalidate the verdict — "
+        "the PR exists for human takeover"
+    )
+    assert any("exit=10" in a for a in result.actions)
+    assert any(
+        "conflict resolver exited 10" in rec.message
+        for rec in caplog.records
+    )
+
+
+def test_approve_skips_resolver_when_checkout_fails(
+    tmp_path: Path, caplog,
+):
+    """If we can't ``git checkout`` the feature branch in the workspace,
+    skip the resolver rather than invoking it on the wrong HEAD
+    (which is how the manual 2026-05-21 attempt rebased main by accident)."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/100"
+    sp_calls: list[list[str]] = []
+
+    def _sp_spy(cmd, *args, **kwargs):  # noqa: ANN001
+        sp_calls.append(list(cmd))
+        if cmd[:2] == ["git", "checkout"]:
+            return _fail_subprocess("conflicting working-tree files")
+        return _ok_subprocess()
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=_sp_spy), \
+         patch("agent.verdict_execution.gh_run") as mock_gh, \
+         caplog.at_level("WARNING", logger="agent.verdict_execution"):
+        mock_gh.side_effect = [
+            _gh_ok(pr_url),
+            _gh_ok("CONFLICTING"),
+            _gh_ok(""), _gh_ok(""), _gh_ok(""),
+        ]
+        result = execute(_verdict(), workspace=tmp_path)
+
+    assert result.success
+    # Resolver script never invoked
+    assert not any(c and c[0] == "bash" for c in sp_calls)
+    # Action recorded
+    assert any("checkout autonomous/issue-42 failed" in a
+               for a in result.actions)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -395,6 +395,14 @@ The manager produces one of four verdicts per project/issue:
 
 The collapse of `APPROVE` and `APPROVE_INTEGRATION` shipped after run-20260521T210606Z, where the manager picked `APPROVE` for completed work and the PRs sat open with no merge path. The previous prompt's decision tree, verdict description, and confidence table all pushed the manager toward `APPROVE` for routine work; now both verdicts produce the same auto-merge-armed PR.
 
+### Auto-resolve on CONFLICTING PRs (#477)
+
+Between `gh pr create` and arming auto-merge, the executor polls `gh pr view --json mergeable` (up to 2 attempts at 3s spacing) and invokes `agent/scripts/resolve-conflicts.sh` if the PR settles in `CONFLICTING` state. The harness rebases the feature branch on `origin/<base_branch>`, falls back to the LLM resolver if the rebase produces conflicts, then `git push --force-with-lease`. GitHub's auto-merge (armed in the next step) picks up the rewritten branch and lands the PR.
+
+Best-effort: any resolver failure (rebase aborted, LLM rejected, budget exhausted) is logged at WARNING and recorded in the verdict's `actions` list. The verdict itself stays successful — the PR remains open for human takeover.
+
+This matters most for back-to-back APPROVE verdicts in the same run: when PR-A merges into the integration branch, PR-B (which was MERGEABLE at create time) goes CONFLICTING the moment PR-A lands. Without this wiring, PR-B's armed auto-merge sits forever; with it, the executor rebases and re-pushes so auto-merge re-evaluates and lands PR-B too.
+
 ## SQLite → Postgres migration playbook
 
 The persistence layer supports both SQLite (single-writer, file-based) and Postgres (multi-writer, recommended once concurrent runs land in #386). Migration is a one-time data copy.


### PR DESCRIPTION
## Summary

Closes the last gap from the 2026-05-21 debugging stack. After #475 collapsed \`APPROVE\` to always arm auto-merge, the failure mode became:

1. Run produces 2+ APPROVE verdicts targeting the same integration branch.
2. PR-A merges first → integration branch advances.
3. PR-B (created at the same time, was MERGEABLE) goes CONFLICTING the instant PR-A lands.
4. PR-B's armed auto-merge stalls forever — no one resolves the conflict.

This exact pattern hit PR #6 + #7 in laboef1900/LCM. The conflict resolver existed (#476 fixed its Phase 3 SDK bug) but **had no caller in the autonomous flow**.

## Change

In \`execute_approve\`, between \`gh pr create\` and arming auto-merge:

1. \`_poll_pr_mergeable\`: up to 2 attempts × 3s spacing for GitHub's async \`mergeable\` field. Returns \`MERGEABLE\` / \`CONFLICTING\` / \`UNKNOWN\` / \`None\`.
2. If \`CONFLICTING\`: \`git checkout\` the feature branch in the workspace, then shell out to \`agent/scripts/resolve-conflicts.sh\` with \`--workspace / --branch / --base / --repo / --pr / --triggered-by at_merge / --run-id\`.
3. Result recorded in \`ExecutionResult.actions\`. Any resolver non-zero exit is logged at WARNING but the verdict stays successful — the PR remains open for human takeover.

## Harness fix

\`resolve-conflicts.sh\` now calls \`git checkout \$BRANCH\` itself before \`git rebase origin/\$BASE\`. Was missing — a workspace left on the wrong branch from a prior task would rebase the wrong tree. We caught this manually on 2026-05-21 when the first invocation rebased \`main\` by accident.

## Test plan
- [x] \`pytest test_verdict_resolver_wiring.py\` — 15 new: URL parsing, polling behavior, MERGEABLE skips, CONFLICTING invokes resolver with correct argv, resolver failure logged but verdict success, checkout-failure short-circuits
- [x] 7 existing tests updated to include the new \`pr view --json mergeable\` call in their mock \`side_effect\` lists
- [x] Broader related suite (75 tests) all green; runs in ~3s because the polling helper hits a definite state on first attempt from all mocks
- [ ] Live: trigger a run that produces 2+ APPROVE verdicts and confirm CONFLICTING PRs auto-rebase + auto-merge

## Stacking

Caps the 2026-05-21 series (#470, #471, #472, #473, #474, #475, #476). After this lands the autonomous pipeline handles back-to-back integration merges end-to-end without operator intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)