### PR TITLE
fix(verdicts): enforce integration.dev_branch as PR base when enabled

### DIFF
--- a/agent/project_loop.py
+++ b/agent/project_loop.py
@@ -314,7 +314,17 @@ def iterate_projects(
     # APPROVE_INTEGRATION / APPROVE / PR executors require ``workspace`` and
     # ``dev_branch`` kwargs (kw-only, no default for workspace). ``dev_branch``
     # is global to the run; capture it once.
-    dev_branch = config.get("integration", {}).get("dev_branch", "autonomous/dev")
+    #
+    # Only pass ``dev_branch`` down when ``integration.enabled`` is true —
+    # otherwise the executor treats the verdict's reported ``base_branch``
+    # as authoritative (legacy behaviour). Without this gate every
+    # APPROVE/PR verdict would be forcibly redirected even on repos the
+    # operator never opted into integration-branch routing on.
+    integration_cfg = config.get("integration", {}) or {}
+    if integration_cfg.get("enabled"):
+        dev_branch = integration_cfg.get("dev_branch", "autonomous/dev")
+    else:
+        dev_branch = None
 
     any_work_attempted = False
     any_real_failure = False

--- a/agent/verdict_execution.py
+++ b/agent/verdict_execution.py
@@ -305,13 +305,94 @@ def _build_pr_body(verdict: Verdict, *, run_id: str | None = None) -> str:
     return body
 
 
+def _resolve_pr_base(verdict: Verdict, dev_branch: str | None) -> str:
+    """Return the branch to target with ``gh pr create --base``.
+
+    When ``integration.enabled`` is true in the manager config,
+    ``project_loop`` passes the configured ``integration.dev_branch`` down
+    as ``dev_branch``. In that mode the integration branch is the SOLE
+    legal base for autonomous PRs — the operator promotes integration to
+    trunk separately. Without this override, the executor would happily
+    open a PR (and arm auto-merge) against whatever ``base_branch`` the
+    employee reported, which on repos without a ``CLAUDE.md`` defaults
+    to ``main``. That regression was introduced when ``APPROVE`` and
+    ``APPROVE_INTEGRATION`` were collapsed (commit 68dca3c / PR #475):
+    the old ``APPROVE_INTEGRATION`` path targeted the integration branch
+    explicitly, and dropping that distinction silently routed every
+    APPROVE to trunk for projects with no per-repo workflow doc.
+
+    ``dev_branch=None`` means integration is disabled (or the caller is
+    test code without the config wired in) — fall back to the verdict's
+    reported base so existing behaviour is preserved.
+    """
+    return dev_branch or verdict.base_branch
+
+
+def _ensure_remote_branch(
+    workspace: Path,
+    repo: str,
+    branch: str,
+    fallback_base: str,
+    env: dict[str, str] | None,
+) -> tuple[bool, str | None]:
+    """Make sure ``branch`` exists on ``origin``; create it from
+    ``fallback_base`` if missing.
+
+    Returns ``(ok, error_message)``. The remote-branch lookup uses
+    ``git ls-remote`` so we don't need extra GitHub-API permissions
+    beyond what the existing push uses. Bootstrap pushes
+    ``refs/remotes/origin/<fallback_base>:refs/heads/<branch>`` so the
+    new branch is anchored at the exact same commit as the trunk tip we
+    know about — no working-tree state involved.
+
+    ``repo`` is unused today (the workspace already has its origin set
+    up by ``ensure_workspace``); kept on the signature for future moves
+    to a pure-API bootstrap that doesn't require a local clone.
+    """
+    del repo  # Reserved — see docstring.
+
+    ls = subprocess.run(
+        ["git", "ls-remote", "--heads", "origin", branch],
+        cwd=str(workspace), capture_output=True, text=True, env=env,
+    )
+    if ls.returncode != 0:
+        return False, f"git ls-remote failed: {ls.stderr.strip()[:200]}"
+    if ls.stdout.strip():
+        return True, None  # branch already exists upstream
+
+    # Make sure we have the base on origin/<fallback_base> before we try
+    # to push it under a new ref name. Without a prior fetch the local
+    # ``refs/remotes/origin/<fallback_base>`` may not exist (e.g. a fresh
+    # shallow workspace), and the push would 404 on a missing src.
+    fetch = subprocess.run(
+        ["git", "fetch", "origin", fallback_base],
+        cwd=str(workspace), capture_output=True, text=True, env=env,
+    )
+    if fetch.returncode != 0:
+        return False, f"git fetch base failed: {fetch.stderr.strip()[:200]}"
+
+    push = subprocess.run(
+        [
+            "git", "push", "origin",
+            f"refs/remotes/origin/{fallback_base}:refs/heads/{branch}",
+        ],
+        cwd=str(workspace), capture_output=True, text=True, env=env,
+    )
+    if push.returncode != 0:
+        return False, (
+            f"bootstrap of integration branch '{branch}' from "
+            f"'{fallback_base}' failed: {push.stderr.strip()[:200]}"
+        )
+    return True, None
+
+
 def execute_approve(
     verdict: Verdict,
     *,
     workspace: Path,
     run_id: str | None = None,
     env: dict[str, str] | None = None,
-    dev_branch: str | None = None,  # noqa: ARG001 — kept for dispatcher symmetry
+    dev_branch: str | None = None,
 ) -> ExecutionResult:
     """Push the branch, open a non-draft PR, arm auto-merge, close the issue.
 
@@ -330,8 +411,11 @@ def execute_approve(
     that delegates to this function (preserved for backward compat with
     stored verdicts and the executor dispatch table).
 
-    ``dev_branch`` is accepted but ignored — kept for dispatcher symmetry.
-    Missing-kwarg failures here used to crash the loop (#470).
+    When ``dev_branch`` is set, the PR is opened against it instead of
+    the verdict's reported ``base_branch`` — see :func:`_resolve_pr_base`.
+    ``project_loop`` passes ``dev_branch`` whenever ``integration.enabled``
+    is true in the manager config. ``None`` preserves the legacy
+    behaviour of trusting the employee-reported base.
     """
     result = ExecutionResult(
         verdict="APPROVE",
@@ -355,15 +439,34 @@ def execute_approve(
         return result
     result.with_action("git push")
 
-    # 2. gh pr create — non-draft, base from the verdict (the manager has
-    # already chosen integration vs. trunk via the employee's base_branch
-    # report).
+    # 1.5. When integration mode is enabled the PR must land on the
+    # configured integration branch (e.g. ``claude-agent-station``), not
+    # whatever the employee reported as ``base_branch`` (typically
+    # ``main``). Ensure the branch exists on origin before pointing the
+    # PR at it; bootstrap from the employee-reported base so the new
+    # integration branch starts at a known-good commit.
+    pr_base = _resolve_pr_base(verdict, dev_branch)
+    if dev_branch is not None and dev_branch != verdict.base_branch:
+        ok, err = _ensure_remote_branch(
+            workspace=workspace,
+            repo=verdict.project,
+            branch=dev_branch,
+            fallback_base=verdict.base_branch,
+            env=env,
+        )
+        if not ok:
+            result.error = err
+            return result
+        result.with_action(f"ensure integration branch {dev_branch!r} on origin")
+
+    # 2. gh pr create — non-draft, base from the resolved integration
+    # branch (when enabled) or the verdict's base_branch (when not).
     pr = gh_run(
         [
             "pr", "create",
             "--repo", verdict.project,
             "--head", verdict.branch,
-            "--base", verdict.base_branch,
+            "--base", pr_base,
             "--title", _pr_title(verdict),
             "--body", _build_pr_body(verdict, run_id=run_id),
         ],
@@ -435,10 +538,14 @@ def execute_pr(
     run_id: str | None = None,
     env: dict[str, str] | None = None,
     draft: bool = True,
-    dev_branch: str | None = None,  # noqa: ARG001 — dispatcher symmetry; see execute_approve
+    dev_branch: str | None = None,
 ) -> ExecutionResult:
     """Open a draft PR (or marked-ready) for manual review. Same path as
     APPROVE but with ``--draft`` and a different issue comment.
+
+    ``dev_branch`` is honored identically to :func:`execute_approve`:
+    when set, the PR opens against the integration branch rather than
+    the employee-reported base. See :func:`_resolve_pr_base`.
     """
     result = ExecutionResult(
         verdict="PR",
@@ -460,11 +567,25 @@ def execute_pr(
         return result
     result.with_action("git push")
 
+    pr_base = _resolve_pr_base(verdict, dev_branch)
+    if dev_branch is not None and dev_branch != verdict.base_branch:
+        ok, err = _ensure_remote_branch(
+            workspace=workspace,
+            repo=verdict.project,
+            branch=dev_branch,
+            fallback_base=verdict.base_branch,
+            env=env,
+        )
+        if not ok:
+            result.error = err
+            return result
+        result.with_action(f"ensure integration branch {dev_branch!r} on origin")
+
     pr_args = [
         "pr", "create",
         "--repo", verdict.project,
         "--head", verdict.branch,
-        "--base", verdict.base_branch,
+        "--base", pr_base,
         "--title", _pr_title(verdict),
         "--body", _build_pr_body(verdict, run_id=run_id),
     ]

--- a/dashboard/backend/tests/test_iterate_projects_python.py
+++ b/dashboard/backend/tests/test_iterate_projects_python.py
@@ -142,7 +142,11 @@ def test_iterate_projects_passes_workspace_and_dev_branch_to_executor(
     cfg.write_text(json.dumps({
         "projects": [{"repo": "owner/repo", "enabled": True, "branch": "main"}],
         "limits": {"max_concurrent_employees": 1},
-        "integration": {"dev_branch": "autonomous/dev"},
+        # ``enabled: true`` is required for project_loop to forward
+        # ``dev_branch`` to the executor. Without it the integration-branch
+        # routing is intentionally inert (see commit fixing the regression
+        # where APPROVE silently merged to main on repos without CLAUDE.md).
+        "integration": {"enabled": True, "dev_branch": "autonomous/dev"},
     }))
 
     monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
@@ -203,6 +207,78 @@ def test_iterate_projects_passes_workspace_and_dev_branch_to_executor(
         f"got {kwargs.get('dev_branch')!r}"
     )
     assert kwargs.get("run_id") == "run-tested"
+
+
+def test_iterate_projects_passes_dev_branch_none_when_integration_disabled(
+    tmp_path, monkeypatch,
+):
+    """Regression guard for the integration-branch enforcement fix.
+
+    ``project_loop`` must only forward ``dev_branch`` when
+    ``integration.enabled`` is true. Otherwise the executor would
+    forcibly redirect PRs to a branch the operator hasn't opted into.
+    When integration is missing or disabled, ``dev_branch`` must be
+    ``None`` so :func:`execute_approve` falls back to the verdict's
+    reported base_branch.
+    """
+    from pathlib import Path
+    from agent import project_loop as pl
+
+    cfg = tmp_path / "manager-config.json"
+    cfg.write_text(json.dumps({
+        "projects": [{"repo": "owner/repo", "enabled": True, "branch": "main"}],
+        "limits": {"max_concurrent_employees": 1},
+        # Note: no "integration" key at all — opt-out by omission.
+    }))
+
+    monkeypatch.setattr("agent.preflight.run_preflight", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.purge_and_recover", lambda *a, **k: None)
+    monkeypatch.setattr("agent.queue_recovery.resume_paused", lambda: None)
+    monkeypatch.setattr(
+        "agent.workspace_setup.ensure_workspace",
+        lambda p, w: str(tmp_path / "ws"),
+    )
+
+    async def _fake_orchestrate(project, config, run_id, workspaces_dir, **kwargs):
+        return 0, None, True
+
+    monkeypatch.setattr("agent.station_orchestrator.orchestrate_project", _fake_orchestrate)
+    monkeypatch.setattr(
+        "agent.station_orchestrator._read_verdicts_file",
+        lambda *a, **k: {
+            "verdicts": [
+                {
+                    "project": "owner/repo",
+                    "issue_number": 17,
+                    "verdict": "APPROVE",
+                    "branch": "autonomous/issue-17",
+                    "base_branch": "main",
+                    "reasoning": "tests pass",
+                },
+            ],
+        },
+    )
+    monkeypatch.setattr("agent.digest.write_digest", lambda **kw: "")
+
+    captured: dict = {}
+
+    def _fake_execute(verdict, **kwargs):
+        captured["kwargs"] = kwargs
+        from agent.verdict_execution import ExecutionResult
+        return ExecutionResult(
+            verdict=verdict.verdict, project=verdict.project,
+            issue_number=verdict.issue_number, success=True,
+        )
+
+    monkeypatch.setattr("agent.verdict_execution.execute", _fake_execute)
+
+    pl.iterate_projects("run-no-integ", str(cfg), str(tmp_path))
+
+    assert captured, "execute_verdict was never invoked"
+    assert captured["kwargs"].get("dev_branch") is None, (
+        "without integration.enabled, dev_branch must be None so the "
+        "executor honours the verdict's reported base_branch"
+    )
 
 
 def test_iterate_projects_emits_manager_no_verdicts_with_kwargs(

--- a/dashboard/backend/tests/test_verdict_execution_integration_branch.py
+++ b/dashboard/backend/tests/test_verdict_execution_integration_branch.py
@@ -1,0 +1,274 @@
+"""Regression tests for integration-branch routing in APPROVE/PR verdicts.
+
+The bug: PR #475 (commit 68dca3c) collapsed the separate
+``APPROVE_INTEGRATION`` verdict into ``execute_approve``. Pre-collapse,
+``APPROVE_INTEGRATION`` opened PRs against the configured integration
+branch; post-collapse, ``execute_approve`` opens PRs against
+``verdict.base_branch`` (the employee-reported value, which defaults to
+``main`` for repos with no ``CLAUDE.md``). On a live run against
+``laboef1900/LCM`` the executor squash-merged PR #9 into ``main``
+despite ``config.integration.enabled = true`` and
+``config.integration.dev_branch = "claude-agent-station"``.
+
+The fix: ``execute_approve`` and ``execute_pr`` now honor a non-None
+``dev_branch`` kwarg by routing the PR base to it, bootstrapping the
+integration branch on origin (from the verdict's reported base) when
+it doesn't exist yet. ``project_loop`` only passes ``dev_branch`` when
+``integration.enabled`` is true, so opt-out repos keep their legacy
+behaviour.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _verdict(verdict_kind: str = "APPROVE", **overrides):
+    from agent.verdict_execution import Verdict
+
+    fields = dict(
+        project="owner/repo",
+        issue_number=42,
+        verdict=verdict_kind,
+        branch="autonomous/issue-42",
+        base_branch="main",
+        reasoning="Looks good",
+        mode="full",
+    )
+    fields.update(overrides)
+    return Verdict(**fields)
+
+
+def _ok_gh_result(stdout: str = ""):
+    from agent.gh_client import GhResult
+
+    return GhResult(cmd=["gh"], returncode=0, stdout=stdout, stderr="")
+
+
+def _subprocess_factory(*, ls_remote_stdout: str = "", bootstrap_ok: bool = True):
+    """Build a side_effect for ``subprocess.run`` that returns sensible
+    results for each git call the executor makes in integration mode.
+
+    Call order (when integration is enabled and branch is missing):
+      1. git push origin <feature_branch>     → ok
+      2. git ls-remote --heads origin <dev>   → stdout configurable
+      3. git fetch origin <fallback_base>     → ok (only if missing)
+      4. git push origin refs/remotes/...     → bootstrap_ok configurable
+    """
+    calls: list[list[str]] = []
+
+    def side_effect(args, **kwargs):
+        calls.append(args)
+        cp = MagicMock()
+        cp.stdout = ""
+        cp.stderr = ""
+        cp.returncode = 0
+        if args[:3] == ["git", "ls-remote", "--heads"]:
+            cp.stdout = ls_remote_stdout
+            return cp
+        if args[:2] == ["git", "push"] and "refs/remotes/origin/" in (
+            args[3] if len(args) > 3 else ""
+        ):
+            if not bootstrap_ok:
+                cp.returncode = 1
+                cp.stderr = "remote rejected"
+            return cp
+        return cp
+
+    return side_effect, calls
+
+
+# ── APPROVE: integration branch is honoured when dev_branch is set ────
+
+
+def test_approve_targets_integration_branch_when_dev_branch_passed(tmp_path):
+    """The whole point of the fix — dev_branch overrides verdict.base_branch."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/200"
+    sp_side, sp_calls = _subprocess_factory()
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=sp_side), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [
+            _ok_gh_result(stdout=pr_url),       # gh pr create
+            _ok_gh_result(stdout="MERGEABLE"),  # gh pr view --json mergeable
+            _ok_gh_result(),                    # gh pr merge --auto
+            _ok_gh_result(),                    # gh issue comment
+            _ok_gh_result(),                    # gh issue close
+        ]
+        result = execute(
+            _verdict("APPROVE", base_branch="main"),
+            workspace=tmp_path,
+            run_id="run-1",
+            dev_branch="claude-agent-station",
+        )
+
+    assert result.success
+    pr_args = mock_gh.call_args_list[0].args[0]
+    assert pr_args[:2] == ["pr", "create"]
+    # The PR must target the integration branch, NOT main.
+    assert pr_args[pr_args.index("--base") + 1] == "claude-agent-station"
+
+
+def test_approve_falls_back_to_base_branch_when_dev_branch_is_none(tmp_path):
+    """Legacy behaviour: integration disabled → trust verdict.base_branch."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/201"
+
+    with patch("agent.verdict_execution.subprocess.run") as mock_sp, \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_sp.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        mock_gh.side_effect = [
+            _ok_gh_result(stdout=pr_url),
+            _ok_gh_result(stdout="MERGEABLE"),
+            _ok_gh_result(),
+            _ok_gh_result(),
+            _ok_gh_result(),
+        ]
+        result = execute(
+            _verdict("APPROVE", base_branch="main"),
+            workspace=tmp_path,
+            run_id="run-1",
+            dev_branch=None,
+        )
+
+    assert result.success
+    pr_args = mock_gh.call_args_list[0].args[0]
+    assert pr_args[pr_args.index("--base") + 1] == "main"
+
+
+def test_approve_bootstraps_missing_integration_branch(tmp_path):
+    """When the integration branch doesn't exist on origin, the executor
+    must create it from the verdict's reported base before opening the PR."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/202"
+    sp_side, sp_calls = _subprocess_factory(ls_remote_stdout="")  # missing
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=sp_side), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [
+            _ok_gh_result(stdout=pr_url),
+            _ok_gh_result(stdout="MERGEABLE"),
+            _ok_gh_result(),
+            _ok_gh_result(),
+            _ok_gh_result(),
+        ]
+        result = execute(
+            _verdict("APPROVE", base_branch="main"),
+            workspace=tmp_path,
+            dev_branch="claude-agent-station",
+        )
+
+    assert result.success
+    # The bootstrap push must have happened with the right refspec.
+    bootstrap_calls = [
+        c for c in sp_calls
+        if len(c) >= 4
+        and c[:2] == ["git", "push"]
+        and "refs/remotes/origin/main:refs/heads/claude-agent-station" in c
+    ]
+    assert bootstrap_calls, (
+        f"expected bootstrap push, got subprocess calls: {sp_calls}"
+    )
+
+
+def test_approve_skips_bootstrap_when_integration_branch_exists(tmp_path):
+    """Idempotency: if the integration branch already exists upstream we
+    must not push a fresh ref over it."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/203"
+    # ls-remote returns content → branch exists.
+    sp_side, sp_calls = _subprocess_factory(
+        ls_remote_stdout="abc123\trefs/heads/claude-agent-station\n"
+    )
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=sp_side), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [
+            _ok_gh_result(stdout=pr_url),
+            _ok_gh_result(stdout="MERGEABLE"),
+            _ok_gh_result(),
+            _ok_gh_result(),
+            _ok_gh_result(),
+        ]
+        execute(
+            _verdict("APPROVE", base_branch="main"),
+            workspace=tmp_path,
+            dev_branch="claude-agent-station",
+        )
+
+    # No call should be `git push origin refs/remotes/origin/main:...`.
+    bootstrap_pushes = [
+        c for c in sp_calls
+        if len(c) >= 4
+        and c[:2] == ["git", "push"]
+        and any("refs/remotes/origin/main:refs/heads/" in arg for arg in c)
+    ]
+    assert not bootstrap_pushes, (
+        f"unexpected bootstrap push: {bootstrap_pushes}"
+    )
+
+
+def test_approve_aborts_when_bootstrap_fails(tmp_path):
+    """If the integration-branch bootstrap fails, the verdict fails too —
+    don't fall through to opening a PR against main."""
+    from agent.verdict_execution import execute
+
+    sp_side, sp_calls = _subprocess_factory(
+        ls_remote_stdout="", bootstrap_ok=False,
+    )
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=sp_side), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        result = execute(
+            _verdict("APPROVE", base_branch="main"),
+            workspace=tmp_path,
+            dev_branch="claude-agent-station",
+        )
+
+    assert not result.success
+    assert "integration branch" in (result.error or "")
+    # Critically: gh pr create must NOT have been called — silent fallback
+    # to opening a PR against main is exactly the bug we're guarding against.
+    create_calls = [
+        c for c in mock_gh.call_args_list
+        if c.args and c.args[0][:2] == ["pr", "create"]
+    ]
+    assert not create_calls, (
+        "executor must not open a PR when integration-branch bootstrap fails"
+    )
+
+
+# ── execute_pr (draft PR) honours dev_branch identically ──────────────
+
+
+def test_pr_verdict_targets_integration_branch_when_dev_branch_passed(tmp_path):
+    """The draft-PR path takes the same routing as APPROVE so reviewers
+    aren't surprised by the base depending on the verdict kind."""
+    from agent.verdict_execution import execute
+
+    pr_url = "https://github.com/owner/repo/pull/300"
+    sp_side, _ = _subprocess_factory()
+
+    with patch("agent.verdict_execution.subprocess.run", side_effect=sp_side), \
+         patch("agent.verdict_execution.gh_run") as mock_gh:
+        mock_gh.side_effect = [
+            _ok_gh_result(stdout=pr_url),  # gh pr create --draft
+            _ok_gh_result(),               # issue comment
+        ]
+        execute(
+            _verdict("PR", base_branch="main"),
+            workspace=tmp_path,
+            dev_branch="claude-agent-station",
+        )
+
+    pr_args = mock_gh.call_args_list[0].args[0]
+    assert pr_args[:2] == ["pr", "create"]
+    assert pr_args[pr_args.index("--base") + 1] == "claude-agent-station"
+    assert "--draft" in pr_args


### PR DESCRIPTION
## Summary

**Regression introduced by PR #475 (commit 68dca3c).** The collapse of `APPROVE` + `APPROVE_INTEGRATION` into a single `execute_approve` dropped the integration-branch routing entirely. Live blast radius: a run against `laboef1900/LCM` squash-merged PR #9 directly into `main` despite `config.integration.enabled=true` and `config.integration.dev_branch=\"claude-agent-station\"`. The user's whole reason for setting up the integration branch — a manually-promoted gate between autonomous work and trunk — was silently inert.

Pre-#475: `APPROVE_INTEGRATION` opened PRs against the integration branch, `APPROVE` against trunk; manager chose between them.
Post-#475: both go to `execute_approve`, which opens against `verdict.base_branch` (employee-reported, defaults to `main` for repos without a `CLAUDE.md`).

## Fix

- **`agent/project_loop.py`**: only forward `dev_branch` when `integration.enabled` is true; otherwise `None` so legacy/opt-out repos keep their existing behavior.
- **`agent/verdict_execution.py`**:
  - `_resolve_pr_base(verdict, dev_branch)` — `dev_branch` wins when set.
  - `_ensure_remote_branch(workspace, repo, branch, fallback_base, env)` — bootstraps the integration branch on origin from the verdict's reported base when missing (uses `git ls-remote` + `git fetch` + a refspec push, no extra GitHub-API permissions).
  - `execute_approve` and `execute_pr` call both helpers. **If bootstrap fails, the verdict fails** — we must not silently fall through to a main-targeted PR. That's the bug we're guarding against.

## Test plan

- [x] 6 new tests in `test_verdict_execution_integration_branch.py`:
  - Routes to integration branch when `dev_branch` is set
  - Falls back to `verdict.base_branch` when `dev_branch` is `None`
  - Bootstraps a missing integration branch from the verdict's base
  - Idempotent: skips bootstrap when the branch already exists upstream
  - Aborts the verdict (no PR opened) if bootstrap fails
  - Draft-PR path routes identically
- [x] New guard in `test_iterate_projects_python.py`: `dev_branch=None` when `integration.enabled` is missing.
- [x] Updated existing `test_iterate_projects_passes_workspace_and_dev_branch_to_executor` to set `integration.enabled=true` (matches the new semantics).
- [x] Full backend suite: **1677 passed**, 1 skipped (pre-existing vision/postgres flakes excluded).
- [ ] After merge: trigger a run on `laboef1900/LCM`; verify the PR targets `claude-agent-station`, not `main`.

## Why this didn't get caught by existing tests

The existing `test_approve_pushes_branch_then_creates_pr_then_arms_auto_merge_then_comments` pins `--base` to `\"main\"` but never passes a non-`None` `dev_branch`, so the regression had no failing test to fall out of. The new file adds explicit coverage for both modes so future refactors can't drop the routing again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)